### PR TITLE
ROM 3 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ unless ENV['TRAVIS']
 end
 
 gem 'hanami-utils', '~> 1.0.0.beta1', require: false, github: 'hanami/utils', branch: '1.0.x'
-gem 'sequel', git: 'https://github.com/jeremyevans/sequel.git', branch: 'master'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ unless ENV['TRAVIS']
 end
 
 gem 'hanami-utils', '~> 1.0.0.beta1', require: false, github: 'hanami/utils', branch: '1.0.x'
-gem 'sequel', github: 'jeremyevans/sequel'
+gem 'sequel', git: 'https://github.com/jeremyevans/sequel.git', branch: 'master'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_runtime_dependency 'hanami-utils',    '~> 1.0.0.beta1'
-  spec.add_runtime_dependency 'rom-sql',         '~> 0.9', '>= 0.9.1'
-  spec.add_runtime_dependency 'rom-repository',  '~> 0.3'
+  spec.add_runtime_dependency 'hanami-utils',    '~> 1.0.0.beta'
+  spec.add_runtime_dependency 'rom-sql',         '~> 1.0'
+  spec.add_runtime_dependency 'rom-repository',  '~> 1.0'
   spec.add_runtime_dependency 'dry-types',       '~> 0.9'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -72,20 +72,9 @@ module Hanami
     end
 
     # @since 0.1.0
-    def self.load!(&blk) # rubocop:disable Metrics/AbcSize
-      configuration.setup.auto_registration(config.directory.to_s) unless config.directory.nil?
-      configuration.instance_eval(&blk)                            if     block_given?
-      configuration.configure_gateway
-      repositories.each(&:load!)
-      configuration.logger = configuration.logger
-
-      @container = ROM.container(configuration)
-
-      configuration.define_entities_mappings(@container, repositories)
-
-      @loaded = true
-    rescue => e
-      raise Hanami::Model::Error.for(e)
+    def self.load!(&blk)
+      @container = configuration.load!(repositories, &blk)
+      @loaded    = true
     end
   end
 end

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -8,7 +8,7 @@ module Hanami
     # via `Hanami::Model.configure`.
     #
     # @since 0.2.0
-    class Configuration #< ROM::Configuration
+    class Configuration
       # @since 0.7.0
       # @api private
       attr_reader :mappings
@@ -30,7 +30,6 @@ module Hanami
       def initialize(configurator)
         @backend = configurator.backend
         @url = configurator.url
-        # super(configurator.backend, configurator.url)
         @migrations        = configurator._migrations
         @schema            = configurator._schema
         @gateway_config    = configurator._gateway
@@ -124,7 +123,7 @@ module Hanami
       end
 
       def rom
-        @rom ||= ROM::Configuration.new(@backend, @url)
+        @rom ||= ROM::Configuration.new(@backend, @url, infer_relations: false)
       end
 
       def load!(repositories, &blk) # rubocop:disable Metrics/AbcSize

--- a/lib/hanami/model/mapping.rb
+++ b/lib/hanami/model/mapping.rb
@@ -1,4 +1,4 @@
-require 'transproc'
+require 'transproc/all'
 
 module Hanami
   module Model
@@ -6,11 +6,19 @@ module Hanami
     #
     # @since 0.1.0
     class Mapping
+      extend Transproc::Registry
+
+      import Transproc::HashTransformations
+
       def initialize(&blk)
         @attributes   = {}
         @r_attributes = {}
         instance_eval(&blk)
-        @processor = @attributes.empty? ? ::Hash : Transproc(:rename_keys, @attributes)
+        @processor = @attributes.empty? ? ::Hash : t(:rename_keys, @attributes)
+      end
+
+      def t(name, *args)
+        self.class[name, *args]
       end
 
       def model(entity)

--- a/lib/hanami/model/plugins/schema.rb
+++ b/lib/hanami/model/plugins/schema.rb
@@ -15,7 +15,7 @@ module Hanami
           # @api private
           def initialize(relation, input)
             super
-            @schema = relation.schema_hash
+            @schema = relation.input_schema
           end
 
           # Processes the input

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -60,9 +60,10 @@ module Hanami
           #
           # @since 0.7.0
           # @api private
