### PR TITLE
Adding line numbers to class_eval

### DIFF
--- a/lib/lotus/entity.rb
+++ b/lib/lotus/entity.rb
@@ -112,11 +112,11 @@ module Lotus
       def attributes=(*attributes)
         @attributes = Lotus::Utils::Kernel.Array(attributes.unshift(:id))
 
-        class_eval %{
+        class_eval <<-END_EVAL, __FILE__, __LINE__
           def initialize(attributes = {})
             #{ @attributes.map {|a| "@#{a} = attributes[:#{a}]" }.join("\n") }
           end
-        }
+        END_EVAL
 
         attr_accessor *@attributes
       end


### PR DESCRIPTION
Given the following:

``` ruby
class MyApp::Document
  include Lotus::Entity
  self.attributes :title
end

MyApp::Document.new(nil)
=> NoMethodError: undefined method `[]' for nil:NilClass
  (eval):2:in `initialize'
```

This error message was unhelpful as I had to go digging around for
where it could be.

The error also calls to attention another interface question. The code
I was using was as follows:

``` ruby
module MyApp
  class New
    include Lotus::Action

    def call(params = {})
      @deposit = MyApp::Document.new(params[:document])
    end
  end
end
```

I would like to allow defaults to be passed into initialization. The
former and latter code that initializes `MyApp::Document` are very
much the same.

Drawing a comparison to `ActiveRecord::Base` initialization the
following initialization methods each work:
- `Document.new`
- `Document.new(nil)`
- `Document.new({})`
