### PR TITLE
Require 'json' before checking if to_json is allowed

### DIFF
--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -62,6 +62,7 @@ describe Hanami::Entity do
     end
 
     it 'returns false for reserved word' do
+      require "json"
       Car.allowed_attribute_name?(:to_json).must_equal false
     end
   end


### PR DESCRIPTION
This test fails for me locally.

This test passes on Travis because it runs `bundle exec rake test:coverage` which sets `COVERAGE=true`. And `test_helper.rb` requires 'simplecov' and 'coveralls' when `COVERAGE` is true and they, in-turn, require 'json'.

This PR just requires 'json' right before checking to see if `to_json` is allowed.