### PR TITLE
Mapping SQL Adapter's Errors into specific Model's Error

### DIFF
--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -47,6 +47,42 @@ module Hanami
       end
     end
 
+    # Error for Unique Constraint Violation
+    #
+    # @since x.x.x
+    class UniqueConstraintViolationError < Hanami::Model::Error
+      def initialize(message = "Unique constraint has been violated")
+        super
+      end
+    end
+
+    # Error for Foreign Key Constraint Violation
+    #
+    # @since x.x.x
+    class ForeignKeyConstraintViolationError < Hanami::Model::Error
+      def initialize(message = "Foreign key constraint has been violated")
+        super
+      end
+    end
+
+    # Error for Not Null Constraint Violation
+    #
+    # @since x.x.x
+    class NotNullConstraintViolationError < Hanami::Model::Error
+      def initialize(message = "NOT NULL constraint has been violated")
+        super
+      end
+    end
+
+    # Error for Check Constraint Violation raised by Sequel
+    #
+    # @since x.x.x
+    class CheckConstraintViolationError < Hanami::Model::Error
+      def initialize(message = "Check constraint has been violated")
+        super
+      end
+    end
+
     include Utils::ClassAttribute
 
     # Framework configuration

--- a/lib/hanami/model/adapters/sql/command.rb
+++ b/lib/hanami/model/adapters/sql/command.rb
@@ -81,16 +81,16 @@ module Hanami
           def _mapping_sequel_to_model(error)
             case error
             when Sequel::CheckConstraintViolation
-              Hanami::Model::CheckConstraintViolationError.new(error.message)
+              Hanami::Model::CheckConstraintViolationError
             when Sequel::ForeignKeyConstraintViolation
-              Hanami::Model::ForeignKeyConstraintViolationError.new(error.message)
+              Hanami::Model::ForeignKeyConstraintViolationError
             when Sequel::NotNullConstraintViolation
-              Hanami::Model::NotNullConstraintViolationError.new(error.message)
+              Hanami::Model::NotNullConstraintViolationError
             when Sequel::UniqueConstraintViolation
-              Hanami::Model::UniqueConstraintViolationError.new(error.message)
+              Hanami::Model::UniqueConstraintViolationError
             else
-              Hanami::Model::InvalidCommandError.new(error.message)
-            end
+              Hanami::Model::InvalidCommandError
+            end.new(error.message)
           end
         end
       end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -10,6 +10,10 @@ describe Hanami::Model::Error do
     Hanami::Model::NonPersistedEntityError.superclass.must_equal Hanami::Model::Error
     Hanami::Model::InvalidMappingError.superclass.must_equal Hanami::Model::Error
     Hanami::Model::InvalidCommandError.superclass.must_equal Hanami::Model::Error
+    Hanami::Model::CheckConstraintViolationError.superclass.must_equal Hanami::Model::Error
+    Hanami::Model::ForeignKeyConstraintViolationError.superclass.must_equal Hanami::Model::Error
+    Hanami::Model::NotNullConstraintViolationError.superclass.must_equal Hanami::Model::Error
+    Hanami::Model::UniqueConstraintViolationError.superclass.must_equal Hanami::Model::Error
     Hanami::Model::InvalidQueryError.superclass.must_equal Hanami::Model::Error
     Hanami::Model::Adapters::DatabaseAdapterNotFound.superclass.must_equal Hanami::Model::Error
     Hanami::Model::Adapters::NotSupportedError.superclass.must_equal Hanami::Model::Error

--- a/test/model/adapters/sql/command_test.rb
+++ b/test/model/adapters/sql/command_test.rb
@@ -8,6 +8,23 @@ SEQUEL_TO_HANAMI_MAPPING = {
 }
 
 describe Hanami::Model::Adapters::Sql::Command do
+  describe 'when create new entity successfully' do
+    it 'delegates the entity to the collection correctly' do
+      entity = Object.new
+      query = SqlQueryFake.new
+
+      collection = Minitest::Mock.new
+      collection.expect(:insert, true, [entity])
+
+      query.stub(:scoped, collection) do
+        command = Hanami::Model::Adapters::Sql::Command.new(query)
+        command.create(entity)
+
+        collection.verify
+      end
+    end
+  end
+
   describe 'when #create raises Sequel Database Violation Error' do
     SEQUEL_TO_HANAMI_MAPPING.each do |sequel_error, hanami_error|
 
