### PR TITLE
Timestamp plugin respects given timestamps.

### DIFF
--- a/lib/hanami/model/plugins/timestamps.rb
+++ b/lib/hanami/model/plugins/timestamps.rb
@@ -63,7 +63,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def _touch(value, now)
-            value[:updated_at] = now
+            value[:updated_at] ||= now
             value
           end
         end
@@ -79,7 +79,7 @@ module Hanami
           # @api private
           def _touch(value, now)
             super
-            value[:created_at] = now
+            value[:created_at] ||= now
             value
           end
         end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -105,6 +105,34 @@ describe 'Repository (base)' do
         user.created_at.must_be_close_to Time.now.utc, 2
         user.updated_at.must_be_close_to Time.now.utc, 2
       end
+
+      it 'respects given timestamps' do
+        repository = UserRepository.new
+        given_time = Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
+
+        user = repository.create(name: 'L', created_at: given_time, updated_at: given_time)
+
+        user.created_at.must_be_close_to given_time, 2
+        user.updated_at.must_be_close_to given_time, 2
+      end
+
+      it 'can update timestamps' do
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+        user.created_at.must_be_close_to Time.now.utc, 2
+        user.updated_at.must_be_close_to Time.now.utc, 2
+
+        given_time = Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
+        updated = repository.update(
+          user.id,
+          created_at: given_time,
+          updated_at: given_time
+        )
+
+        updated.name.must_equal 'L'
+        updated.created_at.must_be_close_to given_time, 2
+        updated.updated_at.must_be_close_to given_time, 2
+      end
     end
 
     # Bug: https://github.com/hanami/model/issues/237


### PR DESCRIPTION
If no timestamps is given, as it most often will, then current time
will be used. If timestamps are given, the given timestamps will be
used.

This restores pre-0.7 behaviour and I think it is correct that when you
ask the repository to insert/update a row with given data it shouldn’t
change given data before data is persisted to the database.