### PR TITLE
Introduce mapped relations to avoid ROM::Relation#as on repository queries

### DIFF
--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -186,7 +186,7 @@ module Hanami
         def _build_scope
           result = relation(target)
           result = result.where(foreign_key => subject.fetch(primary_key)) unless subject.nil?
-          result.as(Repository::MAPPER_NAME)
+          result.as(Model::MappedRelation.mapper_name)
         end
 
         # @since 0.7.0

--- a/lib/hanami/model/mapped_relation.rb
+++ b/lib/hanami/model/mapped_relation.rb
@@ -25,13 +25,8 @@ module Hanami
 
       # @since x.x.x
       # @api private
-      attr_reader :unmapped
-
-      # @since x.x.x
-      # @api private
       def initialize(relation)
-        @unmapped = relation
-        super(unmapped.as(self.class.mapper_name))
+        super(relation.as(self.class.mapper_name))
       end
     end
   end

--- a/lib/hanami/model/mapped_relation.rb
+++ b/lib/hanami/model/mapped_relation.rb
@@ -25,8 +25,13 @@ module Hanami
 
       # @since x.x.x
       # @api private
+      attr_reader :unmapped
+
+      # @since x.x.x
+      # @api private
       def initialize(relation)
-        super(relation.as(self.class.mapper_name))
+        @unmapped = relation
+        super(unmapped.as(self.class.mapper_name))
       end
     end
   end

--- a/lib/hanami/model/mapped_relation.rb
+++ b/lib/hanami/model/mapped_relation.rb
@@ -1,0 +1,33 @@
+module Hanami
+  module Model
+    # Mapped proxy for ROM relations.
+    #
+    # It eliminates the need of use #as for repository queries
+    #
+    # @since x.x.x
+    # @api private
+    class MappedRelation < SimpleDelegator
+      # Mapper name.
+      #
+      # With ROM mapping there is a link between the entity class and a generic
+      # reference for it. Example: <tt>BookRepository</tt> references <tt>Book</tt>
+      # as <tt>:entity</tt>.
+      #
+      # @since x.x.x
+      # @api private
+      MAPPER_NAME = :entity
+
+      # @since x.x.x
+      # @api private
+      def self.mapper_name
+        MAPPER_NAME
+      end
+
+      # @since x.x.x
+      # @api private
+      def initialize(relation)
+        super(relation.as(self.class.mapper_name))
+      end
+    end
+  end
+end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -514,6 +514,14 @@ describe 'Repository (base)' do
 
       found.to_a.must_include user
     end
+
+    it 'uses root relation' do
+      repository = UserRepository.new
+      user    = repository.create(name: 'L')
+      found   = repository.by_name_with_root('L')
+
+      found.to_a.must_include user
+    end
   end
 
   with_platform(db: :postgresql) do

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -514,14 +514,6 @@ describe 'Repository (base)' do
 
       found.to_a.must_include user
     end
-
-    it 'uses unmapped relation' do
-      repository = UserRepository.new
-      user    = repository.create(name: 'L')
-      found   = repository.by_name_with_unmapped_relation('L')
-
-      found.to_a.must_include user
-    end
   end
 
   with_platform(db: :postgresql) do

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -514,6 +514,14 @@ describe 'Repository (base)' do
 
       found.to_a.must_include user
     end
+
+    it 'uses unmapped relation' do
+      repository = UserRepository.new
+      user    = repository.create(name: 'L')
+      found   = repository.by_name_with_unmapped_relation('L')
+
+      found.to_a.must_include user
+    end
   end
 
   with_platform(db: :postgresql) do

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -49,6 +49,10 @@ class UserRepository < Hanami::Repository
     users.where(name: name)
   end
 
+  def by_name_with_unmapped_relation(name)
+    users.unmapped.where(name: name).as(:entity)
+  end
+
   def find_all_by_manual_query
     users.read("select * from users").to_a
   end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -49,6 +49,10 @@ class UserRepository < Hanami::Repository
     users.where(name: name)
   end
 
+  def by_name_with_root(name)
+    root.where(name: name).as(:entity)
+  end
+
   def find_all_by_manual_query
     users.read("select * from users").to_a
   end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -49,10 +49,6 @@ class UserRepository < Hanami::Repository
     users.where(name: name)
   end
 
-  def by_name_with_unmapped_relation(name)
-    users.unmapped.where(name: name).as(:entity)
-  end
-
   def find_all_by_manual_query
     users.read("select * from users").to_a
   end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -46,11 +46,11 @@ end
 
 class UserRepository < Hanami::Repository
   def by_name(name)
-    users.where(name: name).as(:entity)
+    users.where(name: name)
   end
 
   def find_all_by_manual_query
-    users.read("select * from users").as(:entity).to_a
+    users.read("select * from users").to_a
   end
 end
 


### PR DESCRIPTION
This is a proposal to eliminate the need of calling `#as` on the main relation of a repository.

### Before

```ruby
class UserRepository < Hanami::Repository
   def by_name(name)
      users.where(name: name).as(:entity)
   end
end
```

### After

```ruby
class UserRepository < Hanami::Repository
   def by_name(name)
      users.where(name: name)
   end
end
```

Please note that this works only on the **main relation** of a repository. For a given `UserRepository`, it works only for `#users`. All the other relations still need to use `#as`.

As you can see, this isn't a complete solution, but it covers the most common use case. Most of the times a repository uses its main relation.

For `hanami-model` 2.0 we can improve this implementation, by removing the proxy in favor of concrete relation classes.

---

/cc @beauby @choallin @hanami/issues @hanami/ecosystem @solnic @flash-gordon @AMHOL

Closes #343 