### PR TITLE
No need to `uniq` already unique columns

### DIFF
--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -161,7 +161,7 @@ module Lotus
           #
           #   query.select(:name, :year)
           def select(*columns)
-            columns = Lotus::Utils::Kernel.Array(columns).uniq
+            columns = Lotus::Utils::Kernel.Array(columns)
             modifiers.push(Proc.new{ flatten!; each {|r| r.delete_if {|k,_| !columns.include?(k)} } })
           end
 


### PR DESCRIPTION
`Lotus::Utils::Kernel.Array` returns an array with unique elements.
