### PR TITLE
Introducing Configuration callbacks

### DIFF
--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -73,6 +73,7 @@ module Hanami
 
     # @since 0.1.0
     def self.load!(&blk) # rubocop:disable Metrics/AbcSize
+      configuration.run_before_callbacks
       configuration.setup.auto_registration(config.directory.to_s) unless config.directory.nil?
       configuration.instance_eval(&blk)                            if     block_given?
       repositories.each(&:load!)

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -23,6 +23,7 @@ module Hanami
         super(configurator.backend, configurator.url)
         @migrations   = configurator._migrations
         @schema       = configurator._schema
+        @callbacks    = configurator.callbacks
         @mappings     = {}
         @entities     = {}
       end
@@ -96,6 +97,14 @@ module Hanami
           entity   = r.entity
 
           entity.schema = Sql::Entity::Schema.new(entities, container.relations[relation], mappings.fetch(relation))
+        end
+      end
+
+      # @since x.x.x
+      # @api private
+      def run_before_callbacks
+        @callbacks[:before].each do |cb|
+          cb.call(connection)
         end
       end
     end

--- a/lib/hanami/model/configurator.rb
+++ b/lib/hanami/model/configurator.rb
@@ -25,10 +25,20 @@ module Hanami
       # @api private
       attr_reader :_schema
 
+      # @since x.x.x
+      # @api private
+      attr_reader :callbacks
+
       # @since 0.7.0
       # @api private
       def self.build(&block)
         new.tap { |config| config.instance_eval(&block) }
+      end
+
+      # @since x.x.x
+      # @api private
+      def initialize
+        @callbacks = Hash[before: [], after: []]
       end
 
       private
@@ -56,6 +66,12 @@ module Hanami
       # @api private
       def schema(path)
         @_schema = path
+      end
+
+      # @since x.x.x
+      # @api private
+      def before(&blk)
+        callbacks[:before] << blk
       end
     end
   end

--- a/test/fixtures/database_migrations/20170103142428_create_colors.rb
+++ b/test/fixtures/database_migrations/20170103142428_create_colors.rb
@@ -1,0 +1,22 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :postgresql
+      extension :pg_enum
+      create_enum :rainbow, %w(red orange yellow green blue indigo violet)
+
+      create_table :colors do
+        primary_key :id
+
+        column :name, :rainbow, null: false
+
+        column :created_at, DateTime, null: false
+        column :updated_at, DateTime, null: false
+      end
+    else
+      create_table :colors do
+        primary_key :id
+      end
+    end
+  end
+end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -534,6 +534,23 @@ describe 'Repository (base)' do
           found.must_equal(product)
         end
       end
+
+      describe 'enum database type' do
+        it 'allows to write data' do
+          repository = ColorRepository.new
+          color = repository.create(name: 'red')
+
+          color.must_be_kind_of(Color)
+          color.name.must_equal 'red'
+        end
+
+        it 'raises error if the value is not included in the enum' do
+          repository = ColorRepository.new
+
+          exception = -> { repository.create(name: 'grey') }.must_raise(Hanami::Model::Error)
+          exception.message.must_equal %("grey" (String) has invalid type for :name)
+        end
+      end
     end
   end
 end

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -42,6 +42,10 @@ module Database
   def self.engine
     ENV['HANAMI_DATABASE_TYPE'].to_sym
   end
+
+  def self.engine?(name)
+    engine == name.to_sym
+  end
 end
 
 Database::Setup.new.run

--- a/test/support/database/strategies/sql.rb
+++ b/test/support/database/strategies/sql.rb
@@ -20,6 +20,10 @@ module Database
           adapter    ENV['HANAMI_DATABASE_ADAPTER'].to_sym, ENV['HANAMI_DATABASE_URL']
           migrations Dir.pwd + '/test/fixtures/database_migrations'
           schema     Dir.pwd + '/tmp/schema.sql'
+
+          before do |connection|
+            connection.extension(:pg_enum) if Database.engine?(:postgresql)
+          end
         end
       end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -38,6 +38,9 @@ end
 class Product < Hanami::Entity
 end
 
+class Color < Hanami::Entity
+end
+
 class UserRepository < Hanami::Repository
   def by_name(name)
     users.where(name: name).as(:entity)
@@ -129,6 +132,9 @@ class WharehouseRepository < Hanami::Repository
 end
 
 class ProductRepository < Hanami::Repository
+end
+
+class ColorRepository < Hanami::Repository
 end
 
 Hanami::Model.load!


### PR DESCRIPTION
The goal is to provide access to the raw connection during the configuration setup.

In case of a SQL database, it returns a raw Sequel connection: eg. `Sequel::Postgres::Database`. It can be used to setup it (see #352) or to activate extensions.

Example:

```ruby
Hanami::Model.configure do
  adapter :sql, ENV['DATABASE_URL']

  before do |connection|
    connection.extension :pg_enum
  end
end
```

That `before` block will be yielded as first step during `Hanami::Model.load!`.

---

@hanami/core @hanami/issues @hanami/ecosystem @vladra @Moratorius @solnic @flash-gordon @AMHOL I'd love to hear your feedback.

---

Closes #352 
Closes #361 