### PR TITLE
Introducing Hanami::Repository#query

### DIFF
--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -18,8 +18,7 @@ module Hanami
   # @example
   #   require 'hanami/model'
   #
-  #   class Article
-  #     include Hanami::Entity
+  #   class Article < Hanami::Entity
   #   end
   #
   #   # valid
@@ -72,7 +71,7 @@ module Hanami
   #   #  * If we change the storage, we are forced to change the code of the
   #   #    caller(s).
   #
-  #   ArticleRepository.new.where(author_id: 23).order(:published_at).limit(8)
+  #   ArticleRepository.new.q.where(author_id: 23).order(:published_at).limit(8)
   #
   #
   #
@@ -360,6 +359,26 @@ module Hanami
       super(self.class.container)
     end
 
+    # Expose the relation for inline queries.
+    #
+    # NOTE: this should be used only in console or for testing code, we strongly
+    # discourage to use it in production code.
+    #
+    # @return [ROM::Repository::RelationProxy] the database relation
+    #
+    # @since 0.7.0
+    #
+    # @example Inline Query
+    #   UserRepository.new.query.where(...)
+    #   # or
+    #   UserRepository.new.q.where(...)
+    def query
+      root.as(:entity)
+    end
+
+    # @since 0.7.0
+    alias q query
+
     # Find by primary key
     #
     # @return [Hanami::Entity,NilClass] the entity, if found
@@ -384,7 +403,7 @@ module Hanami
     # @example
     #   UserRepository.new.all
     def all
-      root.as(:entity).to_a
+      query.to_a
     end
 
     # Returns the first record for the relation

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -20,6 +20,24 @@ describe 'Repository (base)' do
     end
   end
 
+  describe '#query' do
+    it 'exposes database relation' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+
+      records = repository.query.where(name: 'L').to_a
+      records.must_include user
+    end
+
+    it 'is aliased as q' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+
+      records = repository.q.where(name: 'L').to_a
+      records.must_include user
+    end
+  end
+
   describe '#all' do
     it 'returns all the records' do
       repository = UserRepository.new

--- a/test/integration/repository/legacy_test.rb
+++ b/test/integration/repository/legacy_test.rb
@@ -18,6 +18,24 @@ describe 'Repository (legacy)' do
     end
   end
 
+  describe '#query' do
+    it 'exposes database relation' do
+      repository = OperatorRepository.new
+      operator = repository.create(s_name: 'F')
+
+      records = repository.query.where(s_name: 'F').to_a
+      records.must_include operator
+    end
+
+    it 'is aliased as q' do
+      repository = OperatorRepository.new
+      operator = repository.create(s_name: 'F')
+
+      records = repository.q.where(s_name: 'F').to_a
+      records.must_include operator
+    end
+  end
+
   describe '#all' do
     it 'returns all the records' do
       repository = OperatorRepository.new


### PR DESCRIPTION
## The Problem

Until `hanami-model` 0.6, all the queries are private.
This was a strong guidance for developers to write intention revealing methods in repositories instead of leaking storage abstractions all over the code base.

It avoided code like `ArticleRepository.where(state: 'draft')` to be used directly in actions code.
Developers were forced to write a meaningful method `ArticleRepository.drafts` to get access to the data they were interested into.

This has the huge downside of being not convenient for testing code and Hanami console.

I found myself to define over and over methods in repositories **only for testing purposes**.

```ruby
RSpec.describe ArticleRepository do
  it "creates draft articles" do
    repository = described_class.new
    draft      = repository.create_draft(title: "Introducing Hanami")

    drafts = repository.drafts_by_title("Introducing Hanami")
    expect(drafts).to include(draft)
  end
end
```

```ruby
class ArticleRepository < Hanami::Repository
  def create_draft(data)
    # ...
  end

  # NOTE: this is defined only for testing purposes.
  def drafts_by_title(title)
    # ...
  end
end
```

As the time passed, half of the methods defined in repositories were defined because of testing purposes (like `#drafts_by_title`) in the example above.

## The Solution

This PR introduces `Repository#query` (aliased as `#q`) to allow developers to directly access the database relation and build **_inline queries_**.

The documentation warns developers to use _inline queries_ **only** for testing purposes and Hanami console.

Let's rewrite the testing code above:

```ruby
RSpec.describe ArticleRepository do
  it "creates draft articles" do
    repository = described_class.new
    draft      = repository.create_draft(title: "Introducing Hanami")

    drafts = repository.q.where(state: 'draft').where(title: "Introducing Hanami")
    expect(drafts).to include(draft)
  end
end
```

We don't need to define `#drafts_by_title` in that repository anymore.

---

/cc @hanami/core-team @hanami/contributors @solnic @flash-gordon