### PR TITLE
Username and Password detection

### DIFF
--- a/lib/hanami/model/migrator/connection.rb
+++ b/lib/hanami/model/migrator/connection.rb
@@ -83,7 +83,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def user
-          @user ||= parsed_opt('user') || raw.user
+          @user ||= parsed_opt('user') || parsed_uri.user
         end
 
         # Returns user from DB connection
@@ -93,7 +93,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def password
-          @password ||= parsed_opt('password') || raw.password
+          @password ||= parsed_opt('password') || parsed_uri.password
         end
 
         # Returns DB connection URI directly from adapter

--- a/lib/hanami/model/migrator/connection.rb
+++ b/lib/hanami/model/migrator/connection.rb
@@ -83,7 +83,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def user
-          @user ||= parsed_opt('user')
+          @user ||= parsed_opt('user') || raw.user
         end
 
         # Returns user from DB connection
@@ -93,7 +93,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def password
-          @password ||= parsed_opt('password')
+          @password ||= parsed_opt('password') || raw.password
         end
 
         # Returns DB connection URI directly from adapter

--- a/test/migrator/connection_test.rb
+++ b/test/migrator/connection_test.rb
@@ -4,27 +4,84 @@ require 'hanami/model/migrator/connection'
 describe Hanami::Model::Migrator::Connection do
   let(:connection) { Hanami::Model::Migrator::Connection.new(hanami_model_configuration) }
 
-  let(:hanami_model_configuration) do
-    OpenStruct.new(
-      url: 'postgresql://postgres:s3cr3T@127.0.0.1:5432/database'
-    )
-  end
-
-  describe '#jdbc?' do
-    it 'returns false' do
-      connection.jdbc?.must_equal false
+  describe 'when not a jdbc connection' do
+    let(:hanami_model_configuration) do
+      OpenStruct.new(
+        url: 'postgresql://postgres:s3cr3T@127.0.0.1:5432/database'
+      )
     end
-  end
 
-  describe '#global_uri' do
-    it 'returns connection URI without database' do
-      connection.global_uri.scan('database').empty?.must_equal true
+    describe '#jdbc?' do
+      it 'returns false' do
+        connection.jdbc?.must_equal false
+      end
     end
-  end
 
-  describe '#parsed_uri?' do
-    it 'returns an URI instance' do
-      connection.parsed_uri.must_be_kind_of URI
+    describe '#global_uri' do
+      it 'returns connection URI without database' do
+        connection.global_uri.scan('database').empty?.must_equal true
+      end
+    end
+
+    describe '#parsed_uri?' do
+      it 'returns an URI instance' do
+        connection.parsed_uri.must_be_kind_of URI
+      end
+    end
+
+    describe '#host' do
+      it 'returns configured host' do
+        connection.host.wont_equal nil
+        connection.host.must_equal '127.0.0.1'
+      end
+    end
+
+    describe '#port' do
+      it 'returns configured port' do
+        connection.port.wont_equal nil
+        connection.port.must_equal 5432
+      end
+    end
+
+    describe '#database' do
+      it 'returns configured database' do
+        connection.database.wont_equal nil
+        connection.database.must_equal 'database'
+      end
+    end
+
+    describe '#user' do
+      it 'returns configured user' do
+        connection.user.wont_equal nil
+        connection.user.must_equal 'postgres'
+      end
+
+      describe 'when there is no user option' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(url: 'postgresql://127.0.0.1:5432/database')
+        end
+
+        it 'returns nil' do
+          connection.user.must_equal nil
+        end
+      end
+    end
+
+    describe '#password' do
+      it 'returns configured password' do
+        connection.password.wont_equal nil
+        connection.password.must_equal 's3cr3T'
+      end
+
+      describe 'when there is no password option' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(url: 'postgresql://127.0.0.1/database')
+        end
+
+        it 'returns nil' do
+          connection.password.must_equal nil
+        end
+      end
     end
   end
 

--- a/test/migrator/connection_test.rb
+++ b/test/migrator/connection_test.rb
@@ -31,28 +31,24 @@ describe Hanami::Model::Migrator::Connection do
 
     describe '#host' do
       it 'returns configured host' do
-        connection.host.wont_equal nil
         connection.host.must_equal '127.0.0.1'
       end
     end
 
     describe '#port' do
       it 'returns configured port' do
-        connection.port.wont_equal nil
         connection.port.must_equal 5432
       end
     end
 
     describe '#database' do
       it 'returns configured database' do
-        connection.database.wont_equal nil
         connection.database.must_equal 'database'
       end
     end
 
     describe '#user' do
       it 'returns configured user' do
-        connection.user.wont_equal nil
         connection.user.must_equal 'postgres'
       end
 
@@ -69,7 +65,6 @@ describe Hanami::Model::Migrator::Connection do
 
     describe '#password' do
       it 'returns configured password' do
-        connection.password.wont_equal nil
         connection.password.must_equal 's3cr3T'
       end
 
@@ -100,21 +95,18 @@ describe Hanami::Model::Migrator::Connection do
 
     describe '#host' do
       it 'returns configured host' do
-        connection.host.wont_equal nil
         connection.host.must_equal '127.0.0.1'
       end
     end
 
     describe '#port' do
       it 'returns configured port' do
-        connection.port.wont_equal nil
         connection.port.must_equal 5432
       end
     end
 
     describe '#user' do
       it 'returns configured user' do
-        connection.user.wont_equal nil
         connection.user.must_equal 'postgres'
       end
 
@@ -131,7 +123,6 @@ describe Hanami::Model::Migrator::Connection do
 
     describe '#password' do
       it 'returns configured password' do
-        connection.password.wont_equal nil
         connection.password.must_equal 's3cr3T'
       end
 
@@ -148,7 +139,6 @@ describe Hanami::Model::Migrator::Connection do
 
     describe '#database' do
       it 'returns configured database' do
-        connection.database.wont_equal nil
         connection.database.must_equal 'database'
       end
     end


### PR DESCRIPTION
When not using JDBC the migrator was unable to find the username and password even if they where passed on the connection string. So for running migrations on Postgres for example, you'd need to pass a `PGUSER` env variable to set the username, even if it was already provided.

The issue arised from the fact that `Connection#user` only looked up to `Connection#parsed_opts` and didn't check the raw connection string or `Sequel::Connection` too.

Note: Yeah. I duplicated the jdbc tests on a non jdbc connection. I thought that it would be the best way to guarantee the same behaviour.