### PR TITLE
Fixed migration test

### DIFF
--- a/test/integration/migration_test.rb
+++ b/test/integration/migration_test.rb
@@ -4,6 +4,11 @@ require 'hanami/model/migrator'
 describe "Hanami::Model.migration" do
   let(:adapter_prefix) { 'jdbc:' if Hanami::Utils.jruby?  }
 
+  after(:each) do
+    Hanami::Model.unload!
+    @connection && @connection.disconnect
+  end
+
   describe "SQLite" do
     before do
       @database = Pathname.new("#{ __dir__ }/../../tmp/migration.sqlite3").expand_path
@@ -26,11 +31,6 @@ describe "Hanami::Model.migration" do
     after(:each) do
       File.delete(@database)
       File.delete(@schema)
-    end
-
-    after(:each) do
-      Hanami::Model.unload!
-      @connection.disconnect
     end
 
     describe "columns" do


### PR DESCRIPTION
We had a lot of messages like
```
Hanami::Model.migration::Memory::connection#test_0001_return error [test/integration/migration_test.rb:520]:
Expected "Current adapter (file_system) doesn't support SQL database operations." to include "Current adapter (memory) doesn't support SQL database operations.".
```
or
```
  1) Error:
Hanami::Model.migration::SQLite::columns#test_0003_defines null constraint:
Hanami::Model::MigrationError: Current adapter (memory) doesn't support SQL database operations.
    [PATH]/lib/hanami/model/migrator.rb:296:in `rescue in connection'
    [PATH]/hanami/model/migrator.rb:292:in `connection'
    [PATH]/hanami/model/migrator.rb:84:in `create'
    test/integration/migration_test.rb:19:in `block (3 levels) in <main>'

Error:
Hanami::Model.migration::SQLite::columns#test_0003_defines null constraint:
NoMethodError: undefined method `disconnect' for nil:NilClass
    test/integration/migration_test.rb:33:in `block (3 levels) in <main>'
```

So I added an after block in migration test to unload the hanami model