### PR TITLE
Fix error in `db console` command when scheme is postgresql

### DIFF
--- a/lib/hanami/model/sql/console.rb
+++ b/lib/hanami/model/sql/console.rb
@@ -27,7 +27,7 @@ module Hanami
           when 'sqlite'
             require 'hanami/model/sql/consoles/sqlite'
             Sql::Consoles::Sqlite.new(@uri)
-          when 'postgres'
+          when 'postgres', 'postgresql'
             require 'hanami/model/sql/consoles/postgresql'
             Sql::Consoles::Postgresql.new(@uri)
           when 'mysql', 'mysql2'

--- a/test/sql/console_test.rb
+++ b/test/sql/console_test.rb
@@ -16,6 +16,11 @@ describe Hanami::Model::Sql::Console do
         console = Hanami::Model::Sql::Console.new("postgres://#{uri}").send(:console)
         console.must_be_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
       end
+
+      it 'postgresql:// uri returns an instance of Console::Postgresql' do
+        console = Hanami::Model::Sql::Console.new("postgresql://#{uri}").send(:console)
+        console.must_be_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
+      end
     when :mysql
       it 'mysql:// uri returns an instance of Console::Mysql' do
         console = Hanami::Model::Sql::Console.new("mysql://#{uri}").send(:console)


### PR DESCRIPTION
Fixed error:
```
NoMethodError: undefined method `connection_string' for nil:NilClass
```