### PR TITLE
Fix Minitest nil-comparison warnings

### DIFF
--- a/test/entity/automatic_schema_test.rb
+++ b/test/entity/automatic_schema_test.rb
@@ -79,7 +79,7 @@ describe Hanami::Entity do
       it 'returns nil if not present in attributes' do
         entity = described_class.new
 
-        entity.id.must_equal nil
+        entity.id.must_be_nil
       end
     end
 

--- a/test/entity/manual_schema_test.rb
+++ b/test/entity/manual_schema_test.rb
@@ -115,7 +115,7 @@ describe Hanami::Entity do
       it 'returns nil if not present in attributes' do
         entity = described_class.new
 
-        entity.id.must_equal nil
+        entity.id.must_be_nil
       end
     end
 

--- a/test/entity/schemaless_test.rb
+++ b/test/entity/schemaless_test.rb
@@ -51,7 +51,7 @@ describe Hanami::Entity do
       it 'returns nil if not present in attributes' do
         entity = described_class.new
 
-        entity.id.must_equal nil
+        entity.id.must_be_nil
       end
     end
 
@@ -65,13 +65,13 @@ describe Hanami::Entity do
       it 'returns nil for unknown methods' do
         entity = described_class.new
 
-        entity.foo.must_equal nil
+        entity.foo.must_be_nil
       end
 
       it 'returns nil for #attributes' do
         entity = described_class.new
 
-        entity.attributes.must_equal nil
+        entity.attributes.must_be_nil
       end
     end
 

--- a/test/hanami/model/disconnect_test.rb
+++ b/test/hanami/model/disconnect_test.rb
@@ -33,7 +33,7 @@ describe "Hanami::Model.disconnect" do
 
   it "doesn't disconnect from the database when not connected yet" do
     Hanami::Model.configuration.stub(:connection, nil) do
-      Hanami::Model.disconnect.must_equal nil
+      Hanami::Model.disconnect.must_be_nil
     end
   end
 end

--- a/test/integration/associations/has_many_test.rb
+++ b/test/integration/associations/has_many_test.rb
@@ -6,7 +6,7 @@ describe 'Associations (has_many)' do
     author = repository.create(name: 'L')
     found  = repository.find(author.id)
 
-    found.books.must_equal nil
+    found.books.must_be_nil
   end
 
   it 'preloads associated records' do

--- a/test/integration/migration/mysql.rb
+++ b/test/integration/migration/mysql.rb
@@ -13,7 +13,7 @@ describe 'MySQL' do
       name, options = table[0]
       name.must_equal :integer1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
@@ -22,7 +22,7 @@ describe 'MySQL' do
       name, options = table[1]
       name.must_equal :integer2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
@@ -31,7 +31,7 @@ describe 'MySQL' do
       name, options = table[2]
       name.must_equal :integer3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
@@ -40,7 +40,7 @@ describe 'MySQL' do
       name, options = table[3]
       name.must_equal :string1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(255)'
@@ -49,7 +49,7 @@ describe 'MySQL' do
       name, options = table[4]
       name.must_equal :string2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(3)'
@@ -58,7 +58,7 @@ describe 'MySQL' do
       name, options = table[5]
       name.must_equal :string5
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(50)'
@@ -68,7 +68,7 @@ describe 'MySQL' do
       name, options = table[6]
       name.must_equal :string6
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(255)'
@@ -77,7 +77,7 @@ describe 'MySQL' do
       name, options = table[7]
       name.must_equal :string7
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(64)'
@@ -87,7 +87,7 @@ describe 'MySQL' do
       name, options = table[8]
       name.must_equal :string8
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
@@ -96,7 +96,7 @@ describe 'MySQL' do
       name, options = table[9]
       name.must_equal :file1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
@@ -105,7 +105,7 @@ describe 'MySQL' do
       name, options = table[10]
       name.must_equal :file2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
@@ -114,7 +114,7 @@ describe 'MySQL' do
       name, options = table[11]
       name.must_equal :number1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
@@ -123,7 +123,7 @@ describe 'MySQL' do
       name, options = table[12]
       name.must_equal :number2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'bigint(20)'
@@ -132,7 +132,7 @@ describe 'MySQL' do
       name, options = table[13]
       name.must_equal :number3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :float
       options.fetch(:db_type).must_equal     'double'
@@ -141,7 +141,7 @@ describe 'MySQL' do
       name, options = table[14]
       name.must_equal :number4
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'decimal(10,0)'
@@ -150,7 +150,7 @@ describe 'MySQL' do
       name, options = table[15]
       name.must_equal :number5
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'decimal(10,0)'
@@ -159,7 +159,7 @@ describe 'MySQL' do
       name, options = table[16]
       name.must_equal :number6
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'decimal(10,2)'
@@ -168,7 +168,7 @@ describe 'MySQL' do
       name, options = table[17]
       name.must_equal :number7
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'decimal(10,0)'
@@ -177,7 +177,7 @@ describe 'MySQL' do
       name, options = table[18]
       name.must_equal :date1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :date
       options.fetch(:db_type).must_equal     'date'
@@ -186,7 +186,7 @@ describe 'MySQL' do
       name, options = table[19]
       name.must_equal :date2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'datetime'
@@ -195,7 +195,7 @@ describe 'MySQL' do
       name, options = table[20]
       name.must_equal :time1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'datetime'
