### PR TITLE
Expose original Exceptions from Sequel Adapter

### DIFF
--- a/lib/hanami/model/adapters/sql/command.rb
+++ b/lib/hanami/model/adapters/sql/command.rb
@@ -31,8 +31,6 @@ module Hanami
           # @since 0.1.0
           def create(entity)
             @collection.insert(entity)
-          rescue Sequel::DatabaseError => e
-            raise Hanami::Model::Error.new(e.message)
           end
 
           # Updates the corresponding record for the given entity.
@@ -45,8 +43,6 @@ module Hanami
           # @since 0.1.0
           def update(entity)
             @collection.update(entity)
-          rescue Sequel::DatabaseError => e
-            raise Hanami::Model::Error.new(e.message)
           end
 
           # Deletes all the records for the current query.
@@ -60,8 +56,6 @@ module Hanami
           # @since 0.1.0
           def delete
             @collection.delete
-          rescue Sequel::DatabaseError => e
-            raise Hanami::Model::Error.new(e.message)
           end
 
           alias_method :clear, :delete

--- a/test/model/adapters/sql/command_test.rb
+++ b/test/model/adapters/sql/command_test.rb
@@ -17,9 +17,9 @@ describe Hanami::Model::Adapters::Sql::Command do
     describe 'when a Sequel::ForeignKeyConstraintViolation is raised' do
       it 'raises Hanami::Model::Error exception' do
         collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::ForeignKeyConstraintViolation.new('fkey constraint error')
+          raise Sequel::ForeignKeyConstraintViolation.new('fkey constraint error')
         end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.create(Object.new) }.must_raise(Sequel::ForeignKeyConstraintViolation)
         exception.message.must_equal('fkey constraint error')
       end
     end
@@ -27,9 +27,9 @@ describe Hanami::Model::Adapters::Sql::Command do
     describe 'when a Sequel::CheckConstraintViolation is raised' do
       it 'raises Hanami::Model::Error exception' do
         collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::CheckConstraintViolation.new('check constraint error')
+          raise Sequel::CheckConstraintViolation.new('check constraint error')
         end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.create(Object.new) }.must_raise(Sequel::CheckConstraintViolation)
         exception.message.must_equal('check constraint error')
       end
     end
@@ -37,9 +37,9 @@ describe Hanami::Model::Adapters::Sql::Command do
     describe 'when a Sequel::NotNullConstraintViolation is raised' do
       it 'raises Hanami::Model::Error exception' do
         collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::NotNullConstraintViolation.new('not null constraint error')
+          raise Sequel::NotNullConstraintViolation.new('not null constraint error')
         end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.create(Object.new) }.must_raise(Sequel::NotNullConstraintViolation)
         exception.message.must_equal('not null constraint error')
       end
     end
@@ -47,9 +47,9 @@ describe Hanami::Model::Adapters::Sql::Command do
     describe 'when a Sequel::UniqueConstraintViolation is raised' do
       it 'raises Hanami::Model::Error exception' do
         collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::UniqueConstraintViolation.new('unique constraint error')
+          raise Sequel::UniqueConstraintViolation.new('unique constraint error')
         end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.create(Object.new) }.must_raise(Sequel::UniqueConstraintViolation)
         exception.message.must_equal('unique constraint error')
       end
     end
@@ -57,9 +57,9 @@ describe Hanami::Model::Adapters::Sql::Command do
     describe 'when a Sequel::DatabaseError is raised' do
       it 'raises Hanami::Model::Error exception' do
         collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::DatabaseError.new('db error')
+          raise Sequel::DatabaseError.new('db error')
         end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.create(Object.new) }.must_raise(Sequel::DatabaseError)
         exception.message.must_equal('db error')
       end
     end
@@ -81,7 +81,7 @@ describe Hanami::Model::Adapters::Sql::Command do
         collection.define_singleton_method(:update) do |_|
           raise Sequel::DatabaseError.new('db error')
         end
-        exception = -> { @command.update(Object.new) }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.update(Object.new) }.must_raise(Sequel::DatabaseError)
         exception.message.must_equal('db error')
       end
     end
@@ -103,7 +103,7 @@ describe Hanami::Model::Adapters::Sql::Command do
         collection.define_singleton_method(:delete) do
           raise Sequel::DatabaseError.new('db error')
         end
-        exception = -> { @command.delete }.must_raise(Hanami::Model::Error)
+        exception = -> { @command.delete }.must_raise(Sequel::DatabaseError)
         exception.message.must_equal('db error')
       end
     end


### PR DESCRIPTION
As discussed in #284, we agreed to rollback the `Hanami::Error` in prior to (re)raise specific errors (i.e. Unique Constraints, ForeignKey Violations et al) from Sequel adapter.

Rollback #281 
Closes #284 