### PR TITLE
Add tests for Sql::Console

### DIFF
--- a/test/model/adapters/sql/console_test.rb
+++ b/test/model/adapters/sql/console_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+describe Hanami::Model::Adapters::Sql::Console do
+  describe 'deciding on which SQL console class to use, based on URI scheme' do
+    let(:uri) { 'username:password@localhost:1234/foo_development' }
+
+    it 'mysql:// uri returns an instance of Console::Mysql' do
+      console = Hanami::Model::Adapters::Sql::Console.new("mysql://#{uri}").send(:console)
+      console.must_be_kind_of(Hanami::Model::Adapters::Sql::Consoles::Mysql)
+    end
+
+    it 'mysql2:// uri returns an instance of Console::Mysql' do
+      console = Hanami::Model::Adapters::Sql::Console.new("mysql2://#{uri}").send(:console)
+      console.must_be_kind_of(Hanami::Model::Adapters::Sql::Consoles::Mysql)
+    end
+
+    it 'postgres:// uri returns an instance of Console::Postgresql' do
+      console = Hanami::Model::Adapters::Sql::Console.new("postgres://#{uri}").send(:console)
+      console.must_be_kind_of(Hanami::Model::Adapters::Sql::Consoles::Postgresql)
+    end
+
+    it 'sqlite:// uri returns an instance of Console::Sqlite' do
+      console = Hanami::Model::Adapters::Sql::Console.new("sqlite://#{uri}").send(:console)
+      console.must_be_kind_of(Hanami::Model::Adapters::Sql::Consoles::Sqlite)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds tests for `lib/hanami/model/adapters/sql/console.rb`

Generally private methods don't need to be tested (since they're implementation details), but in this case, `connection_string` is a public method that delegates to `console`, so these are tests for that `console` method.

This test is just to make sure URI's are mapped to a `Sql::Consoles` class correctly.

(I also tried DRYing up the code, but it wasn't any better, since there are specific cases we need to handle to maping URI schemes to classes that aren't just doing `classify` on the scheme, like `mysql2` goes to `Mysql` and `postgres` goes to `Postgresql`)