@@ -204,7 +204,7 @@ describe 'MySQL' do
       name, options = table[21]
       name.must_equal :time2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :time
       options.fetch(:db_type).must_equal     'time'
@@ -213,7 +213,7 @@ describe 'MySQL' do
       name, options = table[22]
       name.must_equal :boolean1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'tinyint(1)'
@@ -222,7 +222,7 @@ describe 'MySQL' do
       name, options = table[23]
       name.must_equal :boolean2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'tinyint(1)'
@@ -375,7 +375,7 @@ describe 'MySQL' do
       name, options = table[0]
       name.must_equal :id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'int(11)'
@@ -427,7 +427,7 @@ describe 'MySQL' do
       name, options = table[0]
       name.must_equal :name
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :string
       options.fetch(:db_type).must_equal        'varchar(255)'
@@ -441,7 +441,7 @@ describe 'MySQL' do
       name, options = table[1]
       name.must_equal :artist_id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'int(11)'

--- a/test/integration/migration/mysql.rb
+++ b/test/integration/migration/mysql.rb
@@ -14,7 +14,7 @@ describe 'MySQL' do
       name.must_equal :integer1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
       options.fetch(:primary_key).must_equal false
@@ -23,7 +23,7 @@ describe 'MySQL' do
       name.must_equal :integer2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
       options.fetch(:primary_key).must_equal false
@@ -32,7 +32,7 @@ describe 'MySQL' do
       name.must_equal :integer3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
       options.fetch(:primary_key).must_equal false
@@ -41,7 +41,7 @@ describe 'MySQL' do
       name.must_equal :string1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(255)'
       options.fetch(:primary_key).must_equal false
@@ -50,7 +50,7 @@ describe 'MySQL' do
       name.must_equal :string2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(3)'
       options.fetch(:primary_key).must_equal false
@@ -59,7 +59,7 @@ describe 'MySQL' do
       name.must_equal :string5
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(50)'
       options.fetch(:max_length).must_equal  50
@@ -69,7 +69,7 @@ describe 'MySQL' do
       name.must_equal :string6
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(255)'
       options.fetch(:primary_key).must_equal false
@@ -78,7 +78,7 @@ describe 'MySQL' do
       name.must_equal :string7
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(64)'
       options.fetch(:max_length).must_equal  64
@@ -88,7 +88,7 @@ describe 'MySQL' do
       name.must_equal :string8
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
       options.fetch(:primary_key).must_equal false
@@ -97,7 +97,7 @@ describe 'MySQL' do
       name.must_equal :file1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
       options.fetch(:primary_key).must_equal false
@@ -106,7 +106,7 @@ describe 'MySQL' do
       name.must_equal :file2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
       options.fetch(:primary_key).must_equal false
@@ -115,7 +115,7 @@ describe 'MySQL' do
       name.must_equal :number1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'int(11)'
       options.fetch(:primary_key).must_equal false
@@ -124,7 +124,7 @@ describe 'MySQL' do
       name.must_equal :number2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'bigint(20)'
       options.fetch(:primary_key).must_equal false
@@ -133,7 +133,7 @@ describe 'MySQL' do
       name.must_equal :number3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :float
       options.fetch(:db_type).must_equal     'double'
       options.fetch(:primary_key).must_equal false
@@ -142,7 +142,7 @@ describe 'MySQL' do
       name.must_equal :number4
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'decimal(10,0)'
       options.fetch(:primary_key).must_equal false
@@ -151,7 +151,7 @@ describe 'MySQL' do
       name.must_equal :number5
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'decimal(10,0)'
       options.fetch(:primary_key).must_equal false
@@ -160,7 +160,7 @@ describe 'MySQL' do
       name.must_equal :number6
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'decimal(10,2)'
       options.fetch(:primary_key).must_equal false
@@ -169,7 +169,7 @@ describe 'MySQL' do
       name.must_equal :number7
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'decimal(10,0)'
       options.fetch(:primary_key).must_equal false
@@ -178,7 +178,7 @@ describe 'MySQL' do
       name.must_equal :date1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :date
       options.fetch(:db_type).must_equal     'date'
       options.fetch(:primary_key).must_equal false
@@ -187,7 +187,7 @@ describe 'MySQL' do
       name.must_equal :date2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'datetime'
       options.fetch(:primary_key).must_equal false
@@ -196,7 +196,7 @@ describe 'MySQL' do
       name.must_equal :time1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'datetime'
       options.fetch(:primary_key).must_equal false
@@ -205,7 +205,7 @@ describe 'MySQL' do
       name.must_equal :time2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :time
       options.fetch(:db_type).must_equal     'time'
       options.fetch(:primary_key).must_equal false
@@ -214,7 +214,7 @@ describe 'MySQL' do
       name.must_equal :boolean1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'tinyint(1)'
       options.fetch(:primary_key).must_equal false
@@ -223,7 +223,7 @@ describe 'MySQL' do
       name.must_equal :boolean2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'tinyint(1)'
       options.fetch(:primary_key).must_equal false
@@ -376,7 +376,7 @@ describe 'MySQL' do
       name.must_equal :id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'int(11)'
       options.fetch(:primary_key).must_equal    true
@@ -428,7 +428,7 @@ describe 'MySQL' do
       name.must_equal :name
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :string
       options.fetch(:db_type).must_equal        'varchar(255)'
       options.fetch(:primary_key).must_equal    true
