### PR TITLE
Fix return value of Hanami::Repository#all.

### DIFF
--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -384,7 +384,7 @@ module Hanami
     # @example
     #   UserRepository.new.all
     def all
-      root.as(:entity)
+      root.as(:entity).to_a
     end
 
     # Returns the first record for the relation

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -25,7 +25,8 @@ describe 'Repository (base)' do
       repository = UserRepository.new
       user = repository.create(name: 'L')
 
-      repository.all.to_a.must_include user
+      repository.all.must_be_instance_of Array
+      repository.all.must_include user
     end
   end
 
@@ -59,7 +60,7 @@ describe 'Repository (base)' do
       repository.create(name: 'L')
 
       repository.clear
-      repository.all.to_a.must_be :empty?
+      repository.all.must_be :empty?
     end
   end
 

--- a/test/integration/repository/legacy_test.rb
+++ b/test/integration/repository/legacy_test.rb
@@ -23,7 +23,8 @@ describe 'Repository (legacy)' do
       repository = OperatorRepository.new
       operator = repository.create(name: 'F')
 
-      repository.all.to_a.must_include operator
+      repository.all.must_be_instance_of Array
+      repository.all.must_include operator
     end
   end
 
@@ -57,7 +58,7 @@ describe 'Repository (legacy)' do
       repository.create(name: 'F')
 
       repository.clear
-      repository.all.to_a.must_be :empty?
+      repository.all.must_be :empty?
     end
   end
 


### PR DESCRIPTION
`Hanami::Repository#all` currently returns an instance of `ROM::Repository::RelationProxy`, which is inconsistent with the comment above the definition (`@return [Array<Hanami::Entity>] all the entities`), and the fact that all other query methods return materialized results.

This PR fixes this by calling `to_a` on the `RelationProxy`.