### PR TITLE
Correcting 'ignores unknown attributes' test

### DIFF
--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -47,7 +47,7 @@ describe Lotus::Entity do
       it 'ignores unknown attributes' do
         book = Book.new(unknown: 'x')
 
-        book.instance_variable_get(:@book).must_be_nil
+        book.instance_variable_get(:@unknown).must_be_nil
       end
 
       it 'accepts given attributes for subclass' do


### PR DESCRIPTION
While the previous test may run without error, it isn't asserting
anything interesting. By switching to check on `:@unknown` instance
variable, the assertion is inline with setting the `:unknown`
attribute during book initialization.