-          def self.coercible(type)
-            return type if type.constrained?
-            MAPPING.fetch(type.with(meta: {}), type)
+          def self.coercible(attribute)
+            return attribute if attribute.constrained?
+            # TODO: figure out a better way of inferring coercions from schema types
+            MAPPING.fetch(attribute.type.with(meta: {}), attribute)
           end
 
           # Coercer for SQL associations target

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -153,10 +153,15 @@ module Hanami
     # @api private
     def self.define_relation # rubocop:disable Metrics/MethodLength
       a = @associations
+      s = @schema
 
       configuration.relation(relation) do
-        schema(infer: true) do
-          associations(&a) unless a.nil?
+        if s.nil?
+          schema(infer: true) do
+            associations(&a) unless a.nil?
+          end
+        else
+          schema(&s)
         end
 
         # rubocop:disable Lint/NestedMethodDefinition
@@ -242,6 +247,10 @@ module Hanami
     #   end
     def self.mapping(&blk)
       @mapping = blk
+    end
+
+    def self.schema(&blk)
+      @schema = blk
     end
 
     # Define relations, mapping and associations

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -230,6 +230,27 @@ module Hanami
       @associations = blk
     end
 
+    # Declare database schema
+    #
+    # NOTE: This should be used **only** when Hanami can't find a corresponding Ruby type for your column.
+    #
+    # @since x.x.x
+    #
+    # @example
+    #   # In this example `name` is a PostgreSQL Enum type that we want to treat like a string.
+    #
+    #   class ColorRepository < Hanami::Repository
+    #     schema do
+    #       attribute :id,         Hanami::Model::Sql::Types::Int
+    #       attribute :name,       Hanami::Model::Sql::Types::String
+    #       attribute :created_at, Hanami::Model::Sql::Types::DateTime
+    #       attribute :updated_at, Hanami::Model::Sql::Types::DateTime
+    #     end
+    #   end
+    def self.schema(&blk)
+      @schema = blk
+    end
+
     # Declare mapping between database columns and entity's attributes
     #
     # NOTE: This should be used **only** when there is a name mismatch (eg. in legacy databases).
@@ -247,10 +268,6 @@ module Hanami
     #   end
     def self.mapping(&blk)
       @mapping = blk
-    end
-
-    def self.schema(&blk)
-      @schema = blk
     end
 
     # Define relations, mapping and associations

--- a/test/entity/automatic_schema_test.rb
+++ b/test/entity/automatic_schema_test.rb
@@ -58,14 +58,6 @@ describe Hanami::Entity do
         end
       end
 
-      it 'raises error if initialized with wrong primitive' do
-        exception = lambda do
-          described_class.new(id: :foo)
-        end.must_raise(ArgumentError)
-
-        exception.message.must_equal('comparison of Symbol with 0 failed')
-      end
-
       it 'raises error if initialized with wrong array object' do
         object    = Object.new
         exception = lambda do

--- a/test/fixtures/database_migrations/20150612081248_column_types.rb
+++ b/test/fixtures/database_migrations/20150612081248_column_types.rb
@@ -91,11 +91,13 @@ Hanami::Model.migration do
 
         column :money1, 'money'
 
-        column :enum1, 'mood'
+        # FIXME: enable again when rom-sql will support enums
+        # column :enum1, 'mood'
 
-        column :geometric1, 'point'
-        column :geometric2, 'line'
-        column :geometric3, 'circle', default: '<(15,15), 1>'
+        # FIXME: enable again when rom-sql will support geometric types
+        # column :geometric1, 'point'
+        # column :geometric2, 'line'
+        # column :geometric3, 'circle', default: '<(15,15), 1>'
 
         column :net1, 'cidr', default: '192.168/24'
 
@@ -106,7 +108,8 @@ Hanami::Model.migration do
         column :json1, 'json'
         column :json2, 'jsonb'
 
-        column :composite1, 'inventory_item', default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
+        # FIXME: enable again when rom-sql will custom types
+        # column :composite1, 'inventory_item', default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
       end
     when :mysql
       create_table :column_types do

--- a/test/fixtures/database_migrations/20150612081248_column_types.rb
+++ b/test/fixtures/database_migrations/20150612081248_column_types.rb
@@ -91,13 +91,11 @@ Hanami::Model.migration do
 
         column :money1, 'money'
 
-        # FIXME: enable again when rom-sql will support enums
-        # column :enum1, 'mood'
+        column :enum1, 'mood'
 
-        # FIXME: enable again when rom-sql will support geometric types
-        # column :geometric1, 'point'
-        # column :geometric2, 'line'
-        # column :geometric3, 'circle', default: '<(15,15), 1>'
+        column :geometric1, 'point'
+        column :geometric2, 'line'
+        column :geometric3, 'circle', default: '<(15,15), 1>'
 
         column :net1, 'cidr', default: '192.168/24'
 
