### PR TITLE
Avoid array allocations for generated coercer code

### DIFF
--- a/lib/lotus/model/mapping/coercer.rb
+++ b/lib/lotus/model/mapping/coercer.rb
@@ -58,15 +58,15 @@ module Lotus
           instance_eval %{
             def to_record(entity)
               if entity.id
-                Hash[*[#{ @collection.attributes.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]]
+                Hash[#{ @collection.attributes.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]
               else
-                Hash[*[#{ @collection.attributes.reject{|name,_| name == @collection.identity }.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]]
+                Hash[#{ @collection.attributes.reject{|name,_| name == @collection.identity }.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]
               end
             end
 
             def from_record(record)
               #{ @collection.entity }.new(
-                Hash[*[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{name},Lotus::Model::Mapping::Coercions.#{klass}(record[:#{mapped}])"}.join(',') }]]
+                Hash[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{name},Lotus::Model::Mapping::Coercions.#{klass}(record[:#{mapped}])"}.join(',') }]
               )
             end
 


### PR DESCRIPTION
Before this commit the coercer generated following hashes:

```
Hash[*[:id, 1, :field, "string"]]
```

After this commit the coercer generates code with the same semantics:

```
Hash[:id, 1, :field, "string"]
```

This later code is not only shorter but also faster because it allocates
less array objects (no splat).

A small benchmark tries to proof it:

```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report "hash simple" do
    Hash[:foo, 1, :bar, 2]
  end

  x.report "hash splat" do
    Hash[*[:foo, 1, :bar, 2]]
  end
end

=begin

Calculating -------------------------------------
         hash simple     91144 i/100ms
          hash splat     80099 i/100ms
-------------------------------------------------
         hash simple  2241513.4 (±1.3%) i/s -   11210712 in   5.002338s
          hash splat  1840887.2 (±1.7%) i/s -    9211385 in   5.005211s
=end
```
