### PR TITLE
Allow running specific adapter's tests, via ENV['ADAPTER']

### DIFF
--- a/test/integration/migration/mysql_test.rb
+++ b/test/integration/migration/mysql_test.rb
@@ -1,322 +1,324 @@
 require 'test_helper'
 require 'hanami/model/migrator'
 
-describe 'Mysql database migrations' do
-  let(:adapter_prefix) { 'jdbc:' if Hanami::Utils.jruby?  }
+if TEST_MYSQL
+  describe 'Mysql database migrations' do
+    let(:adapter_prefix) { 'jdbc:' if Hanami::Utils.jruby?  }
 
-  let(:db_prefix)      { name.gsub(/[^\w]/, '_') }
-  let(:random_token)   { SecureRandom.hex(4) }
+    let(:db_prefix)      { name.gsub(/[^\w]/, '_') }
+    let(:random_token)   { SecureRandom.hex(4) }
 
-  before do
-    Hanami::Model.unload!
-  end
+    before do
+      Hanami::Model.unload!
+    end
 
-  after do
-    Hanami::Model::Migrator.drop rescue nil
-    Hanami::Model.unload!
-  end
+    after do
+      Hanami::Model::Migrator.drop rescue nil
+      Hanami::Model.unload!
+    end
 
-  ['mysql', 'mysql2'].each do |scheme|
-    describe "MySQL" do
-      let(:adapter) { Hanami::Utils.jruby? ? 'mysql' : scheme }
+    ['mysql', 'mysql2'].each do |scheme|
+      describe "MySQL" do
+        let(:adapter) { Hanami::Utils.jruby? ? 'mysql' : scheme }
 
-      before do
-        @database = "#{ db_prefix }_#{ random_token }"
-        @uri      = uri = "#{ adapter_prefix }#{ adapter }://localhost/#{ @database }?user=#{ MYSQL_USER }"
-
-        Hanami::Model.configure do
-          adapter type: :sql, uri: uri
-          migrations __dir__ + '/../../fixtures/migrations'
-        end
-      end
-
-      describe "create" do
         before do
-          Hanami::Model::Migrator.create
+          @database = "#{ db_prefix }_#{ random_token }"
+          @uri      = uri = "#{ adapter_prefix }#{ adapter }://localhost/#{ @database }?user=#{ MYSQL_USER }"
+
+          Hanami::Model.configure do
+            adapter type: :sql, uri: uri
+            migrations __dir__ + '/../../fixtures/migrations'
+          end
         end
 
-        it "creates the database" do
-          connection = Sequel.connect(@uri)
-          connection.tables.must_be :empty?
-        end
-
-        it 'raises error if database is busy' do
-          Sequel.connect(@uri).tables
-          exception = -> { Hanami::Model::Migrator.create }.must_raise Hanami::Model::MigrationError
-          exception.message.must_include 'Database creation failed'
-          exception.message.must_include 'There is 1 other session using the database'
-        end
-      end
-
-      describe "drop" do
-        before do
-          Hanami::Model::Migrator.create
-        end
-
-        it "drops the database" do
-          Hanami::Model::Migrator.drop
-
-          -> { Sequel.connect(@uri).tables }.must_raise Sequel::DatabaseConnectionError
-        end
-
-        it "raises error if database doesn't exist" do
-          Hanami::Model::Migrator.drop # remove the first time
-
-          exception = -> { Hanami::Model::Migrator.drop }.must_raise Hanami::Model::MigrationError
-          exception.message.must_equal "Cannot find database: #{ @database }"
-        end
-      end
-
-      describe "migrate" do
-        before do
-          Hanami::Model::Migrator.create
-        end
-
-        describe "when no migrations" do
+        describe "create" do
           before do
-            @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../fixtures/empty_migrations')
-
-            Hanami::Model.configure do
-              migrations migrations_root
-            end
+            Hanami::Model::Migrator.create
           end
 
-          it "it doesn't alter database" do
-            Hanami::Model::Migrator.migrate
-
+          it "creates the database" do
             connection = Sequel.connect(@uri)
             connection.tables.must_be :empty?
           end
+
+          it 'raises error if database is busy' do
+            Sequel.connect(@uri).tables
+            exception = -> { Hanami::Model::Migrator.create }.must_raise Hanami::Model::MigrationError
+            exception.message.must_include 'Database creation failed'
+            exception.message.must_include 'There is 1 other session using the database'
+          end
         end
 
