### PR TITLE
Introduce Repository#connection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Style/GuardClause:
 Metrics/BlockLength:
   Exclude:
     - "test/**/*.rb" # Minitest syntax generates this false positive
+Bundler/OrderedGems:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -17,7 +17,7 @@ module Hanami
 
     # @api private
     # @since 0.7.0
-    @__repositories__ = Concurrent::Array.new # rubocop:disable Style/VariableNumber
+    @__repositories__ = Concurrent::Array.new
 
     class << self
       # @since 0.7.0

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -8,7 +8,7 @@ module Hanami
     class Error < ::StandardError
       # @api private
       # @since 0.7.0
-      @__mapping__ = Concurrent::Map.new # rubocop:disable Style/VariableNumber
+      @__mapping__ = Concurrent::Map.new
 
       # @api private
       # @since 0.7.0

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -423,6 +423,69 @@ module Hanami
 
     private
 
+    # Gives access to low level connection in order to perform specific
+    # operations for the current database.
+    #
+    # NOTE: Please note that using `#connection` will limit the portability of
+    # the repository in case you want to switch the database/adapter.
+    # For instance, if you fetch data with a raw SQL query, then it would be
+    # impossible to use a Redis database without changing that query.
+    #
+    # NOTE: In order to use `#connection`, please read the API docs of your
+    # current adapter.
+    # In case you're using a SQL database, please check Sequel (`sequel` gem)
+    # API docs.
+    #
+    # @return [Object] A raw connection, the type depends on the current adapter
+    #
+    # @since x.x.x
+    #
+    # @example Fetch data with raw SQL
+    #   class UserRepository < Hanami::Repository
+    #     def find_all
+    #       connection.fetch('SELECT * FROM users').to_a
+    #     end
+    #   end
+    #
+    #   repository = UserRepository.new
+    #   users      = repository.find_all
+    #
+    #   users.class # => Array
+    #   users.first # => {:id=>1, :name=>"Luca", :age=>34, :created_at=>2016-12-02 08:05:56 UTC, :updated_at=>2016-12-02 08:05:56 UTC}
+    #
+    #   # NOTE that `#fetch` is only available for SQL adapter
+    #
+    # @example Count records
+    #   class UserRepository < Hanami::Repository
+    #     def count
+    #       users.count
+    #     end
+    #
+    #     def count_with_connection
+    #       connection[:users].count
+    #     end
+    #
+    #     def active_users
+    #       users.where(active: true)
+    #     end
+    #
+    #     def count_active_users
+    #       active_users.count
+    #     end
+    #   end
+    #
+    #   repository = UserRepository.new
+    #
+    #   repository.count # => 100
+    #   repository.count_with_connection # => 100
+    #
+    #   repository.count_active_users # => 82
+    #
+    #   # NOTE that `connection#[]` is only available for SQL adapter
+    def connection
+      container.gateways[root.gateway].connection
+    end
+
     # Returns an association
     #
     # NOTE: This is an experimental feature

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -3,6 +3,15 @@ require 'test_helper'
 describe 'Repository (base)' do
   extend PlatformHelpers
 
+  describe 'relation' do
+    it 'allows to materialize relation with count' do
+      repository = UserRepository.new
+      count      = repository.count
+
+      count.must_be_kind_of(Integer)
+    end
+  end
+
   describe '#find' do
     it 'finds record by primary key' do
       repository = UserRepository.new
@@ -64,10 +73,35 @@ describe 'Repository (base)' do
     end
   end
 
-  describe '#execute' do
-  end
+  describe '#connection' do
+    it 'is a private method' do
+      repository = UserRepository.new
+      exception  = -> { repository.connection }.must_raise(NoMethodError)
 
