### PR TITLE
WIP: Add tests for table alterations

### DIFF
--- a/test/fixtures/database_migrations/20150612124205_table_alterations.rb
+++ b/test/fixtures/database_migrations/20150612124205_table_alterations.rb
@@ -1,72 +1,43 @@
 Hanami::Model.migration do
   change do
     case ENV['HANAMI_DATABASE_TYPE']
-    when 'sqlite'
-      create_table :songs do
-        column :title, String
-        column :useless, String
-
-        foreign_key :artist_id, :artists
-        index :artist_id
-
-        add_constraint(:useless_min_length) { char_length(useless) > 2 }
-      end
-
-      alter_table :songs do
-        add_primary_key :id
-
-        add_column      :downloads_count, Integer
-        set_column_type :useless,         File
-
-        rename_column :title, :primary_title
-        set_column_default :primary_title, 'Unknown title'
-
-        # add_index :album_id
-        # drop_index :artist_id
-
-        # add_foreign_key :album_id, :albums, on_delete: :cascade
-        # drop_foreign_key :artist_id
-
-        # add_constraint(:title_min_length) { char_length(title) > 2 }
-
-        # add_unique_constraint [:album_id, :title]
-
-        drop_constraint :useless_min_length
-        drop_column     :useless
-      end
     when 'postgresql'
-      create_table :songs do
-        column :title, String
-        column :useless, String
+      # Postgres needs to know how to cast String into File
+      execute "CREATE CAST (TEXT AS BYTEA) WITHOUT FUNCTION AS IMPLICIT;"
+    end
 
-        foreign_key :artist_id, :artists
-        index :artist_id
+    create_table :songs do
+      column :title, String
+      column :useless, String
+      column :cover, String
 
-        # add_constraint(:useless_min_length) { char_length(useless) > 2 }
-      end
+      foreign_key :artist_id, :artists
+      index :artist_id
 
-      alter_table :songs do
-        add_primary_key :id
+      constraint(:useless_min_length) { length(title) > 2 }
+    end
 
-        add_column    :downloads_count, Integer
-        # set_column_type :useless, File
+    alter_table :songs do
+      add_primary_key :id
 
-        rename_column :title, :primary_title
-        set_column_default :primary_title, 'Unknown title'
+      add_column      :downloads_count, Integer
+      set_column_type :cover,         File
 
-        # add_index :album_id
-        # drop_index :artist_id
+      rename_column :title, :primary_title
+      set_column_default :primary_title, 'Unknown title'
 
-        # add_foreign_key :album_id, :albums, on_delete: :cascade
-        # drop_foreign_key :artist_id
+      add_foreign_key :album_id, :albums, on_delete: :cascade
+      add_index :album_id
+      drop_index :artist_id
 
-        # add_constraint(:title_min_length) { char_length(title) > 2 }
+      drop_foreign_key :artist_id
 
-        # add_unique_constraint [:album_id, :title]
+      add_constraint(:title_min_length) { length(primary_title) > 2 }
 
-        # drop_constraint :useless_min_length
-        drop_column :useless
-      end
+      add_unique_constraint [:album_id, :primary_title]
+
+      drop_constraint :useless_min_length
+      drop_column     :useless
     end
   end
 end

--- a/test/fixtures/database_migrations/20150612124205_table_alterations.rb
+++ b/test/fixtures/database_migrations/20150612124205_table_alterations.rb
@@ -28,8 +28,8 @@ Hanami::Model.migration do
 
       add_foreign_key :album_id, :albums, on_delete: :cascade
       add_index :album_id
-      drop_index :artist_id
 
+      # drop_index :artist_id
       drop_foreign_key :artist_id
 
       add_constraint(:title_min_length) { length(primary_title) > 2 }

--- a/test/integration/migration/mysql.rb
+++ b/test/integration/migration/mysql.rb
@@ -455,6 +455,77 @@ describe 'MySQL' do
       # foreign_key.fetch(:on_delete).must_equal :cascade
     end
 
