### PR TITLE
Don't serialize identity column if it's nil

### DIFF
--- a/lib/lotus/model/mapping/coercer.rb
+++ b/lib/lotus/model/mapping/coercer.rb
@@ -57,7 +57,11 @@ module Lotus
 
           instance_eval %{
             def to_record(entity)
-              Hash[*[#{ @collection.attributes.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]]
+              if entity.id
+                Hash[*[#{ @collection.attributes.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]]
+              else
+                Hash[*[#{ @collection.attributes.reject{|name,_| name == @collection.identity }.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]]
+              end
             end
 
             def from_record(record)

--- a/test/model/mapping/coercer_test.rb
+++ b/test/model/mapping/coercer_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+describe Lotus::Model::Mapping::Coercer do
+  let(:entity) { User.new(name: 'Tyrion Lannister') }
+  let(:collection) { Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer) }
+  let(:coercer) { Lotus::Model::Mapping::Coercer.new(collection) }
+
+  before do
+    collection.entity(User)
+    collection.attribute :id,   Integer
+    collection.attribute :name, String
+  end
+
+  describe '#to_record' do
+    it 'should not return identity column' do
+      coercer.to_record(entity).must_equal(name: 'Tyrion Lannister')
+    end
+
+    describe 'when identity is set' do
+      let(:entity) { User.new(id: 3, name: 'Tyrion Lannister') }
+
+      it 'should return identity as well' do
+        coercer.to_record(entity).must_equal(id: 3, name: 'Tyrion Lannister')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sending the NULL value in identity column when inserting a record would cause `Sequel::NotNullConstraintViolation` exception. This patches the `Coercer#to_record` to serialize the identity column only when it's assigned.

Let me know if you think it would be a good idea to update `repository_test.rb` with Postgresql integration as well. Maybe tests for specific RDBMSs could be turned on or off with environment variables (just like AR does it).