-  describe '#fetch' do
+      exception.message.must_include "private method `connection' called for"
+    end
+
+    it 'exposes raw connection' do
+      repository = UserRepository.new
+      data       = repository.find_all_by_manual_query
+      user       = data.first
+
+      user.must_be_kind_of(Hash)
+    end
+
+    it 'allows low level operations, only valid for the current adapter' do
+      repository = UserRepository.new
+      count      = repository.count_with_connection
+
+      count.must_be_kind_of(Integer)
+    end
+
+    it 'allows to run commands' do
+      repository = UserRepository.new
+      repository.reset_comments_count
+
+      repository.first.comments_count.must_equal 0
+    end
   end
 
   describe '#create' do
@@ -451,6 +485,13 @@ describe 'Repository (base)' do
       found   = repository.by_name('L')
 
       found.to_a.must_include user
+    end
+
+    it 'allows to materialize custom finders with count' do
+      repository = UserRepository.new
+      count      = repository.count_active_users
+
+      count.must_be_kind_of(Integer)
     end
   end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -42,6 +42,30 @@ class UserRepository < Hanami::Repository
   def by_name(name)
     users.where(name: name).as(:entity)
   end
+
+  def find_all_by_manual_query
+    connection.fetch('select * from users').to_a
+  end
+
+  def active_users
+    users.where(active: true)
+  end
+
+  def count
+    users.count
+  end
+
+  def count_with_connection
+    connection[:users].count
+  end
+
+  def count_active_users
+    active_users.count
+  end
+
+  def reset_comments_count
+    connection.execute('UPDATE users SET comments_count = 0')
+  end
 end
 
 class AvatarRepository < Hanami::Repository


### PR DESCRIPTION
This is a proposal to introduce a new private method for repositories: `#connection`.

It returns a low level connection for the current database. This allows developers to perform low level operations like fetching raw data with hand written SQL queries, or to perform a SQL `COUNT`.

---

We want that the public interface of `Repository` to be smallest as possible in order to make it compatible with all the available adapters. This is the reason why [we rejected the idea](https://github.com/hanami/model/issues/351#issuecomment-264388994) of having `#count`.

But at the same time, we want to allow developers to perform low level operations that they may need.

**NOTE:** Using `#connection` may limit the portability of your repository. For instance, if you implement a method that fetches data via a SQL query, then it would be hard to swap the adapter to Redis, unless you change that fetching logic.

---

## Examples

### Fetch raw data via SQL

```ruby
class UserRepository < Hanami::Repository
  def find_active_users
    connection.fetch("SELECT * FROM users WHERE active='t'").to_a
  end
end

repository = UserRepository.new
data = repository.find_active_users

data.class # => Array
data.first # => {:id=>1, :name=>"Luca", :age=>34}
```

**NOTE:** Please note that `connection#fetch` is only available for the current adapter, and it may change if you use a different adapter. Again, using `#connection` limits the portability, you're warned 😉 

In the past we used to have `Repository#fetch`, and I think this is wrong for encapsulation. This encourages developers to leak raw fetching scripts (eg a SQL query) **outside** of the repository.

```ruby
repository.fetch("SELECT * FROM users WHERE active='t'").to_a # WRONG
```

For the same reason we do **NOT** want `repository.where(active: true)` is possible, we should forbid `#fetch`.

Even if `#connection` limits portability, at least developers are forced to **expose explicit, meaningful methods**. In the example above, we defined `#find_active_users`, which abstracts that logic on the outside of the repository.

### Execute raw SQL commands

```ruby
class UserRepository < Hanami::Repository
  def reset_comments_count
    connection.execute("UPDATE users SET comments_count = 0")
  end
end
```

This is similar to the previous example. Again, it limits portability because `connection#execute` may not be available for other adapters, but it has the advantage of forcing devs to expose meaningful methods

### Count records

```ruby
class UserRepository < Hanami::Repository
  def count
    users.count
  end

  def active_users
    users.where(active: true)
  end

  def count_active_users
    active_users.count
  end

  def count_users_via_connection # silly name, I know ;-)
    connection[:users].count
  end
end
```

The method `connection#[]` is derived from Sequel (`sequel` gem).

---

Closes #345 
Closes #351 

---

/cc @hanami/core-team @hanami/contributors @choallin @solnic @flash-gordon for review.