+    it 'alters table' do
+      table = @connection.schema(:songs)
+
+      name, options = table[0]
+      name.must_equal :primary_title
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        "Unknown title"
+      options.fetch(:type).must_equal           :string
+      options.fetch(:db_type).must_equal        'varchar(255)'
+      options.fetch(:primary_key).must_equal    false
+
+      name, options = table[1]
+      name.must_equal :cover
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :blob
+      options.fetch(:db_type).must_equal        'blob'
+      options.fetch(:primary_key).must_equal    false
+
+      indexes = @connection.indexes(:songs)
+
+      indexes.fetch(:songs_artist_id_index, nil).must_be_nil
+
+      index = indexes.fetch(:songs_album_id_index)
+      index.fetch(:unique).must_equal           false
+      index.fetch(:columns).must_equal          [:album_id]
+
+      name, options = table[2]
+      name.must_equal :id
+
+      options.fetch(:allow_null).must_equal     false
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'int(11)'
+      options.fetch(:primary_key).must_equal    true
+      options.fetch(:auto_increment).must_equal true
+
+      name, options = table[3]
+      name.must_equal :downloads_count
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'int(11)'
+      options.fetch(:primary_key).must_equal    false
+
+      name, options = table[4]
+      name.must_equal :album_id
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'int(11)'
+      options.fetch(:primary_key).must_equal    false
+
+      foreign_keys = @connection.foreign_key_list(:songs)
+      foreign_keys.length.must_equal 1
+      foreign_key = foreign_keys.last
+      foreign_key.fetch(:columns).must_equal   [:album_id]
+      foreign_key.fetch(:table).must_equal     :albums
+      foreign_key.fetch(:key).must_equal       [:id]
+      #foreign_key.fetch(:on_update).must_equal :no_action
+      #foreign_key.fetch(:on_delete).must_equal :cascade
+
+      @schema.read.must_include 'UNIQUE KEY `album_id` (`album_id`,`primary_title`)'
+      @schema.read.must_include 'CONSTRAINT title_min_length CHECK ((length(primary_title) > 2))'
+      @schema.read.wont_include 'CONSTRAINT useless_min_length'
+    end
+
     it 'defines column constraint and check'
     # it 'defines column constraint and check' do
     #   @schema.read.must_include %(CREATE TABLE `table_constraints` (`age` integer, `role` varchar(255), CONSTRAINT `age_constraint` CHECK (`age` > 18), CHECK (role IN("contributor", "manager", "owner")));)

--- a/test/integration/migration/postgresql.rb
+++ b/test/integration/migration/postgresql.rb
@@ -618,5 +618,75 @@ describe 'PostgreSQL' do
         actual.must_include %(CONSTRAINT table_constraints_role_check CHECK ((role = ANY (ARRAY['contributor'::text, 'manager'::text, 'owner'::text]))))
       end
     end
+
+    it 'alters table' do
+      table = @connection.schema(:songs)
+
+      name, options = table[0]
+      name.must_equal :primary_title
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        "'Unknown title'::text"
+      options.fetch(:type).must_equal           :string
+      options.fetch(:db_type).must_equal        'text'
+      options.fetch(:primary_key).must_equal    false
+
+      name, options = table[1]
+      name.must_equal :cover
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :blob
+      options.fetch(:db_type).must_equal        'bytea'
+      options.fetch(:primary_key).must_equal    false
+
+      indexes = @connection.indexes(:songs)
+
+      indexes.fetch(:songs_artist_id_index, nil).must_be_nil
+
+      index = indexes.fetch(:songs_album_id_index)
+      index.fetch(:unique).must_equal           false
+      index.fetch(:columns).must_equal          [:album_id]
+
+      name, options = table[2]
+      name.must_equal :id
+
+      options.fetch(:allow_null).must_equal     false
+      options.fetch(:default).must_equal        "nextval('songs_id_seq'::regclass)"
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'integer'
+      options.fetch(:primary_key).must_equal    true
+      options.fetch(:auto_increment).must_equal true
+
+      name, options = table[3]
+      name.must_equal :downloads_count
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'integer'
+      options.fetch(:primary_key).must_equal    false
+
+      name, options = table[4]
+      name.must_equal :album_id
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'integer'
+      options.fetch(:primary_key).must_equal    false
+
+      foreign_keys = @connection.foreign_key_list(:songs)
+      foreign_keys.length.must_equal 1
+      foreign_key = foreign_keys.last
+      foreign_key.fetch(:columns).must_equal   [:album_id]
+      foreign_key.fetch(:table).must_equal     :albums
+      foreign_key.fetch(:key).must_equal       [:id]
+      foreign_key.fetch(:on_update).must_equal :no_action
+      foreign_key.fetch(:on_delete).must_equal :cascade
+
+      @schema.read.must_include 'CONSTRAINT title_min_length CHECK ((length(primary_title) > 2))'
+      @schema.read.wont_include 'CONSTRAINT useless_min_length'
+    end
   end
 end

--- a/test/integration/migration/postgresql.rb
+++ b/test/integration/migration/postgresql.rb
@@ -685,6 +685,7 @@ describe 'PostgreSQL' do
       foreign_key.fetch(:on_update).must_equal :no_action
       foreign_key.fetch(:on_delete).must_equal :cascade
 
+      @schema.read.must_include 'ADD CONSTRAINT songs_album_id_primary_title_key UNIQUE (album_id, primary_title);'
       @schema.read.must_include 'CONSTRAINT title_min_length CHECK ((length(primary_title) > 2))'
       @schema.read.wont_include 'CONSTRAINT useless_min_length'
     end

