### PR TITLE
Raise an error when Repository methods are called without an adapter

### DIFF
--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -214,7 +214,7 @@ describe Lotus::Repository do
     }.each do |description, code|
       describe description do
         it 'raises an error' do
-          code.must_raise(NoMethodError)
+          code.must_raise(Lotus::Repository::NoAdapterError)
         end
       end
     end


### PR DESCRIPTION
When the developer forgets to set a repository adapter, we should remind them with a helpful error message. As of 0.10.2, not setting an adapter and calling `UserRepository.all` gives this error:

```
NoMethodError: undefined method `all' for nil:NilClass
```

I think it would be a bit more informative to have something like:

```
Lotus::Repository::NoAdapterError: UserRepository has no persistence adapter. See http://rdoc.info/gems/lotus-model
```

Let me know if you'd prefer a different API for ensuring that developers set the adapter.
