### PR TITLE
Add 'PULL_REQUEST_TEMPLATE' to let people know about upcoming changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Hanami Model is currently being re-worked to be based on ROM (Ruby Object Mapper), as of May 31 2016.
+Please see work on this branch: https://github.com/hanami/model/tree/new-engine
+
+Generally speaking, any new features will be rejected until that branch is merged into master,
+since it's significantly altering the code-base.
+
+Thanks for understanding :)


### PR DESCRIPTION
This PR adds a 'Pull Request Template' so that new PR's will have some default text, informing contributors that `hanami-model` is in the process of being reworked (to be based on `rom`), and therefore, is unlikely to accept PR's for new features.

More info about PR and Issue templates: https://github.com/blog/2111-issue-and-pull-request-templates

Should help reduce PR's like #315 and #316

1. GitHub allows this file to be in a `.github` folder, which I opted for. If we don't want that, it can go in the main directory.

2. This only applies to Pull Requests. I can copy this file to `.github/ISSUE_TEMPLATE.md` if we want it to work for Issues as well.

3. Should we add a note into the README too? Otherwise people could do the work to add a feature and only find out right before submitting a PR.

4. This file should be removed after the `new-engine` branch is merged into master. (I can be responsible for doing this)
