### PR TITLE
Fixed: Repository#find for wrong types will not raise error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: ruby
 sudo: false
 cache: bundler
-install: true
-script:
-  - 'if [[ "$TRAVIS_RUBY_VERSION" =~ "jruby" ]]; then rvm get head && rvm reload && rvm use --install $TRAVIS_RUBY_VERSION; fi'
-  - 'bundle install'
-  - 'bundle exec rake test:coverage'
+script: 'bundle exec rake test:coverage --trace'
 rvm:
   - 2.2.4
   - 2.3.0
+  - jruby-9.0.5.0
   - ruby-head
-  - jruby-9000
   - jruby-head
 
 addons:

--- a/lib/hanami/model/adapters/implementation.rb
+++ b/lib/hanami/model/adapters/implementation.rb
@@ -50,6 +50,8 @@ module Hanami
           _first(
             _find(collection, id)
           )
+        rescue TypeError, Hanami::Model::InvalidQueryError
+          nil
         end
 
         # Returns the first record in the given collection.

--- a/lib/hanami/model/adapters/implementation.rb
+++ b/lib/hanami/model/adapters/implementation.rb
@@ -93,7 +93,7 @@ module Hanami
         end
 
         def _type_mismatch_error?(error)
-          error.message.match(/InvalidTextRepresentation|incorrect-type/)
+          error.message.match(/InvalidTextRepresentation|incorrect-type|syntax\ for\ uuid/)
         end
 
         def _find(collection, id)

--- a/lib/hanami/model/adapters/implementation.rb
+++ b/lib/hanami/model/adapters/implementation.rb
@@ -42,7 +42,7 @@ module Hanami
         # @param collection [Symbol] the target collection (it must be mapped).
         # @param id [Object] the identity of the object.
         #
-        # @return [Object] the entity
+        # @return [Object] the entity or nil if not found
         #
         # @api private
         # @since 0.1.0
@@ -50,7 +50,8 @@ module Hanami
           _first(
             _find(collection, id)
           )
-        rescue TypeError, Hanami::Model::InvalidQueryError
+        rescue TypeError, Hanami::Model::InvalidQueryError => error
+          raise error unless _type_mismatch_error?(error)
           nil
         end
 
@@ -89,6 +90,10 @@ module Hanami
 
         def _mapped_collection(name)
           @mapper.collection(name)
+        end
+
+        def _type_mismatch_error?(error)
+          error.message.match(/InvalidTextRepresentation|incorrect-type/)
         end
 
         def _find(collection, id)

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -111,7 +111,7 @@ end
     String  :comments_count # Not an error: we're testing String => Integer coercion
     String  :umapped_column
 
-    if conn_string.match(/\Apostgres/)
+    if conn_string.match(/postgres/)
       column :tags, 'text[]'
     else
       column :tags, String
@@ -140,7 +140,7 @@ end
     String :code
   end
 
-  if conn_string.match(/\Apostgres/)
+  if conn_string.match(/postgres/)
     DB.run('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
     DB.create_table :robots do
       column :id, :uuid, :default => Sequel.function(:uuid_generate_v1mc), primary_key: true

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -79,6 +79,15 @@ class ArticleRepository
   end
 end
 
+class Robot
+  include Hanami::Entity
+  attributes :name, :build_date
+end
+
+class RobotRepository
+  include Hanami::Repository
+end
+
 [SQLITE_CONNECTION_STRING, POSTGRES_CONNECTION_STRING].each do |conn_string|
   require 'hanami/utils/io'
 
@@ -130,6 +139,15 @@ end
     primary_key :country_id
     String :code
   end
+
+  if conn_string.match(/\Apostgres/)
+    DB.run('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    DB.create_table :robots do
+      column :id, :uuid, :default => Sequel.function(:uuid_generate_v1mc), primary_key: true
+      String :name
+      DateTime :build_date
+    end
+  end
 end
 
 class PGArray < Hanami::Model::Coercer
@@ -166,6 +184,13 @@ MAPPER = Hanami::Model::Mapper.new do
     identity :_id
   end
 
+  collection :robots do
+    entity Robot
+
+    attribute :id, String
+    attribute :name, String
+    attribute :build_date, DateTime
+  end
 end
 
 MAPPER.load!

--- a/test/integration/repository_test.rb
+++ b/test/integration/repository_test.rb
@@ -274,6 +274,40 @@ describe Hanami::Repository do
           end
         end
 
+        describe 'with wrong type' do
+          it 'returns nil' do
+            UserRepository.new.find('incorrect-type').must_be_nil
+          end
+        end
+
+        if adapter_name == :postgres
+          describe 'with id as uuid type' do
+            before do
+              RobotRepository.adapter = adapter.new(mapper, uri)
+              RobotRepository.collection = :robots
+              RobotRepository.new.clear
+
+              @robot = RobotRepository.new.create(Robot.new(name: 'R2D2', build_date: Time.new(1970, 1, 1)))
+            end
+
+            after(:each) do
+              RobotRepository.adapter.disconnect
+            end
+
+            it 'returns correctly' do
+              RobotRepository.new.find(@robot.id).must_equal @robot
+            end
+
+            it 'returns nil for invalid uuid' do
+              RobotRepository.new.find('6ca6bcaa-d36a-3be9-839c-21d6bce84e63').must_be_nil
+            end
+
+            it 'returns nil for invalid id type' do
+              RobotRepository.new.find(1234).must_be_nil
+            end
+          end
+        end
+
         describe 'with data' do
           before do
             TestPrimaryKey = Struct.new(:id) do


### PR DESCRIPTION
Before:
```ruby
BookRepository.new.find(1)   # => book
BookRepository.new.find('1') # => book

BookRepository.new.find(999) # => nil
BookRepository.new.find('999') # => nil

# For Integer PKs
BookRepository.new.find('invalid')
# => TypeError: can't convert "invalid" into Integer

# For UUID Primary Keys (SQL)
BookRepository.new.find(1123)
# => Hanami::Model::InvalidQueryError: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for uuid: "invalid"
# => LINE 1: SELECT * FROM "books" WHERE ("id" = '1123...
```

Now:

```ruby
BookRepository.new.find(1)   # => Book
BookRepository.new.find('1') # => Book

BookRepository.new.find(999) # => nil
BookRepository.new.find('999') # => nil

# For Integer PKs
BookRepository.new.find('invalid') # => nil

# For UUID Primary Keys (SQL)
BookRepository.new.find(1123) # => nil
```

Closes #287 