@@ -108,8 +106,7 @@ Hanami::Model.migration do
         column :json1, 'json'
         column :json2, 'jsonb'
 
-        # FIXME: enable again when rom-sql will custom types
-        # column :composite1, 'inventory_item', default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
+        column :composite1, 'inventory_item', default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
       end
     when :mysql
       create_table :column_types do

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -547,9 +547,13 @@ describe 'Repository (base)' do
 
       it 'raises error if the value is not included in the enum' do
         repository = ColorRepository.new
+        message    = Platform.match do
+          engine(:ruby)  { %(PG::InvalidTextRepresentation: ERROR:  invalid input value for enum rainbow: "grey") }
+          engine(:jruby) { %(Java::OrgPostgresqlUtil::PSQLException: ERROR: invalid input value for enum rainbow: "grey") }
+        end
 
         exception = -> { repository.create(name: 'grey') }.must_raise(Hanami::Model::Error)
-        exception.message.must_equal %("grey" (String) has invalid type for :name)
+        exception.message.must_include message
       end
     end
   end

--- a/test/sql/entity/schema/automatic_test.rb
+++ b/test/sql/entity/schema/automatic_test.rb
@@ -30,14 +30,6 @@ describe Hanami::Model::Sql::Entity::Schema do
 
         result.must_equal({})
       end
-
-      it 'raises error if the process fails' do
-        exception = lambda do
-          subject.call(id: :foo)
-        end.must_raise(ArgumentError)
-
-        exception.message.must_equal 'comparison of Symbol with 0 failed'
-      end
     end
 
     describe '#attribute?' do

--- a/test/sql/entity/schema/mapping_test.rb
+++ b/test/sql/entity/schema/mapping_test.rb
@@ -28,14 +28,6 @@ describe Hanami::Model::Sql::Entity::Schema do
 
         result.must_equal({})
       end
-
-      it 'raises error if the process fails' do
-        exception = lambda do
-          subject.call(id: :foo)
-        end.must_raise(ArgumentError)
-
-        exception.message.must_equal 'comparison of Symbol with 0 failed'
-      end
     end
 
     describe '#attribute?' do

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -136,8 +136,10 @@ end
 
 class ColorRepository < Hanami::Repository
   schema do
-    attribute :id, Hanami::Model::Sql::Types::Int
-    attribute :name, Hanami::Model::Sql::Types::String
+    attribute :id,         Hanami::Model::Sql::Types::Int
+    attribute :name,       Hanami::Model::Sql::Types::String
+    attribute :created_at, Hanami::Model::Sql::Types::DateTime
+    attribute :updated_at, Hanami::Model::Sql::Types::DateTime
   end
 end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -135,6 +135,10 @@ class ProductRepository < Hanami::Repository
 end
 
 class ColorRepository < Hanami::Repository
+  schema do
+    attribute :id, Hanami::Model::Sql::Types::Int
+    attribute :name, Hanami::Model::Sql::Types::String
+  end
 end
 
 Hanami::Model.load!


### PR DESCRIPTION
This PR introduces compatibility with ROM 3 and an extra feature for Repository.

### Repository Schema

As of 0.7, the schema of a relation is auto inferred. That means if the database type is a Postgres `text`, the repository treat it as a Ruby `String`. There are some cases where the auto inferring fails because Hanami doesn't have a corresponding Ruby type.

For this problem we introduce `Repository.schema`.

Imagine we have a database table named `colors` which is defined like this:

```ruby
Hanami::Model.migration do
  change do
    extension :pg_enum
    create_enum :rainbow, %w(red orange yellow green blue indigo violet)

    create_table :colors do
      primary_key :id

      column :name, :rainbow, null: false

      column :created_at, DateTime, null: false
      column :updated_at, DateTime, null: false
    end
  end
end
```

Because we don't support PG enum yet, we can define the database schema for the repository, by using `Hanami::Model::Sql::Types::String` as Ruby type for it.

```ruby
class ColorRepository < Hanami::Repository
  schema do
    attribute :id,         Hanami::Model::Sql::Types::Int
    attribute :name,       Hanami::Model::Sql::Types::String
    attribute :created_at, Hanami::Model::Sql::Types::DateTime
    attribute :updated_at, Hanami::Model::Sql::Types::DateTime
  end
end
```