### PR TITLE
Generate unrolled list of entity attributes

### DIFF
--- a/lib/lotus/entity.rb
+++ b/lib/lotus/entity.rb
@@ -107,7 +107,7 @@ module Lotus
 
         class_eval %{
           def initialize(attributes = {})
-        #{ @attributes.map {|a| "@#{a}" }.join(', ') }, = *attributes.values_at(#{ @attributes.map {|a| ":#{a}"}.join(', ') })
+            #{ @attributes.map {|a| "@#{a} = attributes[:#{a}]" }.join("\n") }
           end
         }
 


### PR DESCRIPTION
This commit improves the performance of Entity's constructor
by unrolling the list of its attributes.

Before the generated code looked like:

```
def initialize(attributes = {})
  @a, @b, @c, = *attributes.values_at(:a, :b, :c)
end
```

After this commit it looks like:

```
def initialize(attributes = {})
  @a = attributes[:a]
  @b = attributes[:b]
  @c = attributes[:c]
end
```

The benchmark:

```
require 'benchmark/ips'
require 'lotus/entity'

def attributes_for(times)
  times.times.map { |i| :"field#{i}" }
end

def hash_for(times)
  Hash[times.times.map { |i| [:"field#{i}", i] }]
end

class Model1
  include Lotus::Entity
  self.attributes = attributes_for(2)
end

class Model5
  include Lotus::Entity
  self.attributes = attributes_for(5)
end

class Model10
  include Lotus::Entity
  self.attributes = attributes_for(10)
end

h1 = hash_for(2)
h5 = hash_for(5)
h10 = hash_for(10)

Benchmark.ips do |x|
  x.report "model1" do
    Model1.new(h1)
  end
  x.report "model5" do
    Model5.new(h5)
  end
  x.report "model10" do
    Model10.new(h10)
  end
end

=begin

## initial

Calculating -------------------------------------
              model1     75310 i/100ms
              model5     51012 i/100ms
             model10     40219 i/100ms
-------------------------------------------------
              model1  1551154.1 (±2.1%) i/s -    7756930 in   5.003060s
              model5   812667.3 (±1.4%) i/s -    4080960 in   5.022625s
             model10   580076.2 (±1.4%) i/s -    2935987 in   5.062472s

## w/o splat

Calculating -------------------------------------
              model1     80699 i/100ms
              model5     53507 i/100ms
             model10     44218 i/100ms
-------------------------------------------------
              model1  1760277.4 (±1.8%) i/s -    8876890 in   5.044533s
              model5   915549.1 (±1.7%) i/s -    4601602 in   5.027518s
             model10   672009.3 (±1.7%) i/s -    3360568 in   5.002209s

## loop unrolled

Calculating -------------------------------------
              model1     86138 i/100ms
              model5     61557 i/100ms
             model10     47912 i/100ms
-------------------------------------------------
              model1  2110472.0 (±2.1%) i/s -   10594974 in   5.022513s
              model5  1186649.0 (±1.0%) i/s -    5971029 in   5.032338s
             model10   747101.7 (±0.9%) i/s -    3737136 in   5.002571s

=end
```
