### PR TITLE
Improve error-handling for adapter

### DIFF
--- a/lib/hanami/model/config/adapter.rb
+++ b/lib/hanami/model/config/adapter.rb
@@ -7,8 +7,8 @@ module Hanami
       #
       # @since 0.2.0
       class AdapterNotFound < Hanami::Model::Error
-        def initialize(adapter_name)
-          super "Cannot find Hanami::Model adapter #{adapter_name}"
+        def initialize(adapter_name, message)
+          super "Cannot find Hanami::Model adapter '#{adapter_name}' (#{message})"
         end
       end
 
@@ -95,7 +95,7 @@ module Hanami
           begin
             require "hanami/model/adapters/#{type}_adapter"
           rescue LoadError => e
-            raise LoadError.new("Cannot find Hanami::Model adapter '#{type}' (#{e.message})")
+            raise AdapterNotFound.new(class_name, e.message)
           end
         end
 
@@ -103,13 +103,10 @@ module Hanami
           begin
             klass = Hanami::Utils::Class.load!(class_name, Hanami::Model::Adapters)
             klass.new(mapper, uri, options)
-          rescue NameError
-            raise AdapterNotFound.new(class_name)
           rescue => e
-            raise "Cannot instantiate adapter of #{klass} (#{e.message})"
+            raise Error, e
           end
         end
-
       end
     end
   end

--- a/test/model/config/adapter_test.rb
+++ b/test/model/config/adapter_test.rb
@@ -37,7 +37,7 @@ describe Hanami::Model::Config::Adapter do
       let(:config) { Hanami::Model::Config::Adapter.new(type: :redis, uri: 'redis://not_exist') }
 
       it 'raises an error' do
-        -> { config.build(mapper) }.must_raise(LoadError)
+        -> { config.build(mapper) }.must_raise(Hanami::Model::Error)
       end
     end
 
@@ -46,7 +46,7 @@ describe Hanami::Model::Config::Adapter do
 
       it 'raises an error' do
         config.stub(:load_adapter, nil) do
-          -> { config.build(mapper) }.must_raise(Hanami::Model::Config::AdapterNotFound)
+          -> { config.build(mapper) }.must_raise(Hanami::Model::Error)
         end
       end
     end


### PR DESCRIPTION
1. Reclassify Adapter errors as Hanami::Model::Error
2. Leverage the `AdapterNotFound` Error class, instead of using `LoadError`

https://github.com/hanami/hanami/issues/556 item 1