### PR TITLE
Introduce `Hanami::Model.disconnect`

### DIFF
--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -77,8 +77,27 @@ module Hanami
       @loaded    = true
     end
 
+    # Disconnect from the database
+    #
+    # This is useful for reboot applications in production and to ensure that
+    # the framework prunes stale connections.
+    #
     # @since x.x.x
-    # @api private
+    #
+    # @example With Full Stack Hanami Project
+    #   # config/puma.rb
+    #   # ...
+    #   on_worker_boot do
+    #     Hanami.boot
+    #   end
+    #
+    # @example With Standalone Hanami::Model
+    #   # config/puma.rb
+    #   # ...
+    #   on_worker_boot do
+    #     Hanami::Model.disconnect
+    #     Hanami::Model.load!
+    #   end
     def self.disconnect
       configuration.connection && configuration.connection.disconnect
     end

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -76,5 +76,11 @@ module Hanami
       @container = configuration.load!(repositories, &blk)
       @loaded    = true
     end
+
+    # @since x.x.x
+    # @api private
+    def self.disconnect
+      configuration.connection && configuration.connection.disconnect
+    end
   end
 end

--- a/test/hanami/model/disconnect_test.rb
+++ b/test/hanami/model/disconnect_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+# This test is tightly coupled to Sequel
+#
+# We should improve connection management via ROM
+describe "Hanami::Model.disconnect" do
+  before do
+    # warm up
+    connection[:users].to_a
+  end
+
+  let(:connection) { Hanami::Model.configuration.connection }
+
+  it "disconnects from database" do
+    # Sequel returns a collection of SQLite3::Database instances that were
+    # active and has been disconnected from the database
+    connections = Hanami::Model.disconnect
+    connections.size.must_equal 1
+
+    # If we don't hit the database, the next disconnection returns an empty set
+    # of SQLite3::Database
+    connections = Hanami::Model.disconnect
+    connections.size.must_equal 0
+
+    # If we try to use the database again, it's able to transparently reconnect
+    connection[:users].to_a.must_be_kind_of(Array)
+
+    # Now that we hit the database again, on this time the collection of
+    # disconnected SQLite3::Database instances has size of 1
+    connections = Hanami::Model.disconnect
+    connections.size.must_equal 1
+  end
+
+  it "doesn't disconnect from the database when not connected yet" do
+    Hanami::Model.configuration.stub(:connection, nil) do
+      Hanami::Model.disconnect.must_equal nil
+    end
+  end
+end


### PR DESCRIPTION
Safely disconnect from the database if there is any active connection.
When the application tries to access the database after the disconnection, it's able to transparently reconnect.

This is designed for rebooting apps in production