### PR TITLE
Map rom/rom-sql exceptions and re-raise as hanami-model errors

### DIFF
--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -78,9 +78,12 @@ module Hanami
       repositories.each(&:load!)
 
       @container = ROM.container(configuration)
+
       configuration.define_entities_mappings(@container, repositories)
 
       @loaded = true
+    rescue => e
+      raise Hanami::Model::Error.for(e)
     end
   end
 end

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -88,5 +88,14 @@ module Hanami
         super
       end
     end
+
+    # Unknown database type error for repository auto-mapping
+    #
+    # @since x.x.x
+    class UnknownDatabaseTypeError < Error
+      def initialize(message)
+        super
+      end
+    end
   end
 end

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -93,9 +93,6 @@ module Hanami
     #
     # @since x.x.x
     class UnknownDatabaseTypeError < Error
-      def initialize(message)
-        super
-      end
     end
   end
 end

--- a/lib/hanami/model/sql.rb
+++ b/lib/hanami/model/sql.rb
@@ -145,6 +145,7 @@ module Hanami
     Error.register(ROM::SQL::UniqueConstraintError,     UniqueConstraintViolationError)
     Error.register(ROM::SQL::CheckConstraintError,      CheckConstraintViolationError)
     Error.register(ROM::SQL::ForeignKeyConstraintError, ForeignKeyConstraintViolationError)
+    Error.register(ROM::SQL::UnknownDBTypeError,        UnknownDatabaseTypeError)
 
     Error.register(Java::JavaSql::SQLException, DatabaseError) if Utils.jruby?
   end

--- a/test/hanami/model/load_test.rb
+++ b/test/hanami/model/load_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+describe "Hanami::Model.load!" do
+  it "raises unknown database error when repository automapping spots an unknown type" do
+    message = "Cannot find corresponding type for form"
+
+    ROM.stub :container, ->(*) { raise ROM::SQL::UnknownDBTypeError, message } do
+      exception = -> { Hanami::Model.load! }.must_raise(Hanami::Model::UnknownDatabaseTypeError)
+      exception.message.must_equal message
+    end
+  end
+end


### PR DESCRIPTION
As we are approaching 1.0, we want to provide a stable set of exceptions that developers can rescue and handle.

For this purpose we need to map ROM exceptions and re-raise as Hanami::Model errors.

Ref: https://github.com/hanami/model/issues/361