### PR TITLE
Fix problem with inheritance and Entitiy::attributes

### DIFF
--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -140,14 +140,9 @@ module Hanami
       #   DeletedUser.attributes => #<Set: {:id, :name, :deleted_at}>
       #
       def attributes(*attrs)
-        return @attributes ||= Set.new unless attrs.any?
-
-        Hanami::Utils::Kernel.Array(attrs).each do |attr|
-          if allowed_attribute_name?(attr)
-            define_attr_accessor(attr)
-            self.attributes << attr
-          end
-        end
+        @attributes ||= Set.new
+        return get_attributes unless attrs.any?
+        set_attributes attrs
       end
 
       # Define setter/getter methods for attributes.
@@ -170,10 +165,21 @@ module Hanami
 
       protected
 
-      # @see Class#inherited
-      def inherited(subclass)
-        subclass.attributes(*attributes)
-        super
+      def get_attributes
+        if self.superclass.respond_to?(:attributes)
+          @attributes + self.superclass.get_attributes
+        else
+          @attributes
+        end
+      end
+
+      def set_attributes(*attrs)
+        Hanami::Utils::Kernel.Array(attrs).each do |attr|
+          if allowed_attribute_name?(attr)
+            define_attr_accessor(attr)
+            @attributes << attr
+          end
+        end
       end
     end
 

--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -43,6 +43,10 @@ describe Hanami::Entity do
       Car.attributes.must_equal Set.new([:id])
     end
 
+    it 'inherits all ancestor attributes' do
+      CoolNonFictionBook.attributes.must_equal Set.new([:id, :title, :author, :published, :tags, :price, :coolness])
+    end
+
     describe 'params is array' do
       it 'defines attributes' do
         Car.attributes [:model]


### PR DESCRIPTION
Hi,

First of all, thank you all for the great work done on the Hanami project! Love using it :-)

There is a bug in the way the inheritance of attributes are implemented with regards to the `::attributes` method. The following example illustrates the problem:

```
class A
  include Hanami::Entity
  attributes :a
end

class B < A
  attributes :b
end

B.attributes # => [:id, :b], but should be [:id, :a, :b]
```

The current code adds the super class attributes to entities by calling ::define_attribute_accessor, but this fails silently because of  a guard on `!instance_methods.include?`

This pull request fixes the problem by adding super class attributes to the result when calling `::attributes`.