### PR TITLE
Mapping SQL Command errors to its specific model's error class

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Think of an adapter for Redis, it will probably employ different strategies to f
 
 ### Model Error Coercions
 
-We encapsulate all adapter's errors into Hanami specialized error classes.
+All adapters' errors are encapsulated into Hanami error classes.
 
 Hanami Model may raise the following exceptions:
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,20 @@ If you need more information regarding those methods, you can use comments from 
 
 Think of an adapter for Redis, it will probably employ different strategies to filter records than an SQL query object.
 
+### Model Error Coercions
+
+We encapsulate all adapter's errors into Hanami specialized error classes.
+
+Hanami Model may raise the following exceptions:
+
+  * `Hanami::Model::UniqueConstraintViolationError`
+  * `Hanami::Model::ForeignKeyConstraintViolationError`
+  * `Hanami::Model::NotNullConstraintViolationError`
+  * `Hanami::Model::CheckConstraintViolationError`
+
+For any other adapter's errors, Hanami will raise the `Hanami::Model::InvalidCommandError` object.
+All errors contains the root cause and the full error message thrown by sql adapter.
+
 ### Conventions
 
   * A repository must be named after an entity, by appending `"Repository"` to the entity class name (eg. `Article` => `ArticleRepository`).

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -11,78 +11,6 @@ module Hanami
   #
   # @since 0.1.0
   module Model
-    # Error for non persisted entity
-    # It's raised when we try to update or delete a non persisted entity.
-    #
-    # @since 0.1.0
-    #
-    # @see Hanami::Repository.update
-    class NonPersistedEntityError < Hanami::Model::Error
-    end
-
-    # Error for invalid mapper configuration
-    # It's raised when mapping is not configured correctly
-    #
-    # @since 0.2.0
-    #
-    # @see Hanami::Configuration#mapping
-    class InvalidMappingError < Hanami::Model::Error
-    end
-
-    # Error for invalid raw command syntax
-    #
-    # @since 0.5.0
-    class InvalidCommandError < Hanami::Model::Error
-      def initialize(message = "Invalid command")
-        super
-      end
-    end
-
-    # Error for invalid raw query syntax
-    #
-    # @since 0.3.1
-    class InvalidQueryError < Hanami::Model::Error
-      def initialize(message = "Invalid query")
-        super
-      end
-    end
-
-    # Error for Unique Constraint Violation
-    #
-    # @since x.x.x
-    class UniqueConstraintViolationError < Hanami::Model::Error
-      def initialize(message = "Unique constraint has been violated")
-        super
-      end
-    end
-
-    # Error for Foreign Key Constraint Violation
-    #
-    # @since x.x.x
-    class ForeignKeyConstraintViolationError < Hanami::Model::Error
-      def initialize(message = "Foreign key constraint has been violated")
-        super
-      end
-    end
-
-    # Error for Not Null Constraint Violation
-    #
-    # @since x.x.x
-    class NotNullConstraintViolationError < Hanami::Model::Error
-      def initialize(message = "NOT NULL constraint has been violated")
-        super
-      end
-    end
-
-    # Error for Check Constraint Violation raised by Sequel
-    #
-    # @since x.x.x
-    class CheckConstraintViolationError < Hanami::Model::Error
-      def initialize(message = "Check constraint has been violated")
-        super
-      end
-    end
-
     include Utils::ClassAttribute
 
     # Framework configuration
@@ -240,6 +168,5 @@ module Hanami
         duplicated.configure(&blk) if block_given?
       end
     end
-
   end
 end

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -1,7 +1,79 @@
 module Hanami
   module Model
+
+    # Default Error class
+    #
     # @since 0.5.1
-    class Error < ::StandardError
+    Error = Class.new(::StandardError)
+
+    # Error for non persisted entity
+    # It's raised when we try to update or delete a non persisted entity.
+    #
+    # @since 0.1.0
+    #
+    # @see Hanami::Repository.update
+    NonPersistedEntityError = Class.new(Error)
+
+    # Error for invalid mapper configuration
+    # It's raised when mapping is not configured correctly
+    #
+    # @since 0.2.0
+    #
+    # @see Hanami::Configuration#mapping
+    InvalidMappingError = Class.new(Error)
+
+    # Error for invalid raw command syntax
+    #
+    # @since 0.5.0
+    class InvalidCommandError < Error
+      def initialize(message = "Invalid command")
+        super
+      end
+    end
+
+    # Error for invalid raw query syntax
+    #
+    # @since 0.3.1
+    class InvalidQueryError < Error
+      def initialize(message = "Invalid query")
+        super
+      end
+    end
+
+    # Error for Unique Constraint Violation
+    #
+    # @since x.x.x
+    class UniqueConstraintViolationError < Error
+      def initialize(message = "Unique constraint has been violated")
+        super
+      end
+    end
+
+    # Error for Foreign Key Constraint Violation
+    #
+    # @since x.x.x
+    class ForeignKeyConstraintViolationError < Error
+      def initialize(message = "Foreign key constraint has been violated")
+        super
+      end
+    end
+
+    # Error for Not Null Constraint Violation
+    #
+    # @since x.x.x
+    class NotNullConstraintViolationError < Error
+      def initialize(message = "NOT NULL constraint has been violated")
+        super
+      end
+    end
+
+    # Error for Check Constraint Violation raised by Sequel
+    #
+    # @since x.x.x
+    class CheckConstraintViolationError < Error
+      def initialize(message = "Check constraint has been violated")
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
There are some minor improvements to do around this issue. They are:

 - [x] Change switch-case over class constant/fetch
 - [x] Move all error classes into `model/error.rb`
 - [x] Ensure the message detail level in each one of `Hanami::Model::Error` type
 - [x] Update README.md to reflect these changes.

Improve and close both #289 and #284