### PR TITLE
Raise exception when Repository#find is used against a table w/o primary key

### DIFF
--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -94,5 +94,14 @@ module Hanami
     # @since x.x.x
     class UnknownDatabaseTypeError < Error
     end
+
+    # Unknown primary key error
+    #
+    # @since x.x.x
+    class UnknownPrimaryKeyError < Error
+      def initialize(relation)
+        super("Can't find primary key for `#{relation}' table")
+      end
+    end
   end
 end

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -151,7 +151,7 @@ module Hanami
     #
     # @since 0.7.0
     # @api private
-    def self.define_relation
+    def self.define_relation # rubocop:disable Metrics/MethodLength
       a = @associations
       s = @schema
 

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -151,19 +151,13 @@ module Hanami
     #
     # @since 0.7.0
     # @api private
-    def self.define_relation # rubocop:disable Metrics/MethodLength
+    def self.define_relation
       a = @associations
 
       configuration.relation(relation) do
         schema(infer: true) do
           associations(&a) unless a.nil?
         end
-
-        # rubocop:disable Lint/NestedMethodDefinition
-        def by_primary_key(id)
-          where(primary_key => id)
-        end
-        # rubocop:enable Lint/NestedMethodDefinition
       end
 
       relations(relation)
@@ -268,7 +262,7 @@ module Hanami
         class_attribute :relation
         self.relation = Model::RelationName.new(name)
 
-        commands :create, update: :by_primary_key, delete: :by_primary_key, mapper: MAPPER_NAME, use: COMMAND_PLUGINS
+        commands :create, update: :by_pk, delete: :by_pk, mapper: MAPPER_NAME, use: COMMAND_PLUGINS
         prepend Commands
       end
 
@@ -372,7 +366,7 @@ module Hanami
     #
     #   user       = repository.find(user.id)
     def find(id)
-      root.by_primary_key(id).as(:entity).one
+      root.by_pk(id).as(:entity).one unless id.nil?
     end
 
     # Return all the records for the relation

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -384,6 +384,9 @@ module Hanami
     #
     # @return [Hanami::Entity,NilClass] the entity, if found
     #
+    # @raise [Hanami::Model::UnknownPrimaryKeyError] if the table doesn't
+    #   define a primary key
+    #
     # @since 0.7.0
     #
     # @example
@@ -392,7 +395,9 @@ module Hanami
     #
     #   user       = repository.find(user.id)
     def find(id)
-      root.by_pk(id).as(:entity).one unless id.nil?
+      root.by_pk(id).as(:entity).one
+    rescue KeyError
+      raise Hanami::Model::UnknownPrimaryKeyError.new(self.class.relation)
     end
 
     # Return all the records for the relation

--- a/test/fixtures/database_migrations/20170124081339_create_labels.rb
+++ b/test/fixtures/database_migrations/20170124081339_create_labels.rb
@@ -1,0 +1,7 @@
+Hanami::Model.migration do
+  change do
+    create_table :labels do
+      column :id, Integer
+    end
+  end
+end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -36,28 +36,11 @@ describe 'Repository (base)' do
       let(:repository) { LabelRepository.new }
       let(:id)         { 1 }
 
-      it 'finds record by id' do
-        label = repository.create(id: id)
-        found = repository.find(id)
-
-        found.must_equal label
-      end
-
-      it 'returns nil when nil is given' do
+      it 'raises error' do
         repository.create(id: id)
-        found = repository.find(nil)
 
-        found.must_be_nil
-      end
-
-      it 'returns nil when nil is given and more than one records are in the table' do
-        (1..2).each do |id|
-          repository.create(id: id)
-        end
-
-        found = repository.find(nil)
-
-        found.must_be_nil
+        exception = -> { repository.find(id) }.must_raise(Hanami::Model::UnknownPrimaryKeyError)
+        exception.message.must_equal "Can't find primary key for `labels' table"
       end
     end
   end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -12,11 +12,53 @@ describe 'Repository (base)' do
       found.must_equal(user)
     end
 
+    it 'returns nil when nil is given' do
+      repository = UserRepository.new
+      repository.create(name: 'L')
+      found = repository.find(nil)
+
+      found.must_be_nil
+    end
+
     it 'returns nil for missing record' do
       repository = UserRepository.new
       found = repository.find('9999999')
 
       found.must_be_nil
+    end
+
+    # See https://github.com/hanami/model/issues/374
+    describe 'with non-autoincrement primary key' do
+      before do
+        repository.clear
+      end
+
+      let(:repository) { LabelRepository.new }
+      let(:id)         { 1 }
+
+      it 'finds record by id' do
+        label = repository.create(id: id)
+        found = repository.find(id)
+
+        found.must_equal label
+      end
+
+      it 'returns nil when nil is given' do
+        repository.create(id: id)
+        found = repository.find(nil)
+
+        found.must_be_nil
+      end
+
+      it 'returns nil when nil is given and more than one records are in the table' do
+        (1..2).each do |id|
+          repository.create(id: id)
+        end
+
+        found = repository.find(nil)
+
+        found.must_be_nil
+      end
     end
   end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -41,6 +41,9 @@ end
 class Color < Hanami::Entity
 end
 
+class Label < Hanami::Entity
+end
+
 class UserRepository < Hanami::Repository
   def by_name(name)
     users.where(name: name).as(:entity)
@@ -135,6 +138,9 @@ class ProductRepository < Hanami::Repository
 end
 
 class ColorRepository < Hanami::Repository
+end
+
+class LabelRepository < Hanami::Repository
 end
 
 Hanami::Model.load!


### PR DESCRIPTION
Raise `Hanami::Model::UnknownPrimaryKeyError` when `Repository#find` is used against a table w/o a primary key.

---

/cc @bbonislawski @beauby @solnic @hanami/issues for review.

Closes #374 
