### PR TITLE
Id flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ This architecture has several advantages:
 
 When a class includes `Lotus::Repository`, it will receive the following interface:
 
-  * `.persist(entity)` – Create or update an entity
   * `.create(entity)`  – Create a record for the given entity
   * `.update(entity)`  – Update the record corresponding to the given entity
   * `.delete(entity)`  – Delete the record corresponding to the given entity

--- a/lib/lotus/model.rb
+++ b/lib/lotus/model.rb
@@ -17,6 +17,21 @@ module Lotus
     #
     # @see Lotus::Repository.update
     class NonPersistedEntityError < ::StandardError
+      def initialize(message = "Entity is not persisted")
+        super
+      end
+    end
+
+    # Error for already persisted entity
+    # It's raised when we try to create already persisted entry.
+    #
+    # @since 0.6.0
+    #
+    # @see Lotus::Repository.create
+    class AlreadyPersistedEntityError < ::StandardError
+      def initialize(message = "Entity is already persisted")
+        super
+      end
     end
 
     # Error for invalid mapper configuration

--- a/lib/lotus/model/adapters/abstract.rb
+++ b/lib/lotus/model/adapters/abstract.rb
@@ -91,18 +91,6 @@ module Lotus
           @uri    = uri
         end
 
-        # Creates or updates a record in the database for the given entity.
-        #
-        # @param collection [Symbol] the target collection (it must be mapped).
-        # @param entity [Object] the entity to persist
-        #
-        # @return [Object] the entity
-        #
-        # @since 0.1.0
-        def persist(collection, entity)
-          raise NotImplementedError
-        end
-
         # Creates a record in the database for the given entity.
         # It should assign an id (identity) to the entity in case of success.
         #

--- a/lib/lotus/model/adapters/implementation.rb
+++ b/lib/lotus/model/adapters/implementation.rb
@@ -6,23 +6,6 @@ module Lotus
       # @api private
       # @since 0.1.0
       module Implementation
-        # Creates or updates a record in the database for the given entity.
-        #
-        # @param collection [Symbol] the target collection (it must be mapped).
-        # @param entity [#id, #id=] the entity to persist
-        #
-        # @return [Object] the entity
-        #
-        # @api private
-        # @since 0.1.0
-        def persist(collection, entity)
-          if entity.id
-            update(collection, entity)
-          else
-            create(collection, entity)
-          end
-        end
-
         # Returns all the records for the given collection
         #
         # @param collection [Symbol] the target collection (it must be mapped).

--- a/lib/lotus/model/adapters/memory/collection.rb
+++ b/lib/lotus/model/adapters/memory/collection.rb
@@ -32,6 +32,29 @@ module Lotus
               yield(@current += 1)
               @current
             end
+
+            # Sets the current count for a given value
+            #
+            # @param id [Fixnum] the value to set
+            #
+            # @see Lotus::Model::Adapters::Memory::Command#create
+            #
+            # @return [Fixnum] the counter
+            #
+            # @api private
+            # @since 0.6.0
+            def set!(id)
+              @current = id
+            end
+          end
+
+          # Error for identity unique constraint
+          # It's raised when new entity duplicates identity value
+          #
+          # @since 0.6.0
+          #
+          # @see Lotus::Model::Adapters::Memory::Collection#create
+          class UniqueConstraintViolation < ::StandardError
           end
 
           # @attr_reader name [Symbol] the name of the collection (eg. `:users`)
@@ -77,9 +100,10 @@ module Lotus
           # @api private
           # @since 0.1.0
           def create(entity)
-            @primary_key.increment! do |id|
-              entity[identity] = id
-              records[id] = entity
+            if entity[identity]
+              create_with_id(entity)
+            else
+              create_without_id(entity)
             end
           end
 
@@ -124,6 +148,48 @@ module Lotus
           def clear
             @records     = {}
             @primary_key = PrimaryKey.new
