### PR TITLE
Raise MissingURIError for FileSystemAdapter is URI is nil or empty

### DIFF
--- a/lib/hanami/model/adapters/abstract.rb
+++ b/lib/hanami/model/adapters/abstract.rb
@@ -25,6 +25,15 @@ module Hanami
       class NotSupportedError < Hanami::Model::Error
       end
 
+      # It's raised when a URI is nil or empty
+      #
+      # @since x.x.x
+      class MissingURIError < Hanami::Model::Error
+        def initialize
+          super "URI for FileSystemAdapter is nil or empty"
+        end
+      end
+
       # It's raised when an operation is requested to an adapter after it was
       # disconnected.
       #
@@ -92,6 +101,8 @@ module Hanami
           @mapper = mapper
           @uri    = uri
           @options = options
+
+          assert_uri_present! if uri_mandatory?
         end
 
         # Creates or updates a record in the database for the given entity.
@@ -274,6 +285,19 @@ module Hanami
         # @since 0.5.0
         def disconnect
           raise NotImplementedError
+        end
+
+        private
+
+        def assert_uri_present!
+          raise MissingURIError if @uri.nil? || @uri.empty?
+        end
+
+        # Lets subclasses decide if they need a URI.
+        #
+        # @since x.x.x
+        def uri_mandatory?
+          true
         end
       end
     end

--- a/lib/hanami/model/adapters/file_system_adapter.rb
+++ b/lib/hanami/model/adapters/file_system_adapter.rb
@@ -282,6 +282,18 @@ module Hanami
         def _load(contents)
           Marshal.load(contents)
         end
+
+        private
+
+
+        # MemoryAddapter (which this Adapter inherits from) does not need a uri
+        # but this adapter does (to know where to put the files).
+        #
+        # @api private
+        # @since x.x.x
+        def uri_mandatory?
+          true
+        end
       end
     end
   end

--- a/lib/hanami/model/adapters/memory_adapter.rb
+++ b/lib/hanami/model/adapters/memory_adapter.rb
@@ -173,6 +173,14 @@ module Hanami
         def synchronize
           @mutex.synchronize { yield }
         end
+
+        # Most adapters need a URI, but this one doesn't
+        #
+        # @api private
+        # @since x.x.x
+        def uri_mandatory?
+          false
+        end
       end
     end
   end

--- a/test/model/adapters/abstract_test.rb
+++ b/test/model/adapters/abstract_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Hanami::Model::Adapters::Abstract do
-  let(:adapter)    { Hanami::Model::Adapters::Abstract.new(mapper) }
+  let(:adapter)    { Hanami::Model::Adapters::Abstract.new(mapper, 'test://uri') }
   let(:mapper)     { Object.new }
   let(:entity)     { Object.new }
   let(:query)      { Object.new }
@@ -82,6 +82,22 @@ describe Hanami::Model::Adapters::Abstract do
   describe '#connection_string' do
     it 'raises error' do
       -> { adapter.connection_string }.must_raise Hanami::Model::Adapters::NotSupportedError
+    end
+  end
+
+  describe 'empty path' do
+    it 'raises MissingURIError' do
+      -> {
+        Hanami::Model::Adapters::Abstract.new(@mapper, nil)
+      }.must_raise(Hanami::Model::Adapters::MissingURIError)
+    end
+  end
+
+  describe 'nil path' do
+    it 'raises MissingURIError' do
+      -> {
+        Hanami::Model::Adapters::Abstract.new(@mapper, nil)
+      }.must_raise(Hanami::Model::Adapters::MissingURIError)
     end
   end
 end

--- a/test/model/adapters/implementation_test.rb
+++ b/test/model/adapters/implementation_test.rb
@@ -7,7 +7,7 @@ describe Hanami::Model::Adapters::Implementation do
     end
 
     mapper   = Object.new
-    @adapter = TestAdapter.new(mapper)
+    @adapter = TestAdapter.new(mapper, "test://uri")
   end
 
   after do


### PR DESCRIPTION
Addresses #3 for https://github.com/hanami/hanami/issues/556.

That issue was closed but we still need a helpful error for when URI is nil or empty. For example, if someone accidentally deletes their `DATABASE_URL` environment variable, we should help them realize that.

The current error doesn't help you identify that at all, even after #307: `/Users/sean/dev/hanami-model/lib/hanami/model/config/adapter.rb:107:in `rescue in instantiate_adapter': undefined method `sub' for nil:NilClass (Hanami::Model::Error)`

And now the error is: `/Users/sean/dev/hanami-model/lib/hanami/model/config/adapter.rb:107:in 'rescue in instantiate_adapter': URI for FileSystemAdapter is nil or empty (Hanami::Model::Error)`, which is more helpful.

Happy to move this to `AbstractAdapter`, since it's relevant for all of the adapters (except MemoryAdapter), although the SQL adapters will have their own errors for missing URI's.