### PR TITLE
Fix example in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ puts user.created_at.to_s # => "2016-09-19 13:40:13 UTC"
 puts user.updated_at.to_s # => "2016-09-19 13:40:13 UTC"
 
 sleep 3
-user = UserRepository.new.update(user.id, age: 34)
+user = repository.update(user.id, age: 34)
 puts user.created_at.to_s # => "2016-09-19 13:40:13 UTC"
 puts user.updated_at.to_s # => "2016-09-19 13:40:16 UTC"
 ```


### PR DESCRIPTION
Example was declaring

```
repository = UserRepository.new
```

and was subsequently calling `UserRepository.new.update` instead of `repository.update`.