--- a/test/integration/migration/sqlite.rb
+++ b/test/integration/migration/sqlite.rb
@@ -462,5 +462,75 @@ describe 'SQLite' do
     it 'defines column constraint and check' do
       @schema.read.must_include %(CREATE TABLE `table_constraints` (`age` integer, `role` varchar(255), CONSTRAINT `age_constraint` CHECK (`age` > 18), CHECK (role IN("contributor", "manager", "owner")));)
     end
+
+    it 'alters table' do
+      table = @connection.schema(:songs)
+
+      name, options = table[0]
+      name.must_equal :primary_title
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        "'Unknown title'"
+      options.fetch(:type).must_equal           :string
+      options.fetch(:db_type).must_equal        'varchar(255)'
+      options.fetch(:primary_key).must_equal    false
+
+      name, options = table[1]
+      name.must_equal :cover
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :blob
+      options.fetch(:db_type).must_equal        'blob'
+      options.fetch(:primary_key).must_equal    false
+
+      indexes = @connection.indexes(:songs)
+
+      indexes.fetch(:songs_artist_id_index, nil).must_be_nil
+
+      index = indexes.fetch(:songs_album_id_index)
+      index.fetch(:unique).must_equal           false
+      index.fetch(:columns).must_equal          [:album_id]
+
+      name, options = table[2]
+      name.must_equal :id
+
+      options.fetch(:allow_null).must_equal     false
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'integer'
+      options.fetch(:primary_key).must_equal    true
+      options.fetch(:auto_increment).must_equal true
+
+      name, options = table[3]
+      name.must_equal :downloads_count
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'integer'
+      options.fetch(:primary_key).must_equal    false
+
+      name, options = table[4]
+      name.must_equal :album_id
+
+      options.fetch(:allow_null).must_equal     true
+      options.fetch(:default).must_equal        nil
+      options.fetch(:type).must_equal           :integer
+      options.fetch(:db_type).must_equal        'integer'
+      options.fetch(:primary_key).must_equal    false
+
+      foreign_keys = @connection.foreign_key_list(:songs)
+      foreign_keys.length.must_equal 1
+      foreign_key = foreign_keys.last
+      foreign_key.fetch(:columns).must_equal   [:album_id]
+      foreign_key.fetch(:table).must_equal     :albums
+      foreign_key.fetch(:key).must_equal       nil
+      foreign_key.fetch(:on_update).must_equal :no_action
+      foreign_key.fetch(:on_delete).must_equal :cascade
+
+      #@schema.read.must_include 'CONSTRAINT title_min_length CHECK ((length(primary_title) > 2))'
+      #@schema.read.wont_include 'CONSTRAINT useless_min_length'
+    end
   end
 end

--- a/test/integration/migration/sqlite.rb
+++ b/test/integration/migration/sqlite.rb
@@ -529,6 +529,7 @@ describe 'SQLite' do
       foreign_key.fetch(:on_update).must_equal :no_action
       foreign_key.fetch(:on_delete).must_equal :cascade
 
+      #@schema.read.must_include 'ADD CONSTRAINT songs_album_id_primary_title_key UNIQUE (album_id, primary_title);'
       #@schema.read.must_include 'CONSTRAINT title_min_length CHECK ((length(primary_title) > 2))'
       #@schema.read.wont_include 'CONSTRAINT useless_min_length'
     end


### PR DESCRIPTION
In the process of trying to fix #387, I noticed that none of the [table alterations](test/fixtures/database_migrations/20150612124205_table_alterations.rb) migration was being tested. And there were commented out lines from that file.

This is a work in progress.

I need to get a MySQL server running locally so I can run those tests.

I have one test failing when I run the postgres tests (`DB=postgresql bundle exec rake test:integration`)
```
  1) Failure:
Hanami::Model.migration::PostgreSQL::columns#test_0002_defines column defaults [test/integration/migration/postgresql.rb:427]:
Expected: "'-1'::integer"
  Actual: "(-1)"
```
`"(-1)"` is what's [expected on linux, but not OS X](https://github.com/cllns/hanami-model/blob/ba298001512d65b7d145d98be2df54030bcdce60/test/integration/migration/postgresql.rb#L422-L425). It seems like we can possibly get rid of the per-platform expectation, which would be 💯 

I just upgraded to macOS Sierra (10.12.3), so I'm not sure if it's related to that. Travis runs on linux, not OS. Does anyone else have insight into that?


Also, the constraints are not being created on SQLite, as far as I can tell. Not sure if that's a bug in `hanami-model` or `sequel`, or just something SQLite doesn't support.


Also need to make sure I'm testing everything that happens in this migration. Let me know what you think.