### PR TITLE
Remove PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-Hanami Model is currently being re-worked to be based on ROM (Ruby Object Mapper), as of May 31 2016.
-Please see work on this branch: https://github.com/hanami/model/tree/new-engine
-
-Generally speaking, any new features will be rejected until that branch is merged into master,
-since it's significantly altering the code-base.
-
-Thanks for understanding :)


### PR DESCRIPTION
Remove the following (outdated) warning when issuing a PR:

> Hanami Model is currently being re-worked to be based on ROM (Ruby Object Mapper), as of May 31 2016.
>
> Please see work on this branch: https://github.com/hanami/model/tree/new-engine
>
> Generally speaking, any new features will be rejected until that branch is merged into master,
since it's significantly altering the code-base.
>
> Thanks for understanding :)

