### PR TITLE
Made the usage of repositories more clear.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,16 +234,19 @@ will not initialize your repositories correctly.
 
 ```ruby
 class MyLotusApp::Model::User
+  include Lotus::Entity
   # your code here
 end
 
 # This repository will work...
 class MyLotusApp::Model::UserRepository
+  include Lotus::Repository
   # your code here
 end
 
 # ...this will not!
 class MyLotusApp::Repository::UserRepository
+  include Lotus::Repository
   # your code here
 end
 ```


### PR DESCRIPTION
Today I struggled a few hours with setting up the `Lotus::Repository` correctly. It took me quite a while till I recognized that the repository has to be in the same namespace as the model.

``` ruby
module Lotus
  module Model
    module Mapping
      class Collection
        def configure_repository!

        # This one here made my initial setup failing...
        repository = Object.const_get("#{ entity.name }#{ REPOSITORY_SUFFIX }")
        repository.collection = name
        rescue NameError
      end
    end
  end
end
```

If it is intended that the repository must have the same namespace it should be documented.
