### PR TITLE
Correcting MemoryAdapter#delete method

### DIFF
--- a/lib/lotus/model/adapters/memory/collection.rb
+++ b/lib/lotus/model/adapters/memory/collection.rb
@@ -104,7 +104,7 @@ module Lotus
           # @api private
           # @since 0.1.0
           def delete(entity)
-            records.delete(entity.id)
+            records.delete(entity.public_send(identity))
           end
 
           # Returns all the raw records


### PR DESCRIPTION
In cases in which the entity has an `identity` other than :id, the
memory adapter would fail deleting the record because :id was
undefined.