+          end
+
+          private
+
+
+          # Creates a record for the given entity with id
+          # If already entity is persisted (`id` exists) it raises an exception.
+          #
+          # @param entity [Object] the entity to persist
+          #
+          # @see Lotus::Model::Adapters::Memory::Collection#create
+          #
+          # @return the primary key which is maximum of all entities
+          #
+          # @api private
+          # @since 0.6.0
+          def create_with_id(entity)
+            _id = entity[identity]
+
+            if records[_id]
+              raise UniqueConstraintViolation, "Duplicate identity value violates unique constraint"
+            end
+
+            records[_id] = entity
+            @primary_key.set!(records.keys.max)
+          end
+
+          # Creates a record for the given entity without id and assigns an id.
+          #
+          # @param entity [Object] the entity to persist
+          #
+          # @see Lotus::Model::Adapters::Memory::Collection#create
+          #
+          # @return the primary key of the created record
+          #
+          # @api private
+          # @since 0.6.0
+          def create_without_id(entity)
+            @primary_key.increment! do |id|
+              entity[identity] = id
+              records[id] = entity
+            end
           end
         end
       end

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -221,7 +221,7 @@ module Lotus
       # Creates a record in the database for the given entity.
       # It returns a copy of the entity with `id` assigned.
       #
-      # If already persisted (`id` present) it does nothing.
+      # If already persisted it does nothing and returns nil.
       #
       # @param entity [#id,#id=] the entity to create
       #
@@ -249,10 +249,14 @@ module Lotus
       #   created_article = ArticleRepository.create(existing_article) # => no-op
       #   created_article # => nil
       #
+      #   imported_article = ArticleRepository.create(Article.new(title: 'New Lotus features', id: 123))
+      #   imported_article.id  # => 123
       def create(entity)
-        unless _persisted?(entity)
-          _touch(entity)
+        _touch(entity)
+        begin
           @adapter.create(collection, entity)
+        rescue Exception => e
+          raise Lotus::Model::AlreadyPersistedEntityError.new e.message
         end
       end
 

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -218,51 +218,6 @@ module Lotus
         @adapter
       end
 
-      # Creates or updates a record in the database for the given entity.
-      #
-      # @param entity [#id, #id=] the entity to persist
-      #
-      # @return [Object] a copy of the entity with `id` assigned
-      #
-      # @since 0.1.0
-      #
-      # @see Lotus::Repository#create
-      # @see Lotus::Repository#update
-      #
-      # @example With a non persisted entity
-      #   require 'lotus/model'
-      #
-      #   class ArticleRepository
-      #     include Lotus::Repository
-      #   end
-      #
-      #   article = Article.new(title: 'Introducing Lotus::Model')
-      #   article.id # => nil
-      #
-      #   persisted_article = ArticleRepository.persist(article) # creates a record
-      #   article.id # => nil
-      #   persisted_article.id # => 23
-      #
-      # @example With a persisted entity
-      #   require 'lotus/model'
-      #
-      #   class ArticleRepository
-      #     include Lotus::Repository
-      #   end
-      #
-      #   article = ArticleRepository.find(23)
-      #   article.id # => 23
-      #
-      #   article.title = 'Launching Lotus::Model'
-      #   ArticleRepository.persist(article) # updates the record
-      #
-      #   article = ArticleRepository.find(23)
-      #   article.title # => "Launching Lotus::Model"
-      def persist(entity)
-        _touch(entity)
-        @adapter.persist(collection, entity)
-      end
-
       # Creates a record in the database for the given entity.
       # It returns a copy of the entity with `id` assigned.
       #
@@ -273,8 +228,6 @@ module Lotus
       # @return [Object] a copy of the entity with `id` assigned
       #
       # @since 0.1.0
-      #
-      # @see Lotus::Repository#persist
       #
       # @example
       #   require 'lotus/model'
@@ -316,7 +269,6 @@ module Lotus
       #
       # @since 0.1.0
       #
-      # @see Lotus::Repository#persist
       # @see Lotus::Model::NonPersistedEntityError
       #
       # @example With a persisted entity

--- a/test/model/adapters/abstract_test.rb
+++ b/test/model/adapters/abstract_test.rb
@@ -7,12 +7,6 @@ describe Lotus::Model::Adapters::Abstract do
   let(:query)      { Object.new }
   let(:collection) { :collection }
 
-  describe '#persist' do
-    it 'raises error' do
-      -> { adapter.persist(collection, entity) }.must_raise NotImplementedError
-    end
-  end
-
   describe '#create' do
     it 'raises error' do
       -> { adapter.create(collection, entity) }.must_raise NotImplementedError

--- a/test/model/adapters/file_system_adapter_test.rb
+++ b/test/model/adapters/file_system_adapter_test.rb
@@ -112,67 +112,6 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
     end
   end
 
