### PR TITLE
Allow Hanami::Entity to be used in Schema as type.

### DIFF
--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -74,11 +74,13 @@ module Hanami
         # @since 0.7.0
         # @api private
         def call(attributes)
-          if attributes.nil?
-            {}
-          else
-            attributes.dup
-          end
+          attributes = if attributes.nil?
+                         {}
+                       else
+                         attributes.dup
+                       end
+
+          Utils::Hash.new(attributes).symbolize!
         end
 
         # @since 0.7.0
@@ -205,9 +207,8 @@ module Hanami
       # @since 0.7.0
       # @api private
       def call(attributes)
-        Utils::Hash.new(
-          schema.call(attributes)
-        ).symbolize!
+        attributes = schema.call(attributes)
+        Utils::Hash.new(attributes)
       end
 
       # @since 0.7.0

--- a/lib/hanami/model/types.rb
+++ b/lib/hanami/model/types.rb
@@ -18,11 +18,15 @@ module Hanami
       #
       # @since 0.7.0
       module ClassMethods
+        def Entity(type) # rubocop:disable Style/MethodName
+          Schema::CoercibleType.wrap_unless_dry_type(type)
+        end
+
         # Define an array of given type
         #
         # @since 0.7.0
         def Collection(type) # rubocop:disable Style/MethodName
-          type = Schema::CoercibleType.new(type) unless type.is_a?(Dry::Types::Definition)
+          type = Schema::CoercibleType.wrap_unless_dry_type(type)
           Types::Array.member(type)
         end
       end
@@ -36,6 +40,15 @@ module Hanami
         # @since 0.7.0
         # @api private
         class CoercibleType < Dry::Types::Definition
+          # Wraps a given type, unless it already is a dry type
+          #
+          # @since x.x.x
+          # @api private
+          def self.wrap_unless_dry_type(type)
+            return type if type.is_a?(Dry::Types::Definition)
+            new(type)
+          end
+
           # Coerce given value into the wrapped object type
           #
           # @param value [Object] the value

--- a/test/entity/manual_schema_test.rb
+++ b/test/entity/manual_schema_test.rb
@@ -67,6 +67,21 @@ describe Hanami::Entity do
         end
       end
 
+      it 'coerces a single value' do
+        entity = described_class.new(owner: { name: 'L' })
+
+        entity.owner.must_be_kind_of(User)
+        entity.owner.name.must_equal 'L'
+      end
+
+      it 'accepts correct type for single value' do
+        user = User.new(name: 'L')
+        entity = described_class.new(owner: user)
+
+        entity.owner.must_be_kind_of(User)
+        entity.owner.name.must_equal user.name
+      end
+
       it 'raises error if initialized with wrong primitive' do
         exception = lambda do
           described_class.new(id: :foo)
@@ -110,7 +125,7 @@ describe Hanami::Entity do
       it 'returns nil if not present in attributes' do
         entity = described_class.new
 
-        entity.id.must_equal nil
+        assert_nil entity.id
       end
     end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -29,6 +29,7 @@ class Account < Hanami::Entity
     attribute :id,         Types::Strict::Int
     attribute :name,       Types::String
     attribute :codes,      Types::Collection(Types::Coercible::Int)
+    attribute :owner,      Types::Entity(User)
     attribute :users,      Types::Collection(User)
     attribute :email,      Types::String.constrained(format: /@/)
     attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })


### PR DESCRIPTION
This allows for Hanami::Entity being used in schema like:

```ruby
class Account < Hanami::User
end

class Account < Hanami::Entity
  attributes do
    attribute :owner, Types::Entity(User)
  end
end
```

`Types::Entity(User)` is new, it matches the `Types::Collection(User)`. Another solution would be to make `User` entity class compatible with dry types.

-----------------

I removed the part of the code which symbolizes both attributes for schemaless entities and entites with schema. Calling `symbolize!` on attributes returned by schema will call `to_hash` on the `User` which defeats the purpose of expressing that `owner` should be a User object. I'm not sure if I'm 100% happy with this change. The previous implementation made it clear when hash was symbolised, but I don't know if this is possible to do this simpler as long as Entity responds to `to_hash`. Keeping entities respond to `to_hash` makes them compatible to be used as data and passed to `repository#create/update` which I like.

I have no idea if this is the best fix and I guess you may want to solve this differently as my knowledge to Hanami Model as a whole is limited, so take this pull request more like a suggestion :-) I also suspect that this touches aspects which also must work when belongs to association is completed.

If this is merged it will close https://github.com/hanami/model/issues/356.