### PR TITLE
Entity defines #id accessor by default

### DIFF
--- a/lib/lotus/entity.rb
+++ b/lib/lotus/entity.rb
@@ -72,6 +72,7 @@ module Lotus
     #   end
     def self.included(base)
       base.extend ClassMethods
+      base.send :attr_accessor, :id
     end
 
     module ClassMethods

--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -59,6 +59,12 @@ describe Lotus::Entity do
     end
 
     describe 'with undefined attributes' do
+      it 'has default accessor for id' do
+        camera = Camera.new
+        camera.must_respond_to :id
+        camera.must_respond_to :id=        
+      end
+      
       it 'is able to initialize an entity without given attributes' do
         camera = Camera.new
         camera.analog.must_be_nil


### PR DESCRIPTION
As discussed [here](https://github.com/lotus/model/issues/17), Entity is suppose to define `#id` accessor even when `#attributes=` was not called