@@ -23,6 +40,23 @@ describe Hanami::Model::Adapters::Sql::Command do
     end
   end
 
+  describe 'when update an entity successfully' do
+    it 'delegates the entity to the collection correctly' do
+      entity = Object.new
+      query = SqlQueryFake.new
+
+      collection = Minitest::Mock.new
+      collection.expect(:update, true, [entity])
+
+      query.stub(:scoped, collection) do
+        command = Hanami::Model::Adapters::Sql::Command.new(query)
+        command.update(entity)
+
+        collection.verify
+      end
+    end
+  end
+
   describe 'when #update raises Sequel Database Violation Error' do
     SEQUEL_TO_HANAMI_MAPPING.each do |sequel_error, hanami_error|
 
@@ -35,6 +69,23 @@ describe Hanami::Model::Adapters::Sql::Command do
         end
       end
 
+    end
+  end
+
+  describe 'when delete an entity successfully' do
+    it 'delegates to delete method on collection' do
+      entity = Object.new
+      query = SqlQueryFake.new
+
+      collection = Minitest::Mock.new
+      collection.expect(:delete, true)
+
+      query.stub(:scoped, collection) do
+        command = Hanami::Model::Adapters::Sql::Command.new(query)
+        command.delete
+
+        collection.verify
+      end
     end
   end
 

--- a/test/model/adapters/sql/command_test.rb
+++ b/test/model/adapters/sql/command_test.rb
@@ -1,121 +1,71 @@
 require 'test_helper'
 
+SEQUEL_TO_HANAMI_MAPPING = {
+  'Sequel::UniqueConstraintViolation'     => 'Hanami::Model::UniqueConstraintViolationError',
+  'Sequel::ForeignKeyConstraintViolation' => 'Hanami::Model::ForeignKeyConstraintViolationError',
+  'Sequel::NotNullConstraintViolation'    => 'Hanami::Model::NotNullConstraintViolationError',
+  'Sequel::CheckConstraintViolation'      => 'Hanami::Model::CheckConstraintViolationError'
+}
+
 describe Hanami::Model::Adapters::Sql::Command do
-  let(:collection) { Object.new }
-  let(:query) do
-    query = Object.new
-    query.instance_variable_set(:@collection, collection)
-    query.define_singleton_method(:scoped, -> { @collection })
-    query
+  describe 'when #create raises Sequel Database Violation Error' do
+    SEQUEL_TO_HANAMI_MAPPING.each do |sequel_error, hanami_error|
+
+      it "raises #{hanami_error} instead of #{sequel_error}" do
+        query = SqlQueryFake.new
+        command = Hanami::Model::Adapters::Sql::Command.new(query)
+
+        query.scoped.stub(:insert, ->(entity) { raise Object.const_get(sequel_error).new }) do
+          assert_raises(Object.const_get(hanami_error)) { command.create(Object.new) }
+        end
+      end
+
+    end
   end
 
-  before do
-    @command = Hanami::Model::Adapters::Sql::Command.new(query)
+  describe 'when #update raises Sequel Database Violation Error' do
+    SEQUEL_TO_HANAMI_MAPPING.each do |sequel_error, hanami_error|
+
+      it "raises #{hanami_error} instead of #{sequel_error}" do
+        query = SqlQueryFake.new
+        command = Hanami::Model::Adapters::Sql::Command.new(query)
+
+        query.scoped.stub(:update, ->(entity) { raise Object.const_get(sequel_error).new }) do
+          assert_raises(Object.const_get(hanami_error)) { command.update(Object.new) }
+        end
+      end
+
+    end
   end
 
-  describe '#create' do
-    describe 'when a Sequel::ForeignKeyConstraintViolation is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::ForeignKeyConstraintViolation.new('fkey constraint error')
-        end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('fkey constraint error')
-      end
-    end
+  describe 'when #delete raises Sequel Database Violation Error' do
+    SEQUEL_TO_HANAMI_MAPPING.each do |sequel_error, hanami_error|
 