@@ -442,7 +442,7 @@ describe 'MySQL' do
       name.must_equal :artist_id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'int(11)'
       options.fetch(:primary_key).must_equal    false

--- a/test/integration/migration/postgresql.rb
+++ b/test/integration/migration/postgresql.rb
@@ -13,7 +13,7 @@ describe 'PostgreSQL' do
       name, options = table[0]
       name.must_equal :integer1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -22,7 +22,7 @@ describe 'PostgreSQL' do
       name, options = table[1]
       name.must_equal :integer2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -31,7 +31,7 @@ describe 'PostgreSQL' do
       name, options = table[2]
       name.must_equal :integer3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -40,7 +40,7 @@ describe 'PostgreSQL' do
       name, options = table[3]
       name.must_equal :string1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
@@ -49,7 +49,7 @@ describe 'PostgreSQL' do
       name, options = table[4]
       name.must_equal :string2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
@@ -58,7 +58,7 @@ describe 'PostgreSQL' do
       name, options = table[5]
       name.must_equal :string3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character varying(1)'
@@ -67,7 +67,7 @@ describe 'PostgreSQL' do
       name, options = table[6]
       name.must_equal :string4
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character varying(2)'
@@ -76,7 +76,7 @@ describe 'PostgreSQL' do
       name, options = table[7]
       name.must_equal :string5
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(3)'
@@ -85,7 +85,7 @@ describe 'PostgreSQL' do
       name, options = table[8]
       name.must_equal :string6
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(4)'
@@ -94,7 +94,7 @@ describe 'PostgreSQL' do
       name, options = table[9]
       name.must_equal :string7
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character varying(50)'
@@ -104,7 +104,7 @@ describe 'PostgreSQL' do
       name, options = table[10]
       name.must_equal :string8
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(255)'
@@ -113,7 +113,7 @@ describe 'PostgreSQL' do
       name, options = table[11]
       name.must_equal :string9
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(64)'
@@ -123,7 +123,7 @@ describe 'PostgreSQL' do
       name, options = table[12]
       name.must_equal :string10
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
@@ -132,7 +132,7 @@ describe 'PostgreSQL' do
       name, options = table[13]
       name.must_equal :file1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'bytea'
@@ -141,7 +141,7 @@ describe 'PostgreSQL' do
       name, options = table[14]
       name.must_equal :file2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'bytea'
@@ -150,7 +150,7 @@ describe 'PostgreSQL' do
       name, options = table[15]
       name.must_equal :number1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -159,7 +159,7 @@ describe 'PostgreSQL' do
       name, options = table[16]
       name.must_equal :number2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'bigint'
@@ -168,7 +168,7 @@ describe 'PostgreSQL' do
       name, options = table[17]
       name.must_equal :number3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :float
       options.fetch(:db_type).must_equal     'double precision'
@@ -177,7 +177,7 @@ describe 'PostgreSQL' do
       name, options = table[18]
       name.must_equal :number4
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
@@ -186,7 +186,7 @@ describe 'PostgreSQL' do
       name, options = table[19]
       name.must_equal :number5
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10,0)'
@@ -195,7 +195,7 @@ describe 'PostgreSQL' do
       name, options = table[20]
       name.must_equal :number6
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10,2)'
@@ -204,7 +204,7 @@ describe 'PostgreSQL' do
       name, options = table[21]
       name.must_equal :number7
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
@@ -213,7 +213,7 @@ describe 'PostgreSQL' do
       name, options = table[22]
       name.must_equal :date1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :date
       options.fetch(:db_type).must_equal     'date'
@@ -222,7 +222,7 @@ describe 'PostgreSQL' do
       name, options = table[23]
       name.must_equal :date2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp without time zone'
@@ -231,7 +231,7 @@ describe 'PostgreSQL' do
       name, options = table[24]
       name.must_equal :time1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp without time zone'
@@ -240,7 +240,7 @@ describe 'PostgreSQL' do
       name, options = table[25]
       name.must_equal :time2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :time
       options.fetch(:db_type).must_equal     'time without time zone'
@@ -249,7 +249,7 @@ describe 'PostgreSQL' do
       name, options = table[26]
       name.must_equal :boolean1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
@@ -258,7 +258,7 @@ describe 'PostgreSQL' do
       name, options = table[27]
       name.must_equal :boolean2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
@@ -267,7 +267,7 @@ describe 'PostgreSQL' do
       name, options = table[28]
       name.must_equal :array1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer[]'
@@ -276,7 +276,7 @@ describe 'PostgreSQL' do
       name, options = table[29]
       name.must_equal :array2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer[]'
@@ -285,7 +285,7 @@ describe 'PostgreSQL' do
       name, options = table[30]
       name.must_equal :array3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text[]'
@@ -294,7 +294,7 @@ describe 'PostgreSQL' do
       name, options = table[31]
       name.must_equal :money1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :money
       options.fetch(:db_type).must_equal     'money'
@@ -303,7 +303,7 @@ describe 'PostgreSQL' do
       name, options = table[32]
       name.must_equal :enum1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :mood
       options.fetch(:db_type).must_equal     'mood'
@@ -312,7 +312,7 @@ describe 'PostgreSQL' do
       name, options = table[33]
       name.must_equal :geometric1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :point
       options.fetch(:db_type).must_equal     'point'
