### PR TITLE
Implement attribute inheritance

### DIFF
--- a/lib/lotus/entity.rb
+++ b/lib/lotus/entity.rb
@@ -95,9 +95,9 @@ module Lotus
       # Please notice that the required `id` attribute is automatically defined
       # and can be omitted in the arguments.
       #
-      # @param attributes [Array<Symbol>] a set of arbitrary attribute names
+      # @param attributes [Set<Symbol>] a set of arbitrary attribute names
       #
-      # @since 0.1.0
+      # @since 0.2.0
       #
       # @see Lotus::Repository
       # @see Lotus::Model::Mapper
@@ -107,10 +107,21 @@ module Lotus
       #
       #   class User
       #     include Lotus::Entity
-      #     self.attributes = :name
+      #     self.attributes = :name, :age
       #   end
-      def attributes=(*attributes)
-        @attributes = Lotus::Utils::Kernel.Array(attributes.unshift(:id))
+      #   User.attributes => #<Set: {:id, :name, :age}>
+      #
+      # @example Given params is array of attributes
+      #   require 'lotus/model'
+      #
+      #   class User
+      #     include Lotus::Entity
+      #     self.attributes = [:name, :age]
+      #   end
+      #   User.attributes => #<Set: {:id, :name, :age}>
+      #
+      def attributes=(*attrs)
+        self.attributes.merge Lotus::Utils::Kernel.Array(attrs)
 
         class_eval <<-END_EVAL, __FILE__, __LINE__
           def initialize(attributes = {})
@@ -124,7 +135,15 @@ module Lotus
       end
 
       def attributes
-        @attributes
+        @attributes ||= Set.new([:id])
+      end
+
+      protected
+
+      # @see Class#inherited
+      def inherited(subclass)
+        subclass.attributes = *attributes
+        super
       end
     end
 

--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -11,7 +11,12 @@ describe Lotus::Entity do
       self.attributes = :title, :author
     end
 
-    class NonFinctionBook < Book
+    class NonFictionBook < Book
+      self.attributes = :price
+    end
+
+    class CoolNonFictionBook < NonFictionBook
+      self.attributes = :coolness
     end
 
     class Camera
@@ -21,17 +26,22 @@ describe Lotus::Entity do
   end
 
   after do
-    [:Car, :Book, :NonFinctionBook, :Camera].each do |const|
+    [:Car, :Book, :NonFictionBook, :CoolNonFictionBook, :Camera].each do |const|
       Object.send(:remove_const, const)
     end
   end
 
   describe 'attributes' do
-    let(:attributes) { [:id, :model] }
-
     it 'defines attributes' do
-      Car.send(:attributes=, attributes)
-      Car.send(:attributes).must_equal attributes
+      Car.attributes = :model
+      Car.attributes.must_equal Set.new([:id, :model])
+    end
+
+    describe 'params is array' do
+      it 'defines attributes' do
+        Car.attributes = [:model]
+        Car.attributes.must_equal Set.new([:id, :model])
+      end
     end
   end
 
@@ -57,11 +67,21 @@ describe Lotus::Entity do
         book.instance_variable_get(:@unknown).must_be_nil
       end
 
-      it 'accepts given attributes for subclass' do
-        book = NonFinctionBook.new(title: 'Refactoring', author: 'Martin Fowler')
+      it 'accepts given attributes for subclasses' do
+        book = NonFictionBook.new(title: 'Refactoring', author: 'Martin Fowler', price: 50)
 
         book.instance_variable_get(:@title).must_equal  'Refactoring'
         book.instance_variable_get(:@author).must_equal 'Martin Fowler'
+        book.instance_variable_get(:@price).must_equal 50
+      end
+
+      it 'accepts given attributes for subclass of subclass' do
+        book = CoolNonFictionBook.new(title: 'Refactoring', author: 'Martin Fowler', price: 50, coolness: 'awesome')
+
+        book.instance_variable_get(:@title).must_equal  'Refactoring'
+        book.instance_variable_get(:@author).must_equal 'Martin Fowler'
+        book.instance_variable_get(:@price).must_equal 50
+        book.instance_variable_get(:@coolness).must_equal 'awesome'
       end
     end
 


### PR DESCRIPTION
This PR aims to implement inheritance for attributes.

Currently this is not possible:

``` ruby
class Book
  include Lotus::Entity
  self.attributes = :title, :author
end

class NonFictionBook < Book
  self.attributes = :price
end
```

For the `NonFictionBook` Entitiy only `price` is available as  attribute.
With this PR merged in this is possible because we are saving the inherited attributes as class instance variable via the inherit hook.
Note that this contains some metaprogramming I wish we could remove and therefore have a clearer and easier to understand codebase.

This closes #98