-    describe 'when a Sequel::CheckConstraintViolation is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::CheckConstraintViolation.new('check constraint error')
-        end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('check constraint error')
-      end
-    end
+      it "raises #{hanami_error} instead of #{sequel_error}" do
+        query = SqlQueryFake.new
+        command = Hanami::Model::Adapters::Sql::Command.new(query)
 
-    describe 'when a Sequel::NotNullConstraintViolation is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::NotNullConstraintViolation.new('not null constraint error')
+        query.scoped.stub(:delete, -> { raise Object.const_get(sequel_error).new }) do
+          assert_raises(Object.const_get(hanami_error)) { command.delete }
         end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('not null constraint error')
-      end
-    end
-
-    describe 'when a Sequel::UniqueConstraintViolation is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::UniqueConstraintViolation.new('unique constraint error')
-        end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('unique constraint error')
-      end
-    end
-
-    describe 'when a Sequel::DatabaseError is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:insert) do |_|
-          raise ::Sequel::DatabaseError.new('db error')
-        end
-        exception = -> { @command.create(Object.new) }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('db error')
-      end
-    end
-
-    describe 'when an error that is not inherited from Sequel::DatabaseError is raised' do
-      it 'bubbles the error up' do
-        collection.define_singleton_method(:insert) do |_|
-          raise Sequel::Error.new('constraint error')
-        end
-        exception = -> { @command.create(Object.new) }.must_raise(Sequel::Error)
-        exception.message.must_equal('constraint error')
       end
     end
   end
 
-  describe '#update' do
-    describe 'when a Sequel::DatabaseError is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:update) do |_|
-          raise Sequel::DatabaseError.new('db error')
-        end
-        exception = -> { @command.update(Object.new) }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('db error')
-      end
-    end
-
-    describe 'when a different error is raised' do
-      it 'bubbles the error up' do
-        collection.define_singleton_method(:update) do |_|
-          raise Sequel::Error.new('constraint error')
-        end
-        exception = -> { @command.update(Object.new) }.must_raise(Sequel::Error)
-        exception.message.must_equal('constraint error')
-      end
+  class SqlQueryFake
+    def scoped
+      @collection ||= CollectionFake.new
     end
   end
 
-  describe '#delete' do
-    describe 'when a Sequel::DatabaseError is raised' do
-      it 'raises Hanami::Model::Error exception' do
-        collection.define_singleton_method(:delete) do
-          raise Sequel::DatabaseError.new('db error')
-        end
-        exception = -> { @command.delete }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal('db error')
-      end
+  class CollectionFake
+    def insert(entity)
     end
 
-    describe 'when a different error is raised' do
-      it 'bubbles the error up' do
-        collection.define_singleton_method(:delete) do
-          raise Sequel::Error.new('constraint error')
-        end
-        exception = -> { @command.delete }.must_raise(Sequel::Error)
-        exception.message.must_equal('constraint error')
-      end
+    def update(entity)
+    end
+
+    def delete
     end
   end
 end

--- a/test/model/adapters/sql/command_test.rb
+++ b/test/model/adapters/sql/command_test.rb
@@ -4,7 +4,8 @@ SEQUEL_TO_HANAMI_MAPPING = {
   'Sequel::UniqueConstraintViolation'     => 'Hanami::Model::UniqueConstraintViolationError',
   'Sequel::ForeignKeyConstraintViolation' => 'Hanami::Model::ForeignKeyConstraintViolationError',
   'Sequel::NotNullConstraintViolation'    => 'Hanami::Model::NotNullConstraintViolationError',
-  'Sequel::CheckConstraintViolation'      => 'Hanami::Model::CheckConstraintViolationError'
+  'Sequel::CheckConstraintViolation'      => 'Hanami::Model::CheckConstraintViolationError',
+  'Sequel::SerializationFailure'          => 'Hanami::Model::InvalidCommandError'
 }
 
 describe Hanami::Model::Adapters::Sql::Command do


### PR DESCRIPTION
As discussed in #284, we agreed to rollback the adapter violation errors in prior to (re)raise specific errors (i.e. Unique Constraints, ForeignKey Violations et al) encapsulated by our Model Errors.

I've created the new error classes inside `hanami/model.rb`, but I'd rather place them (and move all of them) inside `hanami/model/error.rb` just like `Hanami::Model::Error`. /cc @hanami/core-team 

Related #281 
Closes #284