### PR TITLE
Moving class level methods to instance methods for Repositories

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -160,7 +160,7 @@ We instantiate and persist an `Author` and a few `Articles` for our example:
 
 ```ruby
 author = Author.new(name: 'Luca')
-author = AuthorRepository.create(author)
+author = AuthorRepository.new.create(author)
 
 articles = [
   Article.new(title: 'Announcing Hanami',              author_id: author.id, comments_count: 123, published: true),
@@ -170,7 +170,7 @@ articles = [
 ]
 
 articles.each do |article|
-  ArticleRepository.create(article)
+  ArticleRepository.new.create(article)
 end
 ```
 
@@ -179,8 +179,8 @@ end
 We use the repositories to query the database and return the entities we're looking for:
 
 ```ruby
-ArticleRepository.first # => return the first article
-ArticleRepository.last  # => return the last article
+ArticleRepository.new.first # => return the first article
+ArticleRepository.new.last  # => return the last article
 
 ArticleRepository.published # => return all the published articles
 ArticleRepository.drafts    # => return all the drafts
@@ -209,5 +209,5 @@ article.publish!
 
 article.published? # => true
 
-ArticleRepository.update(article)
+ArticleRepository.new.update(article)
 ```

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ end
 Hanami::Model.load!
 
 user = User.new(name: 'Luca', age: 32)
-user = UserRepository.create(user)
+user = UserRepository.new.create(user)
 
 puts user.id # => 1
 
-u = UserRepository.find(user.id)
+u = UserRepository.new.find(user.id)
 u == user # => true
 ```
 
@@ -407,7 +407,7 @@ end
 In the example above, there are a few problems:
 
 * `Article` could not be fetched because mapping could not map `price`.
-* Finding a persisted `RareArticle` record, for eg. `ArticleRepository.find(123)`,
+* Finding a persisted `RareArticle` record, for eg. `ArticleRepository.new.find(123)`,
 the result is an `Article` not `RareArticle`.
 
 ### Adapter
@@ -554,13 +554,13 @@ user = User.new(name: 'L')
 puts user.created_at # => nil
 puts user.updated_at # => nil
 
-user = UserRepository.create(user)
+user = UserRepository.new.create(user)
 puts user.created_at.to_s # => "2015-05-15T10:12:20+00:00"
 puts user.updated_at.to_s # => "2015-05-15T10:12:20+00:00"
 
 sleep 3
 user.name = "Luca"
-user      = UserRepository.update(user)
+user      = UserRepository.new.update(user)
 puts user.created_at.to_s # => "2015-05-15T10:12:20+00:00"
 puts user.updated_at.to_s # => "2015-05-15T10:12:23+00:00"
 ```
@@ -604,17 +604,17 @@ user.age = 33
 user.changed?           # => true
 user.changed_attributes # => {:age=>33}
 
-user = UserRepository.create(user)
+user = UserRepository.new.create(user)
 user.changed? # => false
 
 user.update(name: 'Luca')
 user.changed?           # => true
 user.changed_attributes # => {:name=>"Luca"}
 
-user = UserRepository.update(user)
+user = UserRepository.new.update(user)
 user.changed? # => false
 
