### PR TITLE
move Model.migration to model.rb

### DIFF
--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -168,5 +168,46 @@ module Hanami
         duplicated.configure(&blk) if block_given?
       end
     end
+
+    # Define a migration
+    #
+    # It must define an up/down strategy to write schema changes (up) and to
+    # rollback them (down).
+    #
+    # We can use <tt>up</tt> and <tt>down</tt> blocks for custom strategies, or
+    # only one <tt>change</tt> block that automatically implements "down" strategy.
+    #
+    # @param blk [Proc] a block that defines up/down or change database migration
+    #
+    # @since 0.4.0
+    #
+    # @example Use up/down blocks
+    #   Hanami::Model.migration do
+    #     up do
+    #       create_table :books do
+    #         primary_key :id
+    #         column :book, String
+    #       end
+    #     end
+    #
+    #     down do
+    #       drop_table :books
+    #     end
+    #   end
+    #
+    # @example Use change block
+    #   Hanami::Model.migration do
+    #     change do
+    #       create_table :books do
+    #         primary_key :id
+    #         column :book, String
+    #       end
+    #     end
+    #
+    #     # DOWN strategy is automatically generated
+    #   end
+    def self.migration(&blk)
+      Sequel.migration(&blk)
+    end
   end
 end

--- a/lib/hanami/model/migrator.rb
+++ b/lib/hanami/model/migrator.rb
@@ -11,47 +11,6 @@ module Hanami
     class MigrationError < Hanami::Model::Error
     end
 
-    # Define a migration
-    #
-    # It must define an up/down strategy to write schema changes (up) and to
-    # rollback them (down).
-    #
-    # We can use <tt>up</tt> and <tt>down</tt> blocks for custom strategies, or
-    # only one <tt>change</tt> block that automatically implements "down" strategy.
-    #
-    # @param blk [Proc] a block that defines up/down or change database migration
-    #
-    # @since 0.4.0
-    #
-    # @example Use up/down blocks
-    #   Hanami::Model.migration do
-    #     up do
-    #       create_table :books do
-    #         primary_key :id
-    #         column :book, String
-    #       end
-    #     end
-    #
-    #     down do
-    #       drop_table :books
-    #     end
-    #   end
-    #
-    # @example Use change block
-    #   Hanami::Model.migration do
-    #     change do
-    #       create_table :books do
-    #         primary_key :id
-    #         column :book, String
-    #       end
-    #     end
-    #
-    #     # DOWN strategy is automatically generated
-    #   end
-    def self.migration(&blk)
-      Sequel.migration(&blk)
-    end
-
     # Database schema migrator
     #
     # @since 0.4.0


### PR DESCRIPTION
Personal preference, but I think this would be easier to lookup the definition of `Hanami::Model::migration` if it was defined in `lib/hanami/model.rb` instead of re-opening `Hanami::Model` in `lib/hanami/model/migrator.rb`. I'm not sure how this would compare to the rest of the code however

Thoughts?

I'm currently having trouble reproducing the test environment and don't have time at the moment to debug anything, so I'm relying on Travis for testing