### PR TITLE
Make Memory::Query#offset behave like SQL

### DIFF
--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -285,7 +285,7 @@ module Lotus
           #
           #   query.offset(10)
           def offset(number)
-            modifiers.unshift(Proc.new{ replace(flatten.last(number)) })
+            modifiers.unshift(Proc.new{ replace(flatten.drop(number)) })
             self
           end
 

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -625,19 +625,21 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           @adapter.create(collection, user1)
           @adapter.create(collection, user2)
           @adapter.create(collection, user3)
+          @adapter.create(collection, user4)
         end
 
-        let(:user3) { TestUser.new(name: user2.name) }
+        let(:user3) { TestUser.new(name: user2.name, age: 31) }
+        let(:user4) { TestUser.new(name: user2.name, age: 32) }
 
         it 'returns only the number of requested records' do
           name = user2.name
 
           query = Proc.new {
-            where(name: name).limit(1).offset(1)
+            where(name: name).limit(2).offset(1)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [user3, user4]
         end
       end
     end

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -705,19 +705,21 @@ describe Lotus::Model::Adapters::SqlAdapter do
           @adapter.create(collection, user1)
           @adapter.create(collection, user2)
           @adapter.create(collection, user3)
+          @adapter.create(collection, user4)
         end
 
-        let(:user3) { TestUser.new(name: user2.name) }
+        let(:user3) { TestUser.new(name: user2.name, age: 31) }
+        let(:user4) { TestUser.new(name: user2.name, age: 32) }
 
         it 'returns only the number of requested records' do
           name = user2.name
 
           query = Proc.new {
-            where(name: name).limit(1).offset(1)
+            where(name: name).limit(2).offset(1)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [user3, user4]
         end
       end
     end


### PR DESCRIPTION
Right now, the `offset(number)` method in `Adapter::Memory::Query` returns the last `number` records. The normal behaviour for SQL is to skip the first `number` records. E.g. `offset(1)` with the dataset `[user1, user2, user3]` should result in a query that returns `[user2, user3]`, not `[user3]`.

This fix makes the `offset` in the memory adapter behave more like the method in the SQL adapter.