@@ -321,7 +321,7 @@ describe 'PostgreSQL' do
       name, options = table[34]
       name.must_equal :geometric2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :line
       options.fetch(:db_type).must_equal     'line'
@@ -357,7 +357,7 @@ describe 'PostgreSQL' do
       name, options = table[38]
       name.must_equal :xml1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :xml
       options.fetch(:db_type).must_equal     'xml'
@@ -366,7 +366,7 @@ describe 'PostgreSQL' do
       name, options = table[39]
       name.must_equal :json1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :json
       options.fetch(:db_type).must_equal     'json'
@@ -375,7 +375,7 @@ describe 'PostgreSQL' do
       name, options = table[40]
       name.must_equal :json2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :jsonb
       options.fetch(:db_type).must_equal     'jsonb'
@@ -558,7 +558,7 @@ describe 'PostgreSQL' do
       name, options = table[0]
       name.must_equal :group_id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
@@ -568,7 +568,7 @@ describe 'PostgreSQL' do
       name, options = table[1]
       name.must_equal :position
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
@@ -582,7 +582,7 @@ describe 'PostgreSQL' do
       name, options = table[0]
       name.must_equal :name
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :string
       options.fetch(:db_type).must_equal        'text'
@@ -596,7 +596,7 @@ describe 'PostgreSQL' do
       name, options = table[1]
       name.must_equal :artist_id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'

--- a/test/integration/migration/postgresql.rb
+++ b/test/integration/migration/postgresql.rb
@@ -14,7 +14,7 @@ describe 'PostgreSQL' do
       name.must_equal :integer1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -23,7 +23,7 @@ describe 'PostgreSQL' do
       name.must_equal :integer2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -32,7 +32,7 @@ describe 'PostgreSQL' do
       name.must_equal :integer3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -41,7 +41,7 @@ describe 'PostgreSQL' do
       name.must_equal :string1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
       options.fetch(:primary_key).must_equal false
@@ -50,7 +50,7 @@ describe 'PostgreSQL' do
       name.must_equal :string2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
       options.fetch(:primary_key).must_equal false
@@ -59,7 +59,7 @@ describe 'PostgreSQL' do
       name.must_equal :string3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character varying(1)'
       options.fetch(:primary_key).must_equal false
@@ -68,7 +68,7 @@ describe 'PostgreSQL' do
       name.must_equal :string4
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character varying(2)'
       options.fetch(:primary_key).must_equal false
@@ -77,7 +77,7 @@ describe 'PostgreSQL' do
       name.must_equal :string5
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(3)'
       options.fetch(:primary_key).must_equal false
@@ -86,7 +86,7 @@ describe 'PostgreSQL' do
       name.must_equal :string6
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(4)'
       options.fetch(:primary_key).must_equal false
@@ -95,7 +95,7 @@ describe 'PostgreSQL' do
       name.must_equal :string7
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character varying(50)'
       options.fetch(:max_length).must_equal  50
@@ -105,7 +105,7 @@ describe 'PostgreSQL' do
       name.must_equal :string8
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(255)'
       options.fetch(:primary_key).must_equal false
@@ -114,7 +114,7 @@ describe 'PostgreSQL' do
       name.must_equal :string9
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'character(64)'
       options.fetch(:max_length).must_equal  64
@@ -124,7 +124,7 @@ describe 'PostgreSQL' do
       name.must_equal :string10
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
       options.fetch(:primary_key).must_equal false
@@ -133,7 +133,7 @@ describe 'PostgreSQL' do
       name.must_equal :file1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'bytea'
       options.fetch(:primary_key).must_equal false
@@ -142,7 +142,7 @@ describe 'PostgreSQL' do
       name.must_equal :file2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'bytea'
       options.fetch(:primary_key).must_equal false
@@ -151,7 +151,7 @@ describe 'PostgreSQL' do
       name.must_equal :number1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -160,7 +160,7 @@ describe 'PostgreSQL' do
       name.must_equal :number2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'bigint'
       options.fetch(:primary_key).must_equal false
@@ -169,7 +169,7 @@ describe 'PostgreSQL' do
       name.must_equal :number3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :float
       options.fetch(:db_type).must_equal     'double precision'
       options.fetch(:primary_key).must_equal false
@@ -178,7 +178,7 @@ describe 'PostgreSQL' do
       name.must_equal :number4
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
       options.fetch(:primary_key).must_equal false
@@ -187,7 +187,7 @@ describe 'PostgreSQL' do
       name.must_equal :number5
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10,0)'
       options.fetch(:primary_key).must_equal false
@@ -196,7 +196,7 @@ describe 'PostgreSQL' do
       name.must_equal :number6
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10,2)'
       options.fetch(:primary_key).must_equal false
@@ -205,7 +205,7 @@ describe 'PostgreSQL' do
       name.must_equal :number7
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
       options.fetch(:primary_key).must_equal false
@@ -214,7 +214,7 @@ describe 'PostgreSQL' do
       name.must_equal :date1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :date
       options.fetch(:db_type).must_equal     'date'
       options.fetch(:primary_key).must_equal false
@@ -223,7 +223,7 @@ describe 'PostgreSQL' do
       name.must_equal :date2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp without time zone'
       options.fetch(:primary_key).must_equal false
