### PR TITLE
Configuration gateway

### DIFF
--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -76,6 +76,7 @@ module Hanami
       configuration.gateway.use_logger(configuration.logger)       unless configuration.logger.nil?
       configuration.setup.auto_registration(config.directory.to_s) unless config.directory.nil?
       configuration.instance_eval(&blk)                            if     block_given?
+      configuration.configure_gateway
       repositories.each(&:load!)
 
       @container = ROM.container(configuration)

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -31,6 +31,7 @@ module Hanami
         super(configurator.backend, configurator.url)
         @migrations        = configurator._migrations
         @schema            = configurator._schema
+        @gateway_config    = configurator._gateway
         @logger            = configurator._logger
         @migrations_logger = configurator.migrations_logger
         @mappings          = {}
@@ -107,6 +108,12 @@ module Hanami
 
           entity.schema = Sql::Entity::Schema.new(entities, container.relations[relation], mappings.fetch(relation))
         end
+      end
+
+      # @since x.x.x
+      # @api private
+      def configure_gateway
+        @gateway_config.call(gateway)
       end
     end
   end

--- a/lib/hanami/model/configurator.rb
+++ b/lib/hanami/model/configurator.rb
@@ -29,6 +29,10 @@ module Hanami
       # @api private
       attr_reader :_logger
 
+      # @since x.x.x
+      # @api private
+      attr_reader :_gateway
+
       # @since 0.7.0
       # @api private
       def self.build(&block)
@@ -76,6 +80,12 @@ module Hanami
 
         opts = options.merge(stream: stream)
         @_logger = Hanami::Logger.new('hanami.model', opts)
+      end
+
+      # @since x.x.x
+      # @api private
+      def gateway(&blk)
+        @_gateway = blk
       end
     end
   end

--- a/test/fixtures/database_migrations/20170103142428_create_colors.rb
+++ b/test/fixtures/database_migrations/20170103142428_create_colors.rb
@@ -1,0 +1,22 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :postgresql
+      extension :pg_enum
+      create_enum :rainbow, %w(red orange yellow green blue indigo violet)
+
+      create_table :colors do
+        primary_key :id
+
+        column :name, :rainbow, null: false
+
+        column :created_at, DateTime, null: false
+        column :updated_at, DateTime, null: false
+      end
+    else
+      create_table :colors do
+        primary_key :id
+      end
+    end
+  end
+end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -535,5 +535,22 @@ describe 'Repository (base)' do
         end
       end
     end
+
+    describe 'enum database type' do
+      it 'allows to write data' do
+        repository = ColorRepository.new
+        color = repository.create(name: 'red')
+
+        color.must_be_kind_of(Color)
+        color.name.must_equal 'red'
+      end
+
+      it 'raises error if the value is not included in the enum' do
+        repository = ColorRepository.new
+
+        exception = -> { repository.create(name: 'grey') }.must_raise(Hanami::Model::Error)
+        exception.message.must_equal %("grey" (String) has invalid type for :name)
+      end
+    end
   end
 end

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -42,6 +42,10 @@ module Database
   def self.engine
     ENV['HANAMI_DATABASE_TYPE'].to_sym
   end
+
+  def self.engine?(name)
+    engine == name.to_sym
+  end
 end
 
 Database::Setup.new.run

--- a/test/support/database/strategies/sql.rb
+++ b/test/support/database/strategies/sql.rb
@@ -24,7 +24,7 @@ module Database
         ENV['HANAMI_DATABASE_LOGGER']  = logger.to_s
       end
 
-      def configure
+      def configure # rubocop:disable Metrics/AbcSize
         Hanami::Model.configure do
           adapter    ENV['HANAMI_DATABASE_ADAPTER'].to_sym, ENV['HANAMI_DATABASE_URL']
           logger     ENV['HANAMI_DATABASE_LOGGER'], level: :debug
@@ -32,6 +32,10 @@ module Database
           schema     Dir.pwd + '/tmp/schema.sql'
 
           migrations_logger ENV['HANAMI_DATABASE_LOGGER']
+
+          gateway do |g|
+            g.connection.extension(:pg_enum) if Database.engine?(:postgresql)
+          end
         end
       end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -38,6 +38,9 @@ end
 class Product < Hanami::Entity
 end
 
+class Color < Hanami::Entity
+end
+
 class UserRepository < Hanami::Repository
   def by_name(name)
     users.where(name: name).as(:entity)
@@ -129,6 +132,9 @@ class WharehouseRepository < Hanami::Repository
 end
 
 class ProductRepository < Hanami::Repository
+end
+
+class ColorRepository < Hanami::Repository
 end
 
 Hanami::Model.load!


### PR DESCRIPTION
The goal is to provide access to the gateway during the configuration setup, as discussed in #367 .

Example:

```ruby
Hanami::Model.configure do
  adapter :sql, ENV['DATABASE_URL']

  gateway do |g|
    g.connection.extension :pg_enum
  end
end
```

---

@hanami/core @hanami/issues @hanami/ecosystem @vladra @Moratorius @solnic @flash-gordon @AMHOL I'd love to hear your feedback.

---

Closes #352 
Closes #361 