### PR TITLE
Symbolize entities with schema only shallow

### DIFF
--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -73,7 +73,7 @@ module Hanami
           if attributes.nil?
             {}
           else
-            attributes.dup
+            Utils::Hash.new(attributes.dup).deep_symbolize!
           end
         end
 
@@ -223,7 +223,7 @@ module Hanami
       def call(attributes)
         Utils::Hash.new(
           schema.call(attributes)
-        ).deep_symbolize!
+        ).symbolize!
       end
 
       # @since 0.7.0

--- a/lib/hanami/model/sql/entity/schema.rb
+++ b/lib/hanami/model/sql/entity/schema.rb
@@ -38,6 +38,24 @@ module Hanami
             freeze
           end
 
+          # Process attributes
+          #
+          # @param attributes [#to_hash] the attributes hash
+          #
+          # @raise [TypeError] if the process fails
+          #
+          # @since 1.0.1
+          # @api private
+          def call(attributes)
+            Utils::Hash.new(
+              schema.call(attributes)
+            ).deep_symbolize!
+          end
+
+          # @since 1.0.1
+          # @api private
+          alias [] call
+
           # Check if the attribute is known
           #
           # @param name [Symbol] the attribute name

--- a/test/entity/manual_schema_test.rb
+++ b/test/entity/manual_schema_test.rb
@@ -103,6 +103,31 @@ describe Hanami::Entity do
 
         exception.message.must_equal '"foo" (String) has invalid type for :code'
       end
+
+      it 'symbolizes nested hash keys according to schema' do
+        entity = PageVisit.new(
+          id: 42,
+          start: DateTime.now,
+          end: (Time.now + 53).to_datetime,
+          visitor: {
+            'user_agent' => 'w3m/0.5.3', 'language' => { 'en' => 0.9 }
+          },
+          page_info: {
+            'name' => 'landing page',
+            scroll_depth: 0.7,
+            'meta' => { 'version' => '0.8.3', updated_at: 1_492_769_467_000 }
+          }
+        )
+
+        entity.visitor.must_equal(
+          'user_agent' => 'w3m/0.5.3', 'language' => { 'en' => 0.9 }
+        )
+        entity.page_info.must_equal(
+          name: 'landing page',
+          scroll_depth: 0.7,
+          meta: { 'version' => '0.8.3', updated_at: 1_492_769_467_000 }
+        )
+      end
     end
 
     describe '#id' do

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -35,6 +35,20 @@ class Account < Hanami::Entity
   end
 end
 
+class PageVisit < Hanami::Entity
+  attributes do
+    attribute :id,        Types::Strict::Int
+    attribute :start,     Types::DateTime
+    attribute :end,       Types::DateTime
+    attribute :visitor,   Types::Hash
+    attribute :page_info, Types::Hash.symbolized(
+      name: Types::Coercible::String,
+      scroll_depth: Types::Coercible::Float,
+      meta: Types::Hash
+    )
+  end
+end
+
 class Product < Hanami::Entity
 end
 


### PR DESCRIPTION
See https://github.com/hanami/model/issues/394 for discussion.

Entities with inferred/automatic schema and entities without a schema deeply symbolise / hashify input values as before.
Manual schema however only performs shallow symbolising. It is now left to the user to ensure embedded types are correct (e.g., `Types::Hash.symbolize` for symbolized hashes).