### PR TITLE
Added specs for relation read

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.0.0.beta1'
-  spec.add_runtime_dependency 'rom-sql',         '~> 0.9'
+  spec.add_runtime_dependency 'rom-sql',         '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'rom-repository',  '~> 0.3'
   spec.add_runtime_dependency 'dry-types',       '~> 0.9'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -64,10 +64,19 @@ describe 'Repository (base)' do
     end
   end
 
-  describe '#execute' do
-  end
+  describe 'relation' do
+    describe 'read' do
+      it 'reads records from the database given a raw query string' do
+        repository = UserRepository.new
+        repository.create(name: 'L')
 
-  describe '#fetch' do
+        users = repository.find_all_by_manual_query
+        users.must_be_kind_of(Array)
+
+        user = users.first
+        user.must_be_kind_of(User)
+      end
+    end
   end
 
   describe '#create' do

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -42,6 +42,10 @@ class UserRepository < Hanami::Repository
   def by_name(name)
     users.where(name: name).as(:entity)
   end
+
+  def find_all_by_manual_query
+    users.read("select * from users").as(:entity).to_a
+  end
 end
 
 class AvatarRepository < Hanami::Repository


### PR DESCRIPTION
This is a new feature introduced by `rom-sql` `0.9.1`, as result of the following discussions:

  * https://github.com/hanami/model/issues/351
  * https://github.com/hanami/model/pull/354
  * https://github.com/hanami/model/pull/342
  * https://github.com/hanami/model/issues/345

---

This feature allows to read entities starting from a raw query string (eg SQL).

Because it's exposed by ROM relations, the purpose of this PR is to add a unit test for it to prevent regressions.