-result = UserRepository.find(user.id)
+result = UserRepository.new.find(user.id)
 result.changed? # => false
 ```
 

--- a/lib/hanami/model/adapters/sql_adapter.rb
+++ b/lib/hanami/model/adapters/sql_adapter.rb
@@ -163,7 +163,7 @@ module Hanami
         #   article = Article.new(title: 'Introducing transactions',
         #     body: 'lorem ipsum')
         #
-        #   ArticleRepository.transaction do
+        #   ArticleRepository.new.transaction do
         #     ArticleRepository.dangerous_operation!(article) # => RuntimeError
         #     # !!! ROLLBACK !!!
         #   end
@@ -183,8 +183,8 @@ module Hanami
         #   article = Article.new(title: 'Introducing transactions',
         #     body: 'lorem ipsum')
         #
-        #   ArticleRepository.transaction(rollback: :always) do
-        #     ArticleRepository.create(article)
+        #   ArticleRepository.new.transaction(rollback: :always) do
+        #     ArticleRepository.new.create(article)
         #     # !!! ROLLBACK !!!
         #   end
         #
@@ -205,7 +205,7 @@ module Hanami
         #   article = Article.new(title: 'Introducing transactions',
         #     body: 'lorem ipsum')
         #
-        #   ArticleRepository.transaction(rollback: :reraise) do
+        #   ArticleRepository.new.transaction(rollback: :reraise) do
         #     ArticleRepository.dangerous_operation!(article) # => RuntimeError
         #     # !!! ROLLBACK !!!
         #   end # => RuntimeError

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -24,6 +24,9 @@ class UserRepository
   include Hanami::Repository
 end
 
+class SubclassedUserRepository < UserRepository
+end
+
 class UnmappedRepository
   include Hanami::Repository
 end
@@ -31,35 +34,35 @@ end
 class ArticleRepository
   include Hanami::Repository
 
-  def self.rank
+  def rank
     query do
       desc(:comments_count)
     end
   end
 
-  def self.by_user(user)
+  def by_user(user)
     query do
       where(user_id: user.id)
     end
   end
 
-  def self.not_by_user(user)
+  def not_by_user(user)
     exclude by_user(user)
   end
 
-  def self.rank_by_user(user)
+  def rank_by_user(user)
     rank.by_user(user)
   end
 
-  def self.reset_comments_count
+  def reset_comments_count
     execute("UPDATE articles SET comments_count = '0'")
   end
 
-  def self.find_raw
+  def find_raw
     fetch("SELECT * FROM articles")
   end
 
-  def self.each_titles
+  def each_titles
     result = []
 
     fetch("SELECT s_title FROM articles") do |article|
@@ -69,7 +72,7 @@ class ArticleRepository
     result
   end
 
-  def self.map_titles
+  def map_titles
     fetch("SELECT s_title FROM articles").map do |article|
       article[:s_title]
     end

--- a/test/integration/configuration_test.rb
+++ b/test/integration/configuration_test.rb
@@ -29,11 +29,11 @@ describe 'Configuration DSL' do
     end
 
     it 'add the entity to repositories' do
-      @user_counter = UserRepository.all.size
+      @user_counter = UserRepository.new.all.size
 
-      @user = UserRepository.create(@user)
+      @user = UserRepository.new.create(@user)
 
-      users = UserRepository.all
+      users = UserRepository.new.all
       users.size.must_equal(@user_counter + 1)
       users.first.must_equal(@user)
     end
@@ -41,7 +41,7 @@ describe 'Configuration DSL' do
 
   describe "when a repository isn't mapped" do
     it 'raises an error when try to use it' do
-      exception = -> { UnmappedRepository.find(1) }.must_raise(Hanami::Model::Adapters::NoAdapterError)
+      exception = -> { UnmappedRepository.new.find(1) }.must_raise(Hanami::Model::Adapters::NoAdapterError)
       exception.message.must_equal(
         "Cannot invoke `find' on repository. "\
         "Please check if `adapter' and `mapping' are set, "\

--- a/test/integration/repository_test.rb
+++ b/test/integration/repository_test.rb
@@ -23,8 +23,8 @@ describe Hanami::Repository do
         UserRepository.collection    = :users
         ArticleRepository.collection = :articles
 
-        UserRepository.clear
-        ArticleRepository.clear
+        UserRepository.new.clear
+        ArticleRepository.new.clear
       end
 
       after(:each) do
@@ -37,14 +37,36 @@ describe Hanami::Repository do
           UserRepository.collection.must_equal    :users
           ArticleRepository.collection.must_equal :articles
         end
+
+        it 'allows different collections by subclass' do
+          UserRepository.collection = :users
+          SubclassedUserRepository.collection = :special_users
+
+          UserRepository.collection.must_equal    :users
+          SubclassedUserRepository.collection.must_equal    :special_users
+        end
       end
+
+      describe '#adapter' do
+        it 'returns the adapter configured on class level' do
+          UserRepository.new.adapter.must_equal UserRepository.adapter
+        end
+      end
+
+      describe '#collection' do
+        it 'returns the collection name configured on the class level' do
+          UserRepository.new.collection.must_equal    :users
+          ArticleRepository.new.collection.must_equal :articles
+        end
+      end
+
 
       describe '.persist' do
         describe 'when passed a non-persisted entity' do
           let(:unpersisted_user) { User.new(name: 'Don', age: '25') }
 
           it 'should return that entity' do
-            persisted_user = UserRepository.persist(unpersisted_user)
+            persisted_user = UserRepository.new.persist(unpersisted_user)
 
             persisted_user.id.wont_be_nil
             persisted_user.name.must_equal(unpersisted_user.name)
@@ -52,24 +74,24 @@ describe Hanami::Repository do
           end
 
           it 'returns a copy of the entity passed as argument' do
-            persisted_user = UserRepository.persist(unpersisted_user)
+            persisted_user = UserRepository.new.persist(unpersisted_user)
             refute_same persisted_user, unpersisted_user
           end
 
           it 'does not assign an id on the entity passed as argument' do
-            UserRepository.persist(unpersisted_user)
+            UserRepository.new.persist(unpersisted_user)
             unpersisted_user.id.must_be_nil
           end
 
           it 'should coerce attributes' do
-            persisted_user = UserRepository.persist(unpersisted_user)
+            persisted_user = UserRepository.new.persist(unpersisted_user)
             persisted_user.age.must_equal(25)
           end
 
           if adapter_name == :postgres
             it 'should use custom coercers' do
               article = Article.new(title: 'Coercer', tags: tags = ['ruby', 'hanami'])
-              article = ArticleRepository.persist(article)
+              article = ArticleRepository.new.persist(article)
 
               article.tags.must_equal tags
               article.tags.class.must_equal ::Array
@@ -77,19 +99,19 @@ describe Hanami::Repository do
           end
 
           it 'assigns and persist created_at attribute' do
-            persisted_user = UserRepository.persist(unpersisted_user)
+            persisted_user = UserRepository.new.persist(unpersisted_user)
             persisted_user.created_at.wont_be_nil
           end
 
           it 'assigns and persist updated_at attribute' do
-            persisted_user = UserRepository.persist(unpersisted_user)
+            persisted_user = UserRepository.new.persist(unpersisted_user)
             persisted_user.updated_at.must_equal persisted_user.created_at
           end
         end
 
         describe 'when passed a persisted entity' do
-          let(:user)           { UserRepository.create(User.new(name: 'Don')) }
-          let(:persisted_user) { UserRepository.persist(user) }
+          let(:user)           { UserRepository.new.create(User.new(name: 'Don')) }
+          let(:persisted_user) { UserRepository.new.persist(user) }
 
           before do
             @updated_at = user.updated_at
@@ -100,17 +122,17 @@ describe Hanami::Repository do
           end
 
           it 'should return that entity' do
-            UserRepository.persist(persisted_user).must_equal(user)
+            UserRepository.new.persist(persisted_user).must_equal(user)
           end
 
           it 'does not touch created_at' do
-            UserRepository.persist(persisted_user)
+            UserRepository.new.persist(persisted_user)
 
             persisted_user.created_at.wont_be_nil
           end
 
           it 'touches updated_at' do
-            updated_user = UserRepository.persist(user)
+            updated_user = UserRepository.new.persist(user)
 
             assert updated_user.updated_at > @updated_at
           end
@@ -120,30 +142,30 @@ describe Hanami::Repository do
       describe '.create' do
         before do
           @users = [
-            UserRepository.create(user1),
-            UserRepository.create(user2)
+            UserRepository.new.create(user1),
+            UserRepository.new.create(user2)
           ]
         end
 
         it 'persist entities' do
-          UserRepository.all.must_equal(@users)
+          UserRepository.new.all.must_equal(@users)
         end
 
         it 'creates different kind of entities' do
-          result = ArticleRepository.create(article1)
-          ArticleRepository.all.must_equal([result])
+          result = ArticleRepository.new.create(article1)
+          ArticleRepository.new.all.must_equal([result])
         end
 
         it 'does nothing when already persisted' do
           id = user1.id
 
-          UserRepository.create(user1)
+          UserRepository.new.create(user1)
           user1.id.must_equal id
         end
 
         it 'returns nil when trying to create an already persisted entity' do
-          created_user = UserRepository.create(User.new(name: 'Pascal'))
-          value = UserRepository.create(created_user)
+          created_user = UserRepository.new.create(User.new(name: 'Pascal'))
+          value = UserRepository.new.create(created_user)
           value.must_be_nil
         end
 
@@ -151,27 +173,27 @@ describe Hanami::Repository do
           let(:unpersisted_user) { User.new(name: 'My', age: '23') }
 
           it 'assigns and persists created_at attribute' do
-            result = UserRepository.create(unpersisted_user)
+            result = UserRepository.new.create(unpersisted_user)
             result.created_at.wont_be_nil
           end
 
           it 'assigns and persists updated_at attribute' do
-            result = UserRepository.create(unpersisted_user)
+            result = UserRepository.new.create(unpersisted_user)
             result.updated_at.must_equal result.created_at
           end
         end
 
         describe 'when entity is already persisted' do
           before do
-            @persisted_user = UserRepository.create(User.new(name: 'My', age: '23'))
+            @persisted_user = UserRepository.new.create(User.new(name: 'My', age: '23'))
           end
 
           after do
-            UserRepository.delete(@persisted_user)
+            UserRepository.new.delete(@persisted_user)
           end
 
           it 'does not touch created_at' do
-            UserRepository.create(@persisted_user)
+            UserRepository.new.create(@persisted_user)
             @persisted_user.created_at.wont_be_nil
           end
         end
@@ -179,7 +201,7 @@ describe Hanami::Repository do
 
       describe '.update' do
         before do
-          @user1 = UserRepository.create(user1)
+          @user1 = UserRepository.new.create(user1)
           @updated_at = @user1.updated_at
 
           # Ensure we're updating sufficiently later of the creation, we can get realy close dates in
@@ -191,56 +213,56 @@ describe Hanami::Repository do
           user = User.new(name: 'Luca')
           user.id = @user1.id
 
-          updated_user = UserRepository.update(user)
+          updated_user = UserRepository.new.update(user)
 
           updated_user.name.must_equal('Luca')
         end
 
         it 'touches updated_at' do
-          updated_user = UserRepository.update(@user1)
+          updated_user = UserRepository.new.update(@user1)
 
           assert updated_user.updated_at > @updated_at
         end
 
         it 'raises an error when not persisted' do
-          -> { UserRepository.update(user2) }.must_raise(Hanami::Model::NonPersistedEntityError)
+          -> { UserRepository.new.update(user2) }.must_raise(Hanami::Model::NonPersistedEntityError)
         end
       end
 
       describe '.delete' do
         before do
-          @user = UserRepository.create(user)
-          UserRepository.delete(@user)
+          @user = UserRepository.new.create(user)
+          UserRepository.new.delete(@user)
         end
 
         let(:user) { User.new(name: 'D') }
 
         it 'delete entity' do
-          UserRepository.all.wont_include(@user)
+          UserRepository.new.all.wont_include(@user)
         end
 
         it 'raises error when the given entity is not persisted' do
-          -> { UserRepository.delete(user2) }.must_raise(Hanami::Model::NonPersistedEntityError)
+          -> { UserRepository.new.delete(user2) }.must_raise(Hanami::Model::NonPersistedEntityError)
         end
       end
 
       describe '.all' do
         describe 'without data' do
           it 'returns an empty collection' do
-            UserRepository.all.must_be_empty
+            UserRepository.new.all.must_be_empty
           end
         end
 
         describe 'with data' do
           before do
             @users = [
-              UserRepository.create(user1),
-              UserRepository.create(user2)
+              UserRepository.new.create(user1),
+              UserRepository.new.create(user2)
             ]
           end
 
           it 'returns all the entities' do
-            UserRepository.all.must_equal(@users)
+            UserRepository.new.all.must_equal(@users)
           end
         end
       end
@@ -248,7 +270,7 @@ describe Hanami::Repository do
       describe '.find' do
         describe 'without data' do
           it 'returns nil' do
-            UserRepository.find(1).must_be_nil
+            UserRepository.new.find(1).must_be_nil
           end
         end
 
@@ -260,10 +282,10 @@ describe Hanami::Repository do
               end
             end
 
-            @user1 = UserRepository.create(user1)
-            @user2 = UserRepository.create(user2)
+            @user1 = UserRepository.new.create(user1)
+            @user2 = UserRepository.new.create(user2)
 
-            @article1 = ArticleRepository.create(article1)
+            @article1 = ArticleRepository.new.create(article1)
           end
 
           after do
@@ -271,29 +293,29 @@ describe Hanami::Repository do
           end
 
           it 'returns the entity associated with the given id' do
-            UserRepository.find(@user1.id).must_equal(@user1)
+            UserRepository.new.find(@user1.id).must_equal(@user1)
           end
 
           it 'accepts a string as argument' do
-            UserRepository.find(@user2.id.to_s).must_equal(@user2)
+            UserRepository.new.find(@user2.id.to_s).must_equal(@user2)
           end
 
           it 'accepts an object that can be coerced to integer' do
             id = TestPrimaryKey.new(@user2.id)
-            UserRepository.find(id).must_equal(@user2)
+            UserRepository.new.find(id).must_equal(@user2)
           end
 
           it 'coerces attributes as indicated by the mapper' do
-            result = ArticleRepository.find(@article1.id)
+            result = ArticleRepository.new.find(@article1.id)
             result.comments_count.must_be_kind_of(Integer)
           end
 
           it "doesn't assign a value to unmapped attributes" do
-            ArticleRepository.find(@article1.id).unmapped_attribute.must_be_nil
+            ArticleRepository.new.find(@article1.id).unmapped_attribute.must_be_nil
           end
 
           it "returns nil when the given id isn't associated with any entity" do
-            UserRepository.find(1_000_000).must_be_nil
+            UserRepository.new.find(1_000_000).must_be_nil
           end
         end
       end
@@ -301,18 +323,18 @@ describe Hanami::Repository do
       describe '.first' do
         describe 'without data' do
           it 'returns nil' do
-            UserRepository.first.must_be_nil
+            UserRepository.new.first.must_be_nil
           end
         end
 
         describe 'with data' do
           before do
-            @user1 = UserRepository.create(user1)
-            UserRepository.create(user2)
+            @user1 = UserRepository.new.create(user1)
+            UserRepository.new.create(user2)
           end
 
           it 'returns first record' do
-            UserRepository.first.must_equal(@user1)
+            UserRepository.new.first.must_equal(@user1)
           end
         end
       end
@@ -320,18 +342,18 @@ describe Hanami::Repository do
       describe '.last' do
         describe 'without data' do
           it 'returns nil' do
-            UserRepository.last.must_be_nil
+            UserRepository.new.last.must_be_nil
           end
         end
 
         describe 'with data' do
           before do
-            UserRepository.create(user1)
-            @user2 = UserRepository.create(user2)
+            UserRepository.new.create(user1)
+            @user2 = UserRepository.new.create(user2)
           end
 
           it 'returns last record' do
-            UserRepository.last.must_equal(@user2)
+            UserRepository.new.last.must_equal(@user2)
           end
         end
       end
@@ -339,47 +361,47 @@ describe Hanami::Repository do
       describe '.clear' do
         describe 'without data' do
           it 'removes all the records' do
-            UserRepository.clear
-            UserRepository.all.must_be_empty
+            UserRepository.new.clear
+            UserRepository.new.all.must_be_empty
           end
         end
 
         describe 'with data' do
           before do
-            UserRepository.create(user1)
-            UserRepository.create(user2)
+            UserRepository.new.create(user1)
+            UserRepository.new.create(user2)
           end
 
           it 'removes all the records' do
-            UserRepository.clear
-            UserRepository.all.must_be_empty
+            UserRepository.new.clear
+            UserRepository.new.all.must_be_empty
           end
         end
       end
 
       describe 'querying' do
         before do
-          @user1    = UserRepository.create(user1)
+          @user1    = UserRepository.new.create(user1)
           article1.user_id = article2.user_id = @user1.id
 
-          @article1 = ArticleRepository.create(article1)
-          @article2 = ArticleRepository.create(article2)
-          ArticleRepository.create(article3)
+          @article1 = ArticleRepository.new.create(article1)
+          @article2 = ArticleRepository.new.create(article2)
+          ArticleRepository.new.create(article3)
         end
 
         it 'defines custom finders' do
-          actual = ArticleRepository.by_user(@user1)
+          actual = ArticleRepository.new.by_user(@user1)
           actual.all.must_equal [@article1, @article2]
         end
 
         if adapter_name == :sql
           it 'combines queries' do
-            actual = ArticleRepository.rank_by_user(@user1)
+            actual = ArticleRepository.new.rank_by_user(@user1)
             actual.all.must_equal [@article2, @article1]
           end
 
           it 'negates a query' do
-            actual = ArticleRepository.not_by_user(@user1)
+            actual = ArticleRepository.new.not_by_user(@user1)
             actual.all.must_equal []
           end
         end
@@ -387,7 +409,7 @@ describe Hanami::Repository do
 
       describe 'dirty tracking' do
         before do
-          @article = ArticleRepository.create(article1)
+          @article = ArticleRepository.new.create(article1)
         end
 
         it "hasn't dirty state after creation" do
@@ -395,13 +417,13 @@ describe Hanami::Repository do
         end
 
         it "hasn't dirty state after finding" do
-          found = ArticleRepository.find(@article.id)
+          found = ArticleRepository.new.find(@article.id)
           found.changed?.must_equal false
         end
 
         it "hasn't dirty state after update" do
           @article.title = 'Dirty tracking'
-          @article = ArticleRepository.update(@article)
+          @article = ArticleRepository.new.update(@article)
 
           @article.changed?.must_equal false
         end
@@ -410,7 +432,7 @@ describe Hanami::Repository do
       describe 'missing timestamps attribute' do
         describe '.persist' do
           before do
-            @article = ArticleRepository.persist(Article.new(title: 'Hanami', comments_count: '4'))
+            @article = ArticleRepository.new.persist(Article.new(title: 'Hanami', comments_count: '4'))
             @article.instance_eval do
               def created_at
                 @created_at
@@ -423,7 +445,7 @@ describe Hanami::Repository do
           end
 
           after do
-            ArticleRepository.delete(@article)
+            ArticleRepository.new.delete(@article)
           end
 
           describe 'when entity does not have created_at accessor' do
@@ -450,10 +472,10 @@ describe Hanami::Repository do
       UserRepository.collection    = :users
       ArticleRepository.collection = :articles
 
-      UserRepository.clear
-      ArticleRepository.clear
+      UserRepository.new.clear
+      ArticleRepository.new.clear
 
-      ArticleRepository.create(article1)
+      ArticleRepository.new.create(article1)
     end
 
     after do
@@ -462,47 +484,47 @@ describe Hanami::Repository do
 
     describe '.transaction' do
       it 'if an exception is raised the size of articles is equal to 1' do
-        ArticleRepository.all.size.must_equal 1
-        exception = -> { ArticleRepository.transaction do
-          ArticleRepository.create(article2)
+        ArticleRepository.new.all.size.must_equal 1
+        exception = -> { ArticleRepository.new.transaction do
+          ArticleRepository.new.create(article2)
           raise Exception
         end }
         exception.must_raise Exception
-        ArticleRepository.all.size.must_equal 1
+        ArticleRepository.new.all.size.must_equal 1
       end
 
       it "if an exception isn't raised the size of articles is equal to 2" do
-        ArticleRepository.all.size.must_equal 1
-        ArticleRepository.transaction do
-          ArticleRepository.create(article2)
+        ArticleRepository.new.all.size.must_equal 1
+        ArticleRepository.new.transaction do
+          ArticleRepository.new.create(article2)
         end
-        ArticleRepository.all.size.must_equal 2
+        ArticleRepository.new.all.size.must_equal 2
       end
 
       describe 'using options' do
         it 'rollback: :always option' do
-          ArticleRepository.all.size.must_equal 1
-          ArticleRepository.transaction(rollback: :always) do
-            ArticleRepository.create(article2)
+          ArticleRepository.new.all.size.must_equal 1
+          ArticleRepository.new.transaction(rollback: :always) do
+            ArticleRepository.new.create(article2)
           end
-          ArticleRepository.all.size.must_equal 1
+          ArticleRepository.new.all.size.must_equal 1
         end
 
         it 'rollback: :reraise option' do
-          ArticleRepository.all.size.must_equal 1
-          -> { ArticleRepository.transaction(rollback: :reraise) do
-            ArticleRepository.create(article2)
+          ArticleRepository.new.all.size.must_equal 1
+          -> { ArticleRepository.new.transaction(rollback: :reraise) do
+            ArticleRepository.new.create(article2)
             raise Exception
           end }.must_raise Exception
-          ArticleRepository.all.size.must_equal 1
+          ArticleRepository.new.all.size.must_equal 1
         end
       end
     end
 
     describe '.execute' do
       before do
-        ArticleRepository.clear
-        @article = ArticleRepository.create(Article.new(title: 'WAT', comments_count: 100))
+        ArticleRepository.new.clear
+        @article = ArticleRepository.new.create(Article.new(title: 'WAT', comments_count: 100))
       end
 
       it 'is a private method' do
@@ -510,17 +532,17 @@ describe Hanami::Repository do
       end
 
       it 'executes the command and returns nil' do
-        result = ArticleRepository.reset_comments_count
+        result = ArticleRepository.new.reset_comments_count
         result.must_be_nil
 
-        ArticleRepository.find(@article.id).comments_count.must_equal 0
+        ArticleRepository.new.find(@article.id).comments_count.must_equal 0
       end
     end
 
     describe '.fetch' do
       before do
-        ArticleRepository.clear
-        @article = ArticleRepository.create(Article.new(title: 'Art 1'))
+        ArticleRepository.new.clear
+        @article = ArticleRepository.new.create(Article.new(title: 'Art 1'))
       end
 
       it 'is a private method' do
@@ -528,7 +550,7 @@ describe Hanami::Repository do
       end
 
       it 'returns the raw ResultSet for the given SQL' do
-        result = ArticleRepository.find_raw
+        result = ArticleRepository.new.find_raw
 
         result.must_be_kind_of(::Array)
         result.size.must_equal(1)
@@ -542,12 +564,12 @@ describe Hanami::Repository do
       end
 
       it 'yields a block' do
-        result = ArticleRepository.each_titles
+        result = ArticleRepository.new.each_titles
         result.must_equal ['Art 1']
       end
 
       it 'returns an enumerable' do
-        result = ArticleRepository.map_titles
+        result = ArticleRepository.new.map_titles
         result.must_equal ['Art 1']
       end
     end
@@ -561,13 +583,13 @@ describe Hanami::Repository do
       UserRepository.collection    = :users
       ArticleRepository.collection = :articles
 
-      UserRepository.clear
-      ArticleRepository.clear
+      UserRepository.new.clear
+      ArticleRepository.new.clear
     end
 
     describe '.transaction' do
       it "an exception is raised because of memory adapter doesn't support transactions" do
-        -> { ArticleRepository.transaction do
+        -> { ArticleRepository.new.transaction do
           raise "boom"
         end }.must_raise RuntimeError
       end
@@ -579,7 +601,7 @@ describe Hanami::Repository do
       end
 
       it "raises an exception because memory adapter doesn't support execute" do
-        -> { ArticleRepository.reset_comments_count }.must_raise NotImplementedError
+        -> { ArticleRepository.new.reset_comments_count }.must_raise NotImplementedError
       end
     end
 
@@ -589,7 +611,7 @@ describe Hanami::Repository do
       end
 
       it "raises an exception because memory adapter doesn't support fetch" do
-        -> { ArticleRepository.find_raw }.must_raise NotImplementedError
+        -> { ArticleRepository.new.find_raw }.must_raise NotImplementedError
       end
     end
   end

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -1298,7 +1298,7 @@ describe Hanami::Model::Adapters::SqlAdapter do
         raw = "SELECT * FROM users"
 
         result = @adapter.fetch(raw)
-        result.count.must_equal UserRepository.all.count
+        result.count.must_equal UserRepository.new.all.count
 
         user = result.first
         user[:id].must_equal         @user1.id
@@ -1323,7 +1323,7 @@ describe Hanami::Model::Adapters::SqlAdapter do
           records << result_set
         end
 
-        records.count.must_equal UserRepository.all.count
+        records.count.must_equal UserRepository.new.all.count
       end
 
       it 'raises an exception when an invalid sql is provided' do

--- a/test/model/adapters/sql_joins_test.rb
+++ b/test/model/adapters/sql_joins_test.rb
@@ -253,8 +253,8 @@ describe 'SQL joins test' do
             end
 
             it 'returns records' do
-              user_first = TestUserRepository.first
-              user_last = TestUserRepository.last
+              user_first = TestUserRepository.new.first
+              user_last = TestUserRepository.new.last
 
               query_join = Proc.new {
                 join(:ages, key: :value, foreign_key: :age)
@@ -304,7 +304,7 @@ describe 'SQL joins test' do
             end
 
             it 'returns records' do
-              created_user = TestUserRepository.first
+              created_user = TestUserRepository.new.first
 
               query_join = Proc.new {
                 left_join(:users)


### PR DESCRIPTION
See https://github.com/hanami/model/issues/290

* Keep class level accessors for _adapter_ and _collection_
* Add instance level accessors for _adapter_ and _collection_ that use
  class level accessors
* Move class to instance level methods
* Change all tests and sample code to reflect changes