@@ -232,7 +232,7 @@ describe 'PostgreSQL' do
       name.must_equal :time1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp without time zone'
       options.fetch(:primary_key).must_equal false
@@ -241,7 +241,7 @@ describe 'PostgreSQL' do
       name.must_equal :time2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :time
       options.fetch(:db_type).must_equal     'time without time zone'
       options.fetch(:primary_key).must_equal false
@@ -250,7 +250,7 @@ describe 'PostgreSQL' do
       name.must_equal :boolean1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
       options.fetch(:primary_key).must_equal false
@@ -259,7 +259,7 @@ describe 'PostgreSQL' do
       name.must_equal :boolean2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
       options.fetch(:primary_key).must_equal false
@@ -268,7 +268,7 @@ describe 'PostgreSQL' do
       name.must_equal :array1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer[]'
       options.fetch(:primary_key).must_equal false
@@ -277,7 +277,7 @@ describe 'PostgreSQL' do
       name.must_equal :array2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer[]'
       options.fetch(:primary_key).must_equal false
@@ -286,7 +286,7 @@ describe 'PostgreSQL' do
       name.must_equal :array3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text[]'
       options.fetch(:primary_key).must_equal false
@@ -295,7 +295,7 @@ describe 'PostgreSQL' do
       name.must_equal :money1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :money
       options.fetch(:db_type).must_equal     'money'
       options.fetch(:primary_key).must_equal false
@@ -304,7 +304,7 @@ describe 'PostgreSQL' do
       name.must_equal :enum1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :mood
       options.fetch(:db_type).must_equal     'mood'
       options.fetch(:primary_key).must_equal false
@@ -313,7 +313,7 @@ describe 'PostgreSQL' do
       name.must_equal :geometric1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :point
       options.fetch(:db_type).must_equal     'point'
       options.fetch(:primary_key).must_equal false
@@ -322,7 +322,7 @@ describe 'PostgreSQL' do
       name.must_equal :geometric2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :line
       options.fetch(:db_type).must_equal     'line'
       options.fetch(:primary_key).must_equal false
@@ -358,7 +358,7 @@ describe 'PostgreSQL' do
       name.must_equal :xml1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :xml
       options.fetch(:db_type).must_equal     'xml'
       options.fetch(:primary_key).must_equal false
@@ -367,7 +367,7 @@ describe 'PostgreSQL' do
       name.must_equal :json1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :json
       options.fetch(:db_type).must_equal     'json'
       options.fetch(:primary_key).must_equal false
@@ -376,7 +376,7 @@ describe 'PostgreSQL' do
       name.must_equal :json2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :jsonb
       options.fetch(:db_type).must_equal     'jsonb'
       options.fetch(:primary_key).must_equal false
@@ -559,7 +559,7 @@ describe 'PostgreSQL' do
       name.must_equal :group_id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    true
@@ -569,7 +569,7 @@ describe 'PostgreSQL' do
       name.must_equal :position
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    true
@@ -583,7 +583,7 @@ describe 'PostgreSQL' do
       name.must_equal :name
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :string
       options.fetch(:db_type).must_equal        'text'
       options.fetch(:primary_key).must_equal    true
@@ -597,7 +597,7 @@ describe 'PostgreSQL' do
       name.must_equal :artist_id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    false

--- a/test/integration/migration/sqlite.rb
+++ b/test/integration/migration/sqlite.rb
@@ -14,7 +14,7 @@ describe 'SQLite' do
       name.must_equal :integer1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -23,7 +23,7 @@ describe 'SQLite' do
       name.must_equal :integer2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -32,7 +32,7 @@ describe 'SQLite' do
       name.must_equal :integer3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -41,7 +41,7 @@ describe 'SQLite' do
       name.must_equal :string1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(255)'
       options.fetch(:primary_key).must_equal false
@@ -50,7 +50,7 @@ describe 'SQLite' do
       name.must_equal :string2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'string'
       options.fetch(:primary_key).must_equal false
@@ -59,7 +59,7 @@ describe 'SQLite' do
       name.must_equal :string3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'string'
       options.fetch(:primary_key).must_equal false
@@ -68,7 +68,7 @@ describe 'SQLite' do
       name.must_equal :string4
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(3)'
       options.fetch(:primary_key).must_equal false
@@ -77,7 +77,7 @@ describe 'SQLite' do
       name.must_equal :string5
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(50)'
       options.fetch(:max_length).must_equal  50
@@ -87,7 +87,7 @@ describe 'SQLite' do
       name.must_equal :string6
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(255)'
       options.fetch(:primary_key).must_equal false
@@ -96,7 +96,7 @@ describe 'SQLite' do
       name.must_equal :string7
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(64)'
       options.fetch(:max_length).must_equal  64
@@ -106,7 +106,7 @@ describe 'SQLite' do
       name.must_equal :string8
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
       options.fetch(:primary_key).must_equal false
@@ -115,7 +115,7 @@ describe 'SQLite' do
       name.must_equal :file1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
       options.fetch(:primary_key).must_equal false
@@ -124,7 +124,7 @@ describe 'SQLite' do
       name.must_equal :file2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
       options.fetch(:primary_key).must_equal false
@@ -133,7 +133,7 @@ describe 'SQLite' do
       name.must_equal :number1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
       options.fetch(:primary_key).must_equal false
