### PR TITLE
Allow configuring Repository class

### DIFF
--- a/lib/lotus/model/mapping/collection.rb
+++ b/lib/lotus/model/mapping/collection.rb
@@ -103,6 +103,32 @@ module Lotus
           end
         end
 
+        # Defines the repository that interacts with this collection.
+        #
+        # @param klass [Class] the repository that interacts with this collection.
+        #
+        # @since 0.2.0
+        #
+        # @see Lotus::Repository
+        #
+        # @example
+        #   require 'lotus/model'
+        #
+        #   mapper = Lotus::Model::Mapper.new do
+        #     collection :articles do
+        #       entity Article
+        #
+        #       repository RemoteArticleRepository
+        #     end
+        #   end
+        def repository(klass = nil)
+          if klass
+            @repository = klass
+          else
+            @repository ||= default_repository_klass
+          end
+        end
+
         # Defines the identity for a collection.
         #
         # An identity is an unique value that identifies a record.
@@ -326,9 +352,18 @@ module Lotus
         # @api private
         # @since 0.1.0
         def configure_repository!
-          repository = Object.const_get("#{ entity.name }#{ REPOSITORY_SUFFIX }")
           repository.collection = name
-        rescue NameError
+          rescue NameError
+        end
+
+        # Retrieves the default repository class
+        #
+        # @see Lotus::Repository
+        #
+        # @api private
+        # @since 0.2.0
+        def default_repository_klass
+          Object.const_get("#{ entity.name }#{ REPOSITORY_SUFFIX }")
         end
       end
     end

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -6,7 +6,7 @@ module Lotus
   #
   #
   #
-  # IMPORTANT: A repository MUST be named after an entity, by appending the
+  # By default, a repository is named after an entity, by appending the
   # `Repository` suffix to the entity class name.
   #
   # @example
@@ -26,7 +26,17 @@ module Lotus
   #     include Lotus::Repository
   #   end
   #
+  # Repository for an entity can be configured by setting # the `#repository`
+  # on the mapper.
   #
+  # @example
+  #   # PostRepository is repository for Article
+  #   mapper = Lotus::Model::Mapper.new do
+  #     collection :articles do
+  #       entity Article
+  #       repository PostRepository
+  #     end
+  #   end
   #
   # A repository is storage independent.
   # All the queries and commands are delegated to the current adapter.

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -8,6 +8,10 @@ class Article
   self.attributes = :user_id, :unmapped_attribute, :title, :comments_count
 end
 
+class CustomUserRepository
+  include Lotus::Repository
+end
+
 class UserRepository
   include Lotus::Repository
 end

--- a/test/model/mapping/collection_test.rb
+++ b/test/model/mapping/collection_test.rb
@@ -47,6 +47,39 @@ describe Lotus::Model::Mapping::Collection do
     end
   end
 
+  describe '#repository' do
+    before do
+      @collection.entity User
+    end
+
+    describe 'when a value is given' do
+      before do
+        @collection.repository(CustomUserRepository)
+      end
+
+      it 'sets the value' do
+        @collection.repository.must_equal CustomUserRepository
+      end
+    end
+
+    describe 'when a value is not given' do
+      it 'returns the default value' do
+        @collection.repository.must_equal UserRepository
+      end
+
+      describe 'when repository class is not found' do
+        before do
+          class KlassWithoutRepository; end
+          @collection.entity KlassWithoutRepository
+        end
+
+        it 'raises NameError' do
+          -> { @collection.repository }.must_raise NameError
+        end
+      end
+    end
+  end
+
   describe '#identity' do
     describe 'when a value is given' do
       before do


### PR DESCRIPTION
Now, we wait for the green test

This ticket solves the `Ditch the convention of naming repositories after entities. Allow this association in mapper (see example 3).` of #33 
