### PR TITLE
Preserving adapter declaration for repository

### DIFF
--- a/lib/lotus/model/mapping/collection.rb
+++ b/lib/lotus/model/mapping/collection.rb
@@ -361,7 +361,7 @@ module Lotus
         # @since 0.1.0
         def configure_repository!
           repository.collection = name
-          repository.adapter = adapter
+          repository.adapter ||= adapter
           rescue NameError
         end
 

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -210,6 +210,15 @@ module Lotus
         @adapter = adapter
       end
 
+      # @return adapter [Object] an object that implements
+      #   `Lotus::Model::Adapters::Abstract` interface
+      #
+      # @api private
+      # @since 0.1.2
+      def adapter
+        @adapter
+      end
+
       # Creates or updates a record in the database for the given entity.
       #
       # @param entity [#id, #id=] the entity to persist
@@ -250,7 +259,7 @@ module Lotus
       #   article = ArticleRepository.find(23)
       #   article.title # => "Launching Lotus::Model"
       def persist(entity)
-        @adapter.persist(collection, entity)
+        adapter.persist(collection, entity)
         entity
       end
 
@@ -283,7 +292,7 @@ module Lotus
       #   ArticleRepository.create(article) # no-op
       def create(entity)
         unless entity.id
-          @adapter.create(collection, entity)
+          adapter.create(collection, entity)
         end
 
         entity
@@ -333,7 +342,7 @@ module Lotus
       #   ArticleRepository.update(article) # raises Lotus::Model::NonPersistedEntityError
       def update(entity)
         if entity.id
-          @adapter.update(collection, entity)
+          adapter.update(collection, entity)
         else
           raise Lotus::Model::NonPersistedEntityError
         end
@@ -383,7 +392,7 @@ module Lotus
       #   ArticleRepository.delete(article) # raises Lotus::Model::NonPersistedEntityError
       def delete(entity)
         if entity.id
-          @adapter.delete(collection, entity)
+          adapter.delete(collection, entity)
         else
           raise Lotus::Model::NonPersistedEntityError
         end
@@ -406,7 +415,7 @@ module Lotus
       #
       #   ArticleRepository.all # => [ #<Article:0x007f9b19a60098> ]
       def all
-        @adapter.all(collection)
+        adapter.all(collection)
       end
 
       # Finds an entity by its identity.
@@ -432,7 +441,7 @@ module Lotus
       #
       #   ArticleRepository.find(9) # => raises Lotus::Model::EntityNotFound
       def find(id)
-        @adapter.find(collection, id).tap do |record|
+        adapter.find(collection, id).tap do |record|
           raise Lotus::Model::EntityNotFound.new unless record
         end
       end
@@ -463,7 +472,7 @@ module Lotus
       #
       #   ArticleRepository.first # => nil
       def first
-        @adapter.first(collection)
+        adapter.first(collection)
       end
 
       # Returns the last entity in the database.
@@ -492,7 +501,7 @@ module Lotus
       #
       #   ArticleRepository.last # => nil
       def last
-        @adapter.last(collection)
+        adapter.last(collection)
       end
 
       # Deletes all the records from the current collection.
@@ -510,7 +519,7 @@ module Lotus
       #
       #   ArticleRepository.clear # deletes all the records
       def clear
-        @adapter.clear(collection)
+        adapter.clear(collection)
       end
 
       private
@@ -589,7 +598,7 @@ module Lotus
       #     end
       #   end
       def query(&blk)
-        @adapter.query(collection, self, &blk)
+        adapter.query(collection, self, &blk)
       end
 
       # Negates the filtering conditions of a given query with the logical

--- a/test/integration/load_mapper_test.rb
+++ b/test/integration/load_mapper_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'lotus/entity'
+require 'lotus/repository'
+require 'lotus/model/mapper'
+require 'lotus/model/adapters/memory_adapter'
+
+describe 'load mapper' do
+  before do
+    class MyTestEntity
+      include Lotus::Entity
+      self.attributes = :title
+    end
+    class MyTestRepository
+      include Lotus::Repository
+    end
+    @mapping = Lotus::Model::Mapper.new do
+      collection :test_entity do
+        entity     MyTestEntity
+        repository MyTestRepository
+
+        attribute :id, Integer
+        attribute :title, String
+      end
+    end
+
+    @adapter = Lotus::Model::Adapters::MemoryAdapter.new(@mapping)
+    MyTestRepository.adapter = @adapter
+  end
+  after do
+    Object.send(:remove_const, :MyTestEntity)
+    Object.send(:remove_const, :MyTestRepository)
+  end
+
+  it 'should preserve assigned adapter' do
+    MyTestRepository.send(:adapter).must_equal(@adapter)
+    @mapping.load!
+    MyTestRepository.send(:adapter).must_equal(@adapter)
+  end
+end


### PR DESCRIPTION
This pull request addresses a very specific behavior as documented in
the [README](https://github.com/lotus/model/blob/master/README.md#adapter).

It also appears that there are several paths to setting a repository's
adapter. Below is an excerpt from `Mapper#load!`

``` console
./lib/lotus/repository.rb:211:in `adapter='
./lib/lotus/model/mapping/collection.rb:364:in `configure_repository!'
./lib/lotus/model/mapping/collection.rb:352:in `load!'
./lib/lotus/model/mapper.rb:105:in `block in load!'
./lib/lotus/model/mapper.rb:103:in `each_value'
./lib/lotus/model/mapper.rb:103:in `load!'
```

Closes lotus/model#84
