### PR TITLE
Fix conflict with ActiveSupport dependency loading

### DIFF
--- a/lib/lotus/model/config/adapter.rb
+++ b/lib/lotus/model/config/adapter.rb
@@ -76,13 +76,13 @@ module Lotus
         #
         # @since x.x.x
         def build(mapper)
-          load_dependency
+          load_adapter
           instantiate_adapter(mapper)
         end
 
         private
 
-        def load_dependency
+        def load_adapter
           begin
             require "lotus/model/adapters/#{type}_adapter"
           rescue LoadError => e

--- a/test/model/config/adapter_test.rb
+++ b/test/model/config/adapter_test.rb
@@ -36,7 +36,7 @@ describe Lotus::Model::Config::Adapter do
       let(:config) { Lotus::Model::Config::Adapter.new(type: :redis, uri: SQLITE_CONNECTION_STRING) }
 
       it 'raises an error' do
-        config.stub(:load_dependency, nil) do
+        config.stub(:load_adapter, nil) do
           -> { config.build(mapper) }.must_raise(Lotus::Model::Config::AdapterNotFound)
         end
       end


### PR DESCRIPTION
`Object#require` in ActiveSupport attempts to call their own `Object#load_dependency` method [1], which is overridden in `Adapter` and causes an error when Lotus Model is used with Rails. This addresses the conflict by choosing a different method name.

```
/opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/model-17b037ea2cb5/lib/lotus/model/config/adapter.rb:85:in `load_dependency': wrong number of arguments (1 for 0) (ArgumentError)
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.2.0.rc1/lib/active_support/dependencies.rb:274:in `require'
        from /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/model-17b037ea2cb5/lib/lotus/model/config/adapter.rb:87:in `load_dependency'
```

[1] https://github.com/rails/rails/blob/4-2-0/activesupport/lib/active_support/dependencies.rb#L274