-  # BUG
-  # See: https://github.com/lotus/model/issues/151
-  describe 'when already present database' do
-    before do
-      data = Pathname.new(FILE_SYSTEM_CONNECTION_STRING)
-      data.rmtree if data.exist?
-
-      @user1   = TestUser.new(name: 'L')
-      @user2   = TestUser.new(name: 'MG')
-      old_data = Lotus::Model::Adapters::FileSystemAdapter.new(@mapper, FILE_SYSTEM_CONNECTION_STRING)
-      @user1   = old_data.persist(collection, @user1)
-
-      @adapter = Lotus::Model::Adapters::FileSystemAdapter.new(@mapper, FILE_SYSTEM_CONNECTION_STRING)
-    end
-
-    it 'reads the old data' do
-      @adapter.all(collection).must_equal [@user1]
-    end
-
-    it 'writes without erasing old data' do
-      @user2 = @adapter.persist(collection, @user2)
-      @adapter.all(collection).must_equal [@user1, @user2]
-    end
-  end
-
-  describe '#persist' do
-    after do
-      @adapter.disconnect
-    end
-
-    describe 'when the given entity is not persisted' do
-      let(:entity) { TestUser.new }
-
-      it 'stores the record and assigns an id' do
-        result = @adapter.persist(collection, entity)
-
-        result.id.wont_be_nil
-        @verifier.find(collection, result.id).must_equal result
-      end
-    end
-
-    describe 'when the given entity is persisted' do
-      before do
-        @entity = @adapter.create(collection, entity)
-      end
-
-      let(:entity) { TestUser.new }
-
-      it 'updates the record and leaves untouched the id' do
-        id = @entity.id
-        id.wont_be_nil
-
-        @entity.name = 'L'
-        @adapter.persist(collection, @entity)
-
-        @entity.id.must_equal(id)
-        @verifier.find(collection, @entity.id).name.must_equal @entity.name
-      end
-    end
-  end
-
   describe '#create' do
     let(:entity) { TestUser.new }
 

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -59,38 +59,6 @@ describe Lotus::Model::Adapters::MemoryAdapter do
     end
   end
 
-  describe '#persist' do
-    describe 'when the given entity is not persisted' do
-      let(:entity) { TestUser.new }
-
-      it 'stores the record and assigns an id' do
-        result = @adapter.persist(collection, entity)
-
-        result.id.wont_be_nil
-        @adapter.find(collection, result.id).must_equal result
-      end
-    end
-
-    describe 'when the given entity is persisted' do
-      before do
-        @entity = @adapter.create(collection, entity)
-      end
-
-      let(:entity) { TestUser.new }
-
-      it 'updates the record and leaves untouched the id' do
-        id = @entity.id
-        id.wont_be_nil
-
-        @entity.name = 'L'
-        @adapter.persist(collection, @entity)
-
-        @entity.id.must_equal(id)
-        @adapter.find(collection, @entity.id).name.must_equal @entity.name
-      end
-    end
-  end
-
   describe '#create' do
     let(:entity) { TestUser.new }
 

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -150,38 +150,6 @@ describe Lotus::Model::Adapters::SqlAdapter do
     end
   end
 
-  describe '#persist' do
-    describe 'when the given entity is not persisted' do
-      let(:entity) { TestUser.new }
-
-      it 'stores the record and assigns an id' do
-        result = @adapter.persist(collection, entity)
-
-        result.id.wont_be_nil
-        @adapter.find(collection, result.id).must_equal result
-      end
-    end
-
-    describe 'when the given entity is persisted' do
-      before do
-        @entity = @adapter.create(collection, entity)
-      end
-
-      let(:entity) { TestUser.new }
-
-      it 'updates the record and leaves untouched the id' do
-        id = @entity.id
-        id.wont_be_nil
-
-        @entity.name = 'L'
-        @adapter.persist(collection, @entity)
-
-        @entity.id.must_equal(id)
-        @adapter.find(collection, @entity.id).name.must_equal @entity.name
-      end
-    end
-  end
-
   describe '#create' do
     let(:entity) { TestUser.new }
 


### PR DESCRIPTION
The PR is a result of our discussion with @jodosha in #248 .

I removed `.persist` and check on `id` in `.create`. It give a chance to set `id` manually. Related test also included.

```ruby
@persisted_user = UserRepository.create(User.new(name: 'My', age: '23', id: 100))
UserRepository.all # => [@persisted_user]
@persisted_user.id #=> 100
```