-        describe "when migrations are present" do
-          it "migrates the database" do
-            Hanami::Model::Migrator.migrate
+        describe "drop" do
+          before do
+            Hanami::Model::Migrator.create
+          end
+
+          it "drops the database" do
+            Hanami::Model::Migrator.drop
+
+            -> { Sequel.connect(@uri).tables }.must_raise Sequel::DatabaseConnectionError
+          end
+
+          it "raises error if database doesn't exist" do
+            Hanami::Model::Migrator.drop # remove the first time
+
+            exception = -> { Hanami::Model::Migrator.drop }.must_raise Hanami::Model::MigrationError
+            exception.message.must_equal "Cannot find database: #{ @database }"
+          end
+        end
+
+        describe "migrate" do
+          before do
+            Hanami::Model::Migrator.create
+          end
+
+          describe "when no migrations" do
+            before do
+              @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../fixtures/empty_migrations')
+
+              Hanami::Model.configure do
+                migrations migrations_root
+              end
+            end
+
+            it "it doesn't alter database" do
+              Hanami::Model::Migrator.migrate
+
+              connection = Sequel.connect(@uri)
+              connection.tables.must_be :empty?
+            end
+          end
+
+          describe "when migrations are present" do
+            it "migrates the database" do
+              Hanami::Model::Migrator.migrate
+
+              connection = Sequel.connect(@uri)
+              connection.tables.wont_be :empty?
+
+              table = connection.schema(:books)
+
+              name, options = table[0] # id
+              name.must_equal :id
+
+              options.fetch(:allow_null).must_equal     false
+              options.fetch(:default).must_equal        nil
+              options.fetch(:type).must_equal           :integer
+              options.fetch(:db_type).must_equal        "int(11)"
+              options.fetch(:primary_key).must_equal    true
+              options.fetch(:auto_increment).must_equal true
+
+              name, options = table[1] # title
+              name.must_equal :title
+
+              options.fetch(:allow_null).must_equal     false
+              options.fetch(:default).must_equal        nil
+              options.fetch(:type).must_equal           :string
+              options.fetch(:db_type).must_equal        "varchar(255)"
+              options.fetch(:primary_key).must_equal    false
+
+              name, options = table[2] # price (second migration)
+              name.must_equal :price
+
+              options.fetch(:allow_null).must_equal     true
+              options.fetch(:default).must_equal        "100"
+              options.fetch(:type).must_equal           :integer
+              options.fetch(:db_type).must_equal        "int(11)"
+              options.fetch(:primary_key).must_equal    false
+            end
+          end
+
+          describe "when migrations are ran twice" do
+            before do
+              Hanami::Model::Migrator.migrate
+            end
+
+            it "doesn't alter the schema" do
+              Hanami::Model::Migrator.migrate
+
+              connection = Sequel.connect(@uri)
+              connection.tables.wont_be :empty?
+              connection.tables.must_equal [:books, :schema_migrations]
+            end
+          end
+
+          describe "migrate down" do
+            before do
+              Hanami::Model::Migrator.migrate
+            end
+
+            it "migrates the database" do
+              Hanami::Model::Migrator.migrate(version: '20150610133853')
+
+              connection = Sequel.connect(@uri)
+              connection.tables.wont_be :empty?
+
+              table = connection.schema(:books)
+
+              name, options = table[0] # id
+              name.must_equal :id
+
+              options.fetch(:allow_null).must_equal     false
+              options.fetch(:default).must_equal        nil
+              options.fetch(:type).must_equal           :integer
+              options.fetch(:db_type).must_equal        "int(11)"
+              options.fetch(:primary_key).must_equal    true
+              options.fetch(:auto_increment).must_equal true
+
+              name, options = table[1] # title
+              name.must_equal :title
+
+              options.fetch(:allow_null).must_equal     false
+              options.fetch(:default).must_equal        nil
+              options.fetch(:type).must_equal           :string
+              options.fetch(:db_type).must_equal        "varchar(255)"
+              options.fetch(:primary_key).must_equal    false
+
+              name, options = table[2] # price (rolled back second migration)
+              name.must_be_nil
+              options.must_be_nil
+            end
+          end
+        end
+
+        describe "apply" do
+          before do
+            uri              = @uri
+            @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
+            @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
+
+            migrations_root.mkpath
+            FileUtils.cp_r(fixtures_root, migrations_root)
+
+            Hanami::Model.unload!
+            Hanami::Model.configure do
+              adapter type: :sql, uri: uri
+
+              migrations migrations_root.join('migrations')
+              schema     migrations_root.join('schema-mysql.sql')
+            end
+
+            Hanami::Model::Migrator.create
+            Hanami::Model::Migrator.apply
+          end
+
+          it "migrates to latest version" do
+            connection = Sequel.connect(@uri)
+            migration  = connection[:schema_migrations].to_a.last
+
+            migration.fetch(:filename).must_include("20150610141017")
+          end
+
+          it "dumps database schema.sql" do
+            schema = @migrations_root.join('schema-mysql.sql').read
+
+            schema.must_include %(DROP TABLE IF EXISTS `books`;)
+
+            schema.must_include %(CREATE TABLE `books`)
+            schema.must_include %(`id` int\(11\) NOT NULL AUTO_INCREMENT,)
+
+            schema.must_include %(`title` varchar(255))
+
+            schema.must_include %(`price` int\(11\) DEFAULT '100',)
+            schema.must_include %(PRIMARY KEY \(`id`\))
+
+            schema.must_include %(DROP TABLE IF EXISTS `schema_migrations`;)
+
+            schema.must_include %(CREATE TABLE `schema_migrations` \()
+
+            schema.must_include %(`filename` varchar(255))
+            schema.must_include %(PRIMARY KEY (`filename`))
+
+            schema.must_include %(LOCK TABLES `schema_migrations` WRITE;)
+
+            schema.must_include %(INSERT INTO `schema_migrations` VALUES \('20150610133853_create_books.rb'\),\('20150610141017_add_price_to_books.rb'\);)
+
+            schema.must_include %(UNLOCK TABLES;)
+          end
+
+          it "deletes all the migrations" do
+            @migrations_root.join('migrations').children.must_be :empty?
+          end
+        end
+
+        describe "prepare" do
+          before do
+            uri              = @uri
+            @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
+            @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
+
+            migrations_root.mkpath
+            FileUtils.cp_r(fixtures_root, migrations_root)
+
+            Hanami::Model.unload!
+            Hanami::Model.configure do
+              adapter type: :sql, uri: uri
+
+              migrations migrations_root.join('migrations')
+              schema     migrations_root.join('schema-mysql.sql')
+            end
+          end
+
+          it "creates database, loads schema and migrate" do
+            # Simulate already existing schema.sql, without existing database and pending migrations
+            connection = Sequel.connect(@uri)
+
+            FileUtils.cp 'test/fixtures/20150611165922_create_authors.rb',
+              @migrations_root.join('migrations/20150611165922_create_authors.rb')
+
+            Hanami::Model::Migrator.prepare
+
+            connection.tables.must_include(:schema_migrations)
+            connection.tables.must_include(:books)
+            connection.tables.must_include(:authors)
+
+            FileUtils.rm_f @migrations_root.join('migrations/20150611165922_create_authors.rb')
+          end
+
+          it "works even if schema doesn't exist" do
+            # Simulate no database, no schema and pending migrations
+            @migrations_root.join('migrations/20150611165922_create_authors.rb').delete rescue nil
+            @migrations_root.join('schema-mysql.sql').delete                            rescue nil
+
+            Hanami::Model::Migrator.prepare
 
             connection = Sequel.connect(@uri)
-            connection.tables.wont_be :empty?
-
-            table = connection.schema(:books)
-
-            name, options = table[0] # id
-            name.must_equal :id
-
-            options.fetch(:allow_null).must_equal     false
-            options.fetch(:default).must_equal        nil
-            options.fetch(:type).must_equal           :integer
-            options.fetch(:db_type).must_equal        "int(11)"
-            options.fetch(:primary_key).must_equal    true
-            options.fetch(:auto_increment).must_equal true
-
-            name, options = table[1] # title
-            name.must_equal :title
-
-            options.fetch(:allow_null).must_equal     false
-            options.fetch(:default).must_equal        nil
-            options.fetch(:type).must_equal           :string
-            options.fetch(:db_type).must_equal        "varchar(255)"
-            options.fetch(:primary_key).must_equal    false
-
-            name, options = table[2] # price (second migration)
-            name.must_equal :price
-
-            options.fetch(:allow_null).must_equal     true
-            options.fetch(:default).must_equal        "100"
-            options.fetch(:type).must_equal           :integer
-            options.fetch(:db_type).must_equal        "int(11)"
-            options.fetch(:primary_key).must_equal    false
-          end
-        end
-
-        describe "when migrations are ran twice" do
-          before do
-            Hanami::Model::Migrator.migrate
+            connection.tables.must_include(:schema_migrations)
+            connection.tables.must_include(:books)
           end
 
-          it "doesn't alter the schema" do
-            Hanami::Model::Migrator.migrate
+          it "drops the database and recreate it" do
+            Hanami::Model::Migrator.create
+            Hanami::Model::Migrator.prepare
 
             connection = Sequel.connect(@uri)
-            connection.tables.wont_be :empty?
-            connection.tables.must_equal [:books, :schema_migrations]
+            connection.tables.must_include(:schema_migrations)
+            connection.tables.must_include(:books)
           end
         end
 
-        describe "migrate down" do
+        describe "version" do
           before do
-            Hanami::Model::Migrator.migrate
+            Hanami::Model::Migrator.create
           end
 
-          it "migrates the database" do
-            Hanami::Model::Migrator.migrate(version: '20150610133853')
-
-            connection = Sequel.connect(@uri)
-            connection.tables.wont_be :empty?
-
-            table = connection.schema(:books)
-
-            name, options = table[0] # id
-            name.must_equal :id
-
-            options.fetch(:allow_null).must_equal     false
-            options.fetch(:default).must_equal        nil
-            options.fetch(:type).must_equal           :integer
-            options.fetch(:db_type).must_equal        "int(11)"
-            options.fetch(:primary_key).must_equal    true
-            options.fetch(:auto_increment).must_equal true
-
-            name, options = table[1] # title
-            name.must_equal :title
-
-            options.fetch(:allow_null).must_equal     false
-            options.fetch(:default).must_equal        nil
-            options.fetch(:type).must_equal           :string
-            options.fetch(:db_type).must_equal        "varchar(255)"
-            options.fetch(:primary_key).must_equal    false
-
-            name, options = table[2] # price (rolled back second migration)
-            name.must_be_nil
-            options.must_be_nil
-          end
-        end
-      end
-
-      describe "apply" do
-        before do
-          uri              = @uri
-          @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
-          @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
-
-          migrations_root.mkpath
-          FileUtils.cp_r(fixtures_root, migrations_root)
-
-          Hanami::Model.unload!
-          Hanami::Model.configure do
-            adapter type: :sql, uri: uri
-
-            migrations migrations_root.join('migrations')
-            schema     migrations_root.join('schema-mysql.sql')
+          describe "when no migrations were ran" do
+            it "returns nil" do
+              version = Hanami::Model::Migrator.version
+              version.must_be_nil
+            end
           end
 
-          Hanami::Model::Migrator.create
-          Hanami::Model::Migrator.apply
-        end
+          describe "with migrations" do
+            before do
+              Hanami::Model::Migrator.migrate
+            end
 
-        it "migrates to latest version" do
-          connection = Sequel.connect(@uri)
-          migration  = connection[:schema_migrations].to_a.last
-
-          migration.fetch(:filename).must_include("20150610141017")
-        end
-
-        it "dumps database schema.sql" do
-          schema = @migrations_root.join('schema-mysql.sql').read
-
-          schema.must_include %(DROP TABLE IF EXISTS `books`;)
-
-          schema.must_include %(CREATE TABLE `books`)
-          schema.must_include %(`id` int\(11\) NOT NULL AUTO_INCREMENT,)
-
-          schema.must_include %(`title` varchar(255))
-
-          schema.must_include %(`price` int\(11\) DEFAULT '100',)
-          schema.must_include %(PRIMARY KEY \(`id`\))
-
-          schema.must_include %(DROP TABLE IF EXISTS `schema_migrations`;)
-
-          schema.must_include %(CREATE TABLE `schema_migrations` \()
-
-          schema.must_include %(`filename` varchar(255))
-          schema.must_include %(PRIMARY KEY (`filename`))
-
-          schema.must_include %(LOCK TABLES `schema_migrations` WRITE;)
-
-          schema.must_include %(INSERT INTO `schema_migrations` VALUES \('20150610133853_create_books.rb'\),\('20150610141017_add_price_to_books.rb'\);)
-
-          schema.must_include %(UNLOCK TABLES;)
-        end
-
-        it "deletes all the migrations" do
-          @migrations_root.join('migrations').children.must_be :empty?
-        end
-      end
-
-      describe "prepare" do
-        before do
-          uri              = @uri
-          @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
-          @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
-
-          migrations_root.mkpath
-          FileUtils.cp_r(fixtures_root, migrations_root)
-
-          Hanami::Model.unload!
-          Hanami::Model.configure do
-            adapter type: :sql, uri: uri
-
-            migrations migrations_root.join('migrations')
-            schema     migrations_root.join('schema-mysql.sql')
-          end
-        end
-
-        it "creates database, loads schema and migrate" do
-          # Simulate already existing schema.sql, without existing database and pending migrations
-          connection = Sequel.connect(@uri)
-
-          FileUtils.cp 'test/fixtures/20150611165922_create_authors.rb',
-            @migrations_root.join('migrations/20150611165922_create_authors.rb')
-
-          Hanami::Model::Migrator.prepare
-
-          connection.tables.must_include(:schema_migrations)
-          connection.tables.must_include(:books)
-          connection.tables.must_include(:authors)
-
-          FileUtils.rm_f @migrations_root.join('migrations/20150611165922_create_authors.rb')
-        end
-
-        it "works even if schema doesn't exist" do
-          # Simulate no database, no schema and pending migrations
-          @migrations_root.join('migrations/20150611165922_create_authors.rb').delete rescue nil
-          @migrations_root.join('schema-mysql.sql').delete                            rescue nil
-
-          Hanami::Model::Migrator.prepare
-
-          connection = Sequel.connect(@uri)
-          connection.tables.must_include(:schema_migrations)
-          connection.tables.must_include(:books)
-        end
-
-        it "drops the database and recreate it" do
-          Hanami::Model::Migrator.create
-          Hanami::Model::Migrator.prepare
-
-          connection = Sequel.connect(@uri)
-          connection.tables.must_include(:schema_migrations)
-          connection.tables.must_include(:books)
-        end
-      end
-
-      describe "version" do
-        before do
-          Hanami::Model::Migrator.create
-        end
-
-        describe "when no migrations were ran" do
-          it "returns nil" do
-            version = Hanami::Model::Migrator.version
-            version.must_be_nil
-          end
-        end
-
-        describe "with migrations" do
-          before do
-            Hanami::Model::Migrator.migrate
-          end
-
-          it "returns current database version" do
-            version = Hanami::Model::Migrator.version
-            version.must_equal "20150610141017"
+            it "returns current database version" do
+              version = Hanami::Model::Migrator.version
+              version.must_equal "20150610141017"
+            end
           end
         end
       end

--- a/test/integration/migration/postgres_test.rb
+++ b/test/integration/migration/postgres_test.rb
@@ -1,242 +1,243 @@
 require 'test_helper'
 require 'hanami/model/migrator'
 
-describe 'PostgreSQL Database migrations' do
-  let(:adapter_prefix) { 'jdbc:' if Hanami::Utils.jruby?  }
-  let(:db_prefix)      { name.gsub(/[^\w]/, '_') }
-  let(:random_token)   { SecureRandom.hex(4) }
+if TEST_POSTGRES
+  describe 'PostgreSQL Database migrations' do
+    let(:adapter_prefix) { 'jdbc:' if Hanami::Utils.jruby?  }
+    let(:db_prefix)      { name.gsub(/[^\w]/, '_') }
+    let(:random_token)   { SecureRandom.hex(4) }
 
-  before do
-    Hanami::Model.unload!
-  end
-
-  after do
-    Hanami::Model::Migrator.drop rescue nil
-    Hanami::Model.unload!
-  end
-
-  describe "PostgreSQL" do
     before do
-      @database  = "#{ db_prefix }_#{ random_token }"
-      @uri       = uri = "#{ adapter_prefix }postgresql://127.0.0.1/#{ @database }?user=#{ POSTGRES_USER }"
-
-      Hanami::Model.configure do
-        adapter type: :sql, uri: uri
-        migrations __dir__ + '/../../fixtures/migrations'
-      end
+      Hanami::Model.unload!
     end
 
     after do
-      SQLite3::Database.new(@uri) { |db| db.close } if File.exist?(@database)
+      Hanami::Model::Migrator.drop rescue nil
+      Hanami::Model.unload!
     end
 
-    describe "create" do
+    describe "PostgreSQL" do
       before do
-        Hanami::Model::Migrator.create
+        @database  = "#{ db_prefix }_#{ random_token }"
+        @uri       = uri = "#{ adapter_prefix }postgresql://127.0.0.1/#{ @database }?user=#{ POSTGRES_USER }"
+
+        Hanami::Model.configure do
+          adapter type: :sql, uri: uri
+          migrations __dir__ + '/../../fixtures/migrations'
+        end
       end
 
-      it "creates the database" do
-        connection = Sequel.connect(@uri)
-        connection.tables.must_be :empty?
+      after do
+        SQLite3::Database.new(@uri) { |db| db.close } if File.exist?(@database)
       end
 
-      it 'raises error if database is busy' do
-        Sequel.connect(@uri).tables
-        exception = -> { Hanami::Model::Migrator.create }.must_raise Hanami::Model::MigrationError
-        exception.message.must_include 'createdb: database creation failed'
-        exception.message.must_include 'There is 1 other session using the database'
-      end
-    end
-
-    describe "drop" do
-      before do
-        Hanami::Model::Migrator.create
-      end
-
-      it "drops the database" do
-        Hanami::Model::Migrator.drop
-
-        -> { Sequel.connect(@uri).tables }.must_raise Sequel::DatabaseConnectionError
-      end
-
-      it "raises error if database doesn't exist" do
-        Hanami::Model::Migrator.drop # remove the first time
-        exception = -> { Hanami::Model::Migrator.drop }.must_raise Hanami::Model::MigrationError
-        exception.message.must_equal "Cannot find database: #{ @database }"
-      end
-
-      it 'raises error if database is busy' do
-        Sequel.connect(@uri).tables
-        exception = -> { Hanami::Model::Migrator.drop }.must_raise Hanami::Model::MigrationError
-        exception.message.must_include 'dropdb: database removal failed'
-        exception.message.must_include 'There is 1 other session using the database'
-      end
-
-      describe "when a command isn't available" do
+      describe "create" do
         before do
-          # We accomplish having a command not be available by setting PATH
-          # to an empty string, which means *no commands* are available.
-          @original_path = ENV['PATH']
-          ENV['PATH'] = ''
+          Hanami::Model::Migrator.create
         end
 
-        after do
-          ENV['PATH'] = @original_path
-        end
-
-        it "raises MigrationError on create" do
-          exception = -> { Hanami::Model::Migrator.create }.must_raise Hanami::Model::MigrationError
-          exception.message.must_equal "No such file or directory - createdb"
-        end
-      end
-    end
-
-    describe "migrate" do
-      before do
-        Hanami::Model::Migrator.create
-      end
-
-      describe "when no migrations" do
-        before do
-          @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../fixtures/empty_migrations')
-
-          Hanami::Model.configure do
-            migrations migrations_root
-          end
-        end
-
-        it "it doesn't alter database" do
-          Hanami::Model::Migrator.migrate
-
+        it "creates the database" do
           connection = Sequel.connect(@uri)
           connection.tables.must_be :empty?
         end
-      end
 
-      describe "when migrations are present" do
-        it "migrates the database" do
-          Hanami::Model::Migrator.migrate
-
-          connection = Sequel.connect(@uri)
-          connection.tables.wont_be :empty?
-
-          table = connection.schema(:books)
-
-          name, options = table[0] # id
-          name.must_equal :id
-
-          options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        "nextval('books_id_seq'::regclass)"
-          options.fetch(:type).must_equal           :integer
-          options.fetch(:db_type).must_equal        "integer"
-          options.fetch(:primary_key).must_equal    true
-          options.fetch(:auto_increment).must_equal true
-
-          name, options = table[1] # title
-          name.must_equal :title
-
-          options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
-          options.fetch(:type).must_equal           :string
-          options.fetch(:db_type).must_equal        "text"
-          options.fetch(:primary_key).must_equal    false
-
-          name, options = table[2] # price (second migration)
-          name.must_equal :price
-
-          options.fetch(:allow_null).must_equal     true
-          options.fetch(:default).must_equal        "100"
-          options.fetch(:type).must_equal           :integer
-          options.fetch(:db_type).must_equal        "integer"
-          options.fetch(:primary_key).must_equal    false
+        it 'raises error if database is busy' do
+          Sequel.connect(@uri).tables
+          exception = -> { Hanami::Model::Migrator.create }.must_raise Hanami::Model::MigrationError
+          exception.message.must_include 'createdb: database creation failed'
+          exception.message.must_include 'There is 1 other session using the database'
         end
       end
 
-      describe "when migrations are ran twice" do
+      describe "drop" do
         before do
-          Hanami::Model::Migrator.migrate
+          Hanami::Model::Migrator.create
         end
 
-        it "doesn't alter the schema" do
-          Hanami::Model::Migrator.migrate
+        it "drops the database" do
+          Hanami::Model::Migrator.drop
 
-          connection = Sequel.connect(@uri)
-          connection.tables.wont_be :empty?
-          connection.tables.must_equal [:schema_migrations, :books]
+          -> { Sequel.connect(@uri).tables }.must_raise Sequel::DatabaseConnectionError
+        end
+
+        it "raises error if database doesn't exist" do
+          Hanami::Model::Migrator.drop # remove the first time
+          exception = -> { Hanami::Model::Migrator.drop }.must_raise Hanami::Model::MigrationError
+          exception.message.must_equal "Cannot find database: #{ @database }"
+        end
+
+        it 'raises error if database is busy' do
+          Sequel.connect(@uri).tables
+          exception = -> { Hanami::Model::Migrator.drop }.must_raise Hanami::Model::MigrationError
+          exception.message.must_include 'dropdb: database removal failed'
+          exception.message.must_include 'There is 1 other session using the database'
+        end
+
+        describe "when a command isn't available" do
+          before do
+            # We accomplish having a command not be available by setting PATH
+            # to an empty string, which means *no commands* are available.
+            @original_path = ENV['PATH']
+            ENV['PATH'] = ''
+          end
+
+          after do
+            ENV['PATH'] = @original_path
+          end
+
+          it "raises MigrationError on create" do
+            exception = -> { Hanami::Model::Migrator.create }.must_raise Hanami::Model::MigrationError
+            exception.message.must_equal "No such file or directory - createdb"
+          end
         end
       end
 
-      describe "migrate down" do
+      describe "migrate" do
         before do
-          Hanami::Model::Migrator.migrate
+          Hanami::Model::Migrator.create
         end
 
-        it "migrates the database" do
-          Hanami::Model::Migrator.migrate(version: '20150610133853')
+        describe "when no migrations" do
+          before do
+            @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../fixtures/empty_migrations')
 
+            Hanami::Model.configure do
+              migrations migrations_root
+            end
+          end
+
+          it "it doesn't alter database" do
+            Hanami::Model::Migrator.migrate
+
+            connection = Sequel.connect(@uri)
+            connection.tables.must_be :empty?
+          end
+        end
+
+        describe "when migrations are present" do
+          it "migrates the database" do
+            Hanami::Model::Migrator.migrate
+
+            connection = Sequel.connect(@uri)
+            connection.tables.wont_be :empty?
+
+            table = connection.schema(:books)
+
+            name, options = table[0] # id
+            name.must_equal :id
+
+            options.fetch(:allow_null).must_equal     false
+            options.fetch(:default).must_equal        "nextval('books_id_seq'::regclass)"
+            options.fetch(:type).must_equal           :integer
+            options.fetch(:db_type).must_equal        "integer"
+            options.fetch(:primary_key).must_equal    true
+            options.fetch(:auto_increment).must_equal true
+
+            name, options = table[1] # title
+            name.must_equal :title
+
+            options.fetch(:allow_null).must_equal     false
+            options.fetch(:default).must_equal        nil
+            options.fetch(:type).must_equal           :string
+            options.fetch(:db_type).must_equal        "text"
+            options.fetch(:primary_key).must_equal    false
+
+            name, options = table[2] # price (second migration)
+            name.must_equal :price
+
+            options.fetch(:allow_null).must_equal     true
+            options.fetch(:default).must_equal        "100"
+            options.fetch(:type).must_equal           :integer
+            options.fetch(:db_type).must_equal        "integer"
+            options.fetch(:primary_key).must_equal    false
+          end
+        end
+
+        describe "when migrations are ran twice" do
+          before do
+            Hanami::Model::Migrator.migrate
+          end
+
+          it "doesn't alter the schema" do
+            Hanami::Model::Migrator.migrate
+
+            connection = Sequel.connect(@uri)
+            connection.tables.wont_be :empty?
+            connection.tables.must_equal [:schema_migrations, :books]
+          end
+        end
+
+        describe "migrate down" do
+          before do
+            Hanami::Model::Migrator.migrate
+          end
+
+          it "migrates the database" do
+            Hanami::Model::Migrator.migrate(version: '20150610133853')
+
+            connection = Sequel.connect(@uri)
+            connection.tables.wont_be :empty?
+
+            table = connection.schema(:books)
+
+            name, options = table[0] # id
+            name.must_equal :id
+
+            options.fetch(:allow_null).must_equal     false
+            options.fetch(:default).must_equal        "nextval('books_id_seq'::regclass)"
+            options.fetch(:type).must_equal           :integer
+            options.fetch(:db_type).must_equal        "integer"
+            options.fetch(:primary_key).must_equal    true
+            options.fetch(:auto_increment).must_equal true
+
+            name, options = table[1] # title
+            name.must_equal :title
+
+            options.fetch(:allow_null).must_equal     false
+            options.fetch(:default).must_equal        nil
+            options.fetch(:type).must_equal           :string
+            options.fetch(:db_type).must_equal        "text"
+            options.fetch(:primary_key).must_equal    false
+
+            name, options = table[2] # price (rolled back second migration)
+            name.must_be_nil
+            options.must_be_nil
+          end
+        end
+      end
+
+      describe "apply" do
+        before do
+          uri              = @uri
+          @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
+          @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
+
+          migrations_root.mkpath
+          FileUtils.cp_r(fixtures_root, migrations_root)
+
+          Hanami::Model.unload!
+          Hanami::Model.configure do
+            adapter type: :sql, uri: uri
+
+            migrations migrations_root.join('migrations')
+            schema     migrations_root.join('schema-postgres.sql')
+          end
+
+          Hanami::Model::Migrator.create
+          Hanami::Model::Migrator.apply
+        end
+
+        it "migrates to latest version" do
           connection = Sequel.connect(@uri)
-          connection.tables.wont_be :empty?
+          migration  = connection[:schema_migrations].to_a[1]
 
-          table = connection.schema(:books)
-
-          name, options = table[0] # id
-          name.must_equal :id
-
-          options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        "nextval('books_id_seq'::regclass)"
-          options.fetch(:type).must_equal           :integer
-          options.fetch(:db_type).must_equal        "integer"
-          options.fetch(:primary_key).must_equal    true
-          options.fetch(:auto_increment).must_equal true
-
-          name, options = table[1] # title
-          name.must_equal :title
-
-          options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
-          options.fetch(:type).must_equal           :string
-          options.fetch(:db_type).must_equal        "text"
-          options.fetch(:primary_key).must_equal    false
-
-          name, options = table[2] # price (rolled back second migration)
-          name.must_be_nil
-          options.must_be_nil
-        end
-      end
-    end
-
-    describe "apply" do
-      before do
-        uri              = @uri
-        @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
-        @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
-
-        migrations_root.mkpath
-        FileUtils.cp_r(fixtures_root, migrations_root)
-
-        Hanami::Model.unload!
-        Hanami::Model.configure do
-          adapter type: :sql, uri: uri
-
-          migrations migrations_root.join('migrations')
-          schema     migrations_root.join('schema-postgres.sql')
+          migration.fetch(:filename).must_include("20150610141017")
         end
 
-        Hanami::Model::Migrator.create
-        Hanami::Model::Migrator.apply
-      end
+        it "dumps database schema.sql" do
+          schema = @migrations_root.join('schema-postgres.sql').read
 
-      it "migrates to latest version" do
-        connection = Sequel.connect(@uri)
-        migration  = connection[:schema_migrations].to_a[1]
-
-        migration.fetch(:filename).must_include("20150610141017")
-      end
-
-      it "dumps database schema.sql" do
-        schema = @migrations_root.join('schema-postgres.sql').read
-
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 CREATE TABLE books (
     id integer NOT NULL,
     title text NOT NULL,
@@ -244,7 +245,7 @@ CREATE TABLE books (
 );
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 CREATE SEQUENCE books_id_seq
     START WITH 1
     INCREMENT BY 1
@@ -253,117 +254,118 @@ CREATE SEQUENCE books_id_seq
     CACHE 1;
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 ALTER SEQUENCE books_id_seq OWNED BY books.id;
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 ALTER TABLE ONLY books ALTER COLUMN id SET DEFAULT nextval('books_id_seq'::regclass);
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 ALTER TABLE ONLY books
     ADD CONSTRAINT books_pkey PRIMARY KEY (id);
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 CREATE TABLE schema_migrations (
     filename text NOT NULL
 );
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 COPY schema_migrations (filename) FROM stdin;
 20150610133853_create_books.rb
 20150610141017_add_price_to_books.rb
 SQL
 
-        schema.must_include <<-SQL
+          schema.must_include <<-SQL
 ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (filename);
 SQL
-      end
+        end
 
-      it "deletes all the migrations" do
-        @migrations_root.join('migrations').children.must_be :empty?
-      end
-    end
-
-    describe "prepare" do
-      before do
-        uri              = @uri
-        @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
-        @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
-
-        migrations_root.mkpath
-        FileUtils.cp_r(fixtures_root, migrations_root)
-
-        Hanami::Model.unload!
-        Hanami::Model.configure do
-          adapter type: :sql, uri: uri
-
-          migrations migrations_root.join('migrations')
-          schema     migrations_root.join('schema-postgres.sql')
+        it "deletes all the migrations" do
+          @migrations_root.join('migrations').children.must_be :empty?
         end
       end
 
-      it "creates database, loads schema and migrate" do
-        # Simulate already existing schema.sql, without existing database and pending migrations
-        connection = Sequel.connect(@uri)
-
-        FileUtils.cp 'test/fixtures/20150611165922_create_authors.rb',
-          @migrations_root.join('migrations/20150611165922_create_authors.rb')
-
-        Hanami::Model::Migrator.prepare
-
-        connection.tables.must_include(:schema_migrations)
-        connection.tables.must_include(:books)
-        connection.tables.must_include(:authors)
-
-        FileUtils.rm_f @migrations_root.join('migrations/20150611165922_create_authors.rb')
-      end
-
-      it "works even if schema doesn't exist" do
-        # Simulate no database, no schema and pending migrations
-        @migrations_root.join('migrations/20150611165922_create_authors.rb').delete rescue nil
-        @migrations_root.join('schema-postgres.sql').delete                         rescue nil
-
-        Hanami::Model::Migrator.prepare
-
-        connection = Sequel.connect(@uri)
-        connection.tables.must_equal [:schema_migrations, :books]
-      end
-
-      it "drops the database and recreate it" do
-        Hanami::Model::Migrator.create
-        Hanami::Model::Migrator.prepare
-
-        connection = Sequel.connect(@uri)
-        connection.tables.must_include(:schema_migrations)
-        connection.tables.must_include(:books)
-      end
-    end
-
-    describe "version" do
-      before do
-        Hanami::Model::Migrator.create
-      end
-
-      describe "when no migrations were ran" do
-        it "returns nil" do
-          version = Hanami::Model::Migrator.version
-          version.must_be_nil
-        end
-      end
-
-      describe "with migrations" do
+      describe "prepare" do
         before do
-          Hanami::Model::Migrator.migrate
+          uri              = @uri
+          @migrations_root = migrations_root = Pathname.new(__dir__ + '/../../../tmp')
+          @fixtures_root   = fixtures_root   = Pathname.new(__dir__ + '/../../fixtures/migrations')
+
+          migrations_root.mkpath
+          FileUtils.cp_r(fixtures_root, migrations_root)
+
+          Hanami::Model.unload!
+          Hanami::Model.configure do
+            adapter type: :sql, uri: uri
+
+            migrations migrations_root.join('migrations')
+            schema     migrations_root.join('schema-postgres.sql')
+          end
         end
 
-        it "returns current database version" do
-          version = Hanami::Model::Migrator.version
-          version.must_equal "20150610141017"
+        it "creates database, loads schema and migrate" do
+          # Simulate already existing schema.sql, without existing database and pending migrations
+          connection = Sequel.connect(@uri)
+
+          FileUtils.cp 'test/fixtures/20150611165922_create_authors.rb',
+            @migrations_root.join('migrations/20150611165922_create_authors.rb')
+
+          Hanami::Model::Migrator.prepare
+
+          connection.tables.must_include(:schema_migrations)
+          connection.tables.must_include(:books)
+          connection.tables.must_include(:authors)
+
+          FileUtils.rm_f @migrations_root.join('migrations/20150611165922_create_authors.rb')
+        end
+
+        it "works even if schema doesn't exist" do
+          # Simulate no database, no schema and pending migrations
+          @migrations_root.join('migrations/20150611165922_create_authors.rb').delete rescue nil
+          @migrations_root.join('schema-postgres.sql').delete                         rescue nil
+
+          Hanami::Model::Migrator.prepare
+
+          connection = Sequel.connect(@uri)
+          connection.tables.must_equal [:schema_migrations, :books]
+        end
+
+        it "drops the database and recreate it" do
+          Hanami::Model::Migrator.create
+          Hanami::Model::Migrator.prepare
+
+          connection = Sequel.connect(@uri)
+          connection.tables.must_include(:schema_migrations)
+          connection.tables.must_include(:books)
+        end
+      end
+
+      describe "version" do
+        before do
+          Hanami::Model::Migrator.create
+        end
+
+        describe "when no migrations were ran" do
+          it "returns nil" do
+            version = Hanami::Model::Migrator.version
+            version.must_be_nil
+          end
+        end
+
+        describe "with migrations" do
+          before do
+            Hanami::Model::Migrator.migrate
+          end
+
+          it "returns current database version" do
+            version = Hanami::Model::Migrator.version
+            version.must_equal "20150610141017"
+          end
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,6 +61,9 @@ else
   MYSQL_USER    = 'hanami'
 end
 
+TEST_POSTGRES= Hanami::Utils::Blank.blank?(ENV['ADAPTER']) || ENV['ADAPTER'] == 'postgres'
+TEST_MYSQL = Hanami::Utils::Blank.blank?(ENV['ADAPTER']) || ENV['ADAPTER'] == 'mysql'
+
 system "dropdb #{ postgres_database }" rescue nil
 system "createdb #{ postgres_database }" rescue nil
 sleep 1


### PR DESCRIPTION
Closes #257.

You can try this out by calling `ADAPTER=postgres bundle exec rake`.

One potential bug/feature of this is that running with `ADAPTER=dog` will silently run none of the adapter-specific tests.

It looks like I change `mysql_test.rb` and `postgres_test.rb` a lot but I just add a conditional around the whole file and indent inside of that.