@@ -142,7 +142,7 @@ describe 'SQLite' do
       name.must_equal :number2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'bigint'
       options.fetch(:primary_key).must_equal false
@@ -151,7 +151,7 @@ describe 'SQLite' do
       name.must_equal :number3
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :float
       options.fetch(:db_type).must_equal     'double precision'
       options.fetch(:primary_key).must_equal false
@@ -160,7 +160,7 @@ describe 'SQLite' do
       name.must_equal :number4
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
       options.fetch(:primary_key).must_equal false
@@ -169,7 +169,7 @@ describe 'SQLite' do
       name.must_equal :number5
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10)'
       options.fetch(:primary_key).must_equal false
@@ -178,7 +178,7 @@ describe 'SQLite' do
       name.must_equal :number6
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10, 2)'
       options.fetch(:primary_key).must_equal false
@@ -187,7 +187,7 @@ describe 'SQLite' do
       name.must_equal :number7
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
       options.fetch(:primary_key).must_equal false
@@ -196,7 +196,7 @@ describe 'SQLite' do
       name.must_equal :date1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :date
       options.fetch(:db_type).must_equal     'date'
       options.fetch(:primary_key).must_equal false
@@ -205,7 +205,7 @@ describe 'SQLite' do
       name.must_equal :date2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp'
       options.fetch(:primary_key).must_equal false
@@ -214,7 +214,7 @@ describe 'SQLite' do
       name.must_equal :time1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp'
       options.fetch(:primary_key).must_equal false
@@ -223,7 +223,7 @@ describe 'SQLite' do
       name.must_equal :time2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :time
       options.fetch(:db_type).must_equal     'time'
       options.fetch(:primary_key).must_equal false
@@ -232,7 +232,7 @@ describe 'SQLite' do
       name.must_equal :boolean1
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
       options.fetch(:primary_key).must_equal false
@@ -241,7 +241,7 @@ describe 'SQLite' do
       name.must_equal :boolean2
 
       options.fetch(:allow_null).must_equal  true
-      options.fetch(:default).must_equal     nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
       options.fetch(:primary_key).must_equal false
@@ -394,7 +394,7 @@ describe 'SQLite' do
       name.must_equal :id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    true
@@ -408,7 +408,7 @@ describe 'SQLite' do
       name.must_equal :group_id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    true
@@ -418,7 +418,7 @@ describe 'SQLite' do
       name.must_equal :position
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    true
@@ -432,7 +432,7 @@ describe 'SQLite' do
       name.must_equal :name
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :string
       options.fetch(:db_type).must_equal        'varchar(255)'
       options.fetch(:primary_key).must_equal    true
@@ -446,7 +446,7 @@ describe 'SQLite' do
       name.must_equal :artist_id
 
       options.fetch(:allow_null).must_equal     false
-      options.fetch(:default).must_equal        nil
+      options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
       options.fetch(:primary_key).must_equal    false
@@ -454,7 +454,7 @@ describe 'SQLite' do
       foreign_key = @connection.foreign_key_list(:albums).first
       foreign_key.fetch(:columns).must_equal   [:artist_id]
       foreign_key.fetch(:table).must_equal     :artists
-      foreign_key.fetch(:key).must_equal       nil
+      foreign_key.fetch(:key).must_be_nil
       foreign_key.fetch(:on_update).must_equal :no_action
       foreign_key.fetch(:on_delete).must_equal :cascade
     end

--- a/test/integration/migration/sqlite.rb
+++ b/test/integration/migration/sqlite.rb
@@ -13,7 +13,7 @@ describe 'SQLite' do
       name, options = table[0]
       name.must_equal :integer1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -22,7 +22,7 @@ describe 'SQLite' do
       name, options = table[1]
       name.must_equal :integer2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -31,7 +31,7 @@ describe 'SQLite' do
       name, options = table[2]
       name.must_equal :integer3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -40,7 +40,7 @@ describe 'SQLite' do
       name, options = table[3]
       name.must_equal :string1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(255)'
@@ -49,7 +49,7 @@ describe 'SQLite' do
       name, options = table[4]
       name.must_equal :string2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'string'
@@ -58,7 +58,7 @@ describe 'SQLite' do
       name, options = table[5]
       name.must_equal :string3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'string'
@@ -67,7 +67,7 @@ describe 'SQLite' do
       name, options = table[6]
       name.must_equal :string4
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(3)'
@@ -76,7 +76,7 @@ describe 'SQLite' do
       name, options = table[7]
       name.must_equal :string5
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'varchar(50)'
@@ -86,7 +86,7 @@ describe 'SQLite' do
       name, options = table[8]
       name.must_equal :string6
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(255)'
@@ -95,7 +95,7 @@ describe 'SQLite' do
       name, options = table[9]
       name.must_equal :string7
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'char(64)'
@@ -105,7 +105,7 @@ describe 'SQLite' do
       name, options = table[10]
       name.must_equal :string8
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :string
       options.fetch(:db_type).must_equal     'text'
@@ -114,7 +114,7 @@ describe 'SQLite' do
       name, options = table[11]
       name.must_equal :file1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
@@ -123,7 +123,7 @@ describe 'SQLite' do
       name, options = table[12]
       name.must_equal :file2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :blob
       options.fetch(:db_type).must_equal     'blob'
@@ -132,7 +132,7 @@ describe 'SQLite' do
       name, options = table[13]
       name.must_equal :number1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'integer'
@@ -141,7 +141,7 @@ describe 'SQLite' do
       name, options = table[14]
       name.must_equal :number2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :integer
       options.fetch(:db_type).must_equal     'bigint'
@@ -150,7 +150,7 @@ describe 'SQLite' do
       name, options = table[15]
       name.must_equal :number3
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :float
       options.fetch(:db_type).must_equal     'double precision'
@@ -159,7 +159,7 @@ describe 'SQLite' do
       name, options = table[16]
       name.must_equal :number4
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
@@ -168,7 +168,7 @@ describe 'SQLite' do
       name, options = table[17]
       name.must_equal :number5
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       # options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10)'
@@ -177,7 +177,7 @@ describe 'SQLite' do
       name, options = table[18]
       name.must_equal :number6
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric(10, 2)'
@@ -186,7 +186,7 @@ describe 'SQLite' do
       name, options = table[19]
       name.must_equal :number7
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :decimal
       options.fetch(:db_type).must_equal     'numeric'
@@ -195,7 +195,7 @@ describe 'SQLite' do
       name, options = table[20]
       name.must_equal :date1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :date
       options.fetch(:db_type).must_equal     'date'
@@ -204,7 +204,7 @@ describe 'SQLite' do
       name, options = table[21]
       name.must_equal :date2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp'
@@ -213,7 +213,7 @@ describe 'SQLite' do
       name, options = table[22]
       name.must_equal :time1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :datetime
       options.fetch(:db_type).must_equal     'timestamp'
@@ -222,7 +222,7 @@ describe 'SQLite' do
       name, options = table[23]
       name.must_equal :time2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :time
       options.fetch(:db_type).must_equal     'time'
@@ -231,7 +231,7 @@ describe 'SQLite' do
       name, options = table[24]
       name.must_equal :boolean1
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
@@ -240,7 +240,7 @@ describe 'SQLite' do
       name, options = table[25]
       name.must_equal :boolean2
 
-      options.fetch(:allow_null).must_equal  true
+      options.fetch(:allow_null).must_equal true
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal        :boolean
       options.fetch(:db_type).must_equal     'boolean'
@@ -393,7 +393,7 @@ describe 'SQLite' do
       name, options = table[0]
       name.must_equal :id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
@@ -407,7 +407,7 @@ describe 'SQLite' do
       name, options = table[0]
       name.must_equal :group_id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
@@ -417,7 +417,7 @@ describe 'SQLite' do
       name, options = table[1]
       name.must_equal :position
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'
@@ -431,7 +431,7 @@ describe 'SQLite' do
       name, options = table[0]
       name.must_equal :name
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :string
       options.fetch(:db_type).must_equal        'varchar(255)'
@@ -445,7 +445,7 @@ describe 'SQLite' do
       name, options = table[1]
       name.must_equal :artist_id
 
-      options.fetch(:allow_null).must_equal     false
+      options.fetch(:allow_null).must_equal false
       options.fetch(:default).must_be_nil
       options.fetch(:type).must_equal           :integer
       options.fetch(:db_type).must_equal        'integer'

--- a/test/migrator/connection_test.rb
+++ b/test/migrator/connection_test.rb
@@ -58,7 +58,7 @@ describe Hanami::Model::Migrator::Connection do
         end
 
         it 'returns nil' do
-          connection.user.must_equal nil
+          connection.user.must_be_nil
         end
       end
     end
@@ -74,7 +74,7 @@ describe Hanami::Model::Migrator::Connection do
         end
 
         it 'returns nil' do
-          connection.password.must_equal nil
+          connection.password.must_be_nil
         end
       end
     end
@@ -115,7 +115,7 @@ describe Hanami::Model::Migrator::Connection do
         end
 
         it 'raises an error' do
-          connection.port.must_equal nil
+          connection.port.must_be_nil
         end
       end
     end
@@ -157,7 +157,7 @@ describe Hanami::Model::Migrator::Connection do
         end
 
         it 'returns nil' do
-          connection.user.must_equal nil
+          connection.user.must_be_nil
         end
       end
     end
@@ -173,7 +173,7 @@ describe Hanami::Model::Migrator::Connection do
         end
 
         it 'returns nil' do
-          connection.password.must_equal nil
+          connection.password.must_be_nil
         end
       end
     end

--- a/test/migrator/mysql.rb
+++ b/test/migrator/mysql.rb
@@ -122,7 +122,7 @@ describe 'MySQL Database migrations' do
           name, options = table[0] # id
           name.must_equal :id
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'int(11)'
@@ -132,7 +132,7 @@ describe 'MySQL Database migrations' do
           name, options = table[1] # title
           name.must_equal :title
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'
@@ -179,7 +179,7 @@ describe 'MySQL Database migrations' do
           name, options = table[0] # id
           name.must_equal :id
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'int(11)'
@@ -189,7 +189,7 @@ describe 'MySQL Database migrations' do
           name, options = table[1] # title
           name.must_equal :title
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'

--- a/test/migrator/mysql.rb
+++ b/test/migrator/mysql.rb
@@ -123,7 +123,7 @@ describe 'MySQL Database migrations' do
           name.must_equal :id
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'int(11)'
           options.fetch(:primary_key).must_equal    true
@@ -133,7 +133,7 @@ describe 'MySQL Database migrations' do
           name.must_equal :title
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'
           options.fetch(:primary_key).must_equal    false
@@ -180,7 +180,7 @@ describe 'MySQL Database migrations' do
           name.must_equal :id
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'int(11)'
           options.fetch(:primary_key).must_equal    true
@@ -190,7 +190,7 @@ describe 'MySQL Database migrations' do
           name.must_equal :title
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'
           options.fetch(:primary_key).must_equal    false

--- a/test/migrator/postgresql.rb
+++ b/test/migrator/postgresql.rb
@@ -136,7 +136,7 @@ describe 'PostgreSQL Database migrations' do
           name.must_equal :title
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'text'
           options.fetch(:primary_key).must_equal    false
@@ -194,7 +194,7 @@ describe 'PostgreSQL Database migrations' do
           name.must_equal :title
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'text'
           options.fetch(:primary_key).must_equal    false

--- a/test/migrator/postgresql.rb
+++ b/test/migrator/postgresql.rb
@@ -135,7 +135,7 @@ describe 'PostgreSQL Database migrations' do
           name, options = table[1] # title
           name.must_equal :title
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'text'
@@ -193,7 +193,7 @@ describe 'PostgreSQL Database migrations' do
           name, options = table[1] # title
           name.must_equal :title
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'text'

--- a/test/migrator/sqlite.rb
+++ b/test/migrator/sqlite.rb
@@ -118,7 +118,7 @@ describe 'Filesystem SQLite Database migrations' do
           name.must_equal :id
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'integer'
           options.fetch(:primary_key).must_equal    true
@@ -128,7 +128,7 @@ describe 'Filesystem SQLite Database migrations' do
           name.must_equal :title
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'
           options.fetch(:primary_key).must_equal    false
@@ -175,7 +175,7 @@ describe 'Filesystem SQLite Database migrations' do
           name.must_equal :id
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'integer'
           options.fetch(:primary_key).must_equal    true
@@ -185,7 +185,7 @@ describe 'Filesystem SQLite Database migrations' do
           name.must_equal :title
 
           options.fetch(:allow_null).must_equal     false
-          options.fetch(:default).must_equal        nil
+          options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'
           options.fetch(:primary_key).must_equal    false

--- a/test/migrator/sqlite.rb
+++ b/test/migrator/sqlite.rb
@@ -117,7 +117,7 @@ describe 'Filesystem SQLite Database migrations' do
           name, options = table[0] # id
           name.must_equal :id
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'integer'
@@ -127,7 +127,7 @@ describe 'Filesystem SQLite Database migrations' do
           name, options = table[1] # title
           name.must_equal :title
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'
@@ -174,7 +174,7 @@ describe 'Filesystem SQLite Database migrations' do
           name, options = table[0] # id
           name.must_equal :id
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :integer
           options.fetch(:db_type).must_equal        'integer'
@@ -184,7 +184,7 @@ describe 'Filesystem SQLite Database migrations' do
           name, options = table[1] # title
           name.must_equal :title
 
-          options.fetch(:allow_null).must_equal     false
+          options.fetch(:allow_null).must_equal false
           options.fetch(:default).must_be_nil
           options.fetch(:type).must_equal           :string
           options.fetch(:db_type).must_equal        'varchar(255)'

--- a/test/sql/schema/array_test.rb
+++ b/test/sql/schema/array_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::Array do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_ary' do

--- a/test/sql/schema/bool_test.rb
+++ b/test/sql/schema/bool_test.rb
@@ -5,7 +5,7 @@ describe Hanami::Model::Sql::Types::Schema::Bool do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'returns true for true' do

--- a/test/sql/schema/date_test.rb
+++ b/test/sql/schema/date_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::Date do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_date' do

--- a/test/sql/schema/date_time_test.rb
+++ b/test/sql/schema/date_time_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::DateTime do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_datetime' do

--- a/test/sql/schema/decimal_test.rb
+++ b/test/sql/schema/decimal_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::Decimal do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_d' do

--- a/test/sql/schema/float_test.rb
+++ b/test/sql/schema/float_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::Float do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_f' do

--- a/test/sql/schema/hash_test.rb
+++ b/test/sql/schema/hash_test.rb
@@ -13,7 +13,7 @@ describe Hanami::Model::Sql::Types::Schema::Hash do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_hash' do

--- a/test/sql/schema/int_test.rb
+++ b/test/sql/schema/int_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::Int do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_int' do

--- a/test/sql/schema/string_test.rb
+++ b/test/sql/schema/string_test.rb
@@ -5,7 +5,7 @@ describe Hanami::Model::Sql::Types::Schema::String do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces string' do

--- a/test/sql/schema/time_test.rb
+++ b/test/sql/schema/time_test.rb
@@ -12,7 +12,7 @@ describe Hanami::Model::Sql::Types::Schema::Time do
 
   it 'returns nil for nil' do
     input = nil
-    described_class[input].must_equal input
+    described_class[input].must_be_nil
   end
 
   it 'coerces object that respond to #to_time' do


### PR DESCRIPTION
When running the test suite the output was littered with warnings from minitest. I tracked those down and fixed the issues.

Use of `must_equal` with `nil` resulted in the following warning:
```
Use assert_nil if expecting nil from `must_equal'. This will fail in MT6.
```