### PR TITLE
Migrate to rspec 

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Lint/IneffectiveAccessModifier:
 Metrics/BlockLength:
   Exclude:
     - "test/**/*.rb" # Minitest syntax generates this false positive
+    - "spec/**/*.rb"
 Style/FileName:
   Enabled: false
 Style/GuardClause:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,7 @@ Style/MethodMissing:
   Enabled: false
 Style/PredicateName:
   Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/IndentHeredoc:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
-script: 'bundle exec rubocop && bundle exec rake test:coverage --trace'
+script: 'bundle exec rubocop && bundle exec rake spec:coverage --trace'
 after_script: 'echo `env`'
 before_install:
   - rvm @global do gem uninstall bundler -a -x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Hanami::Model
 A persistence layer for Hanami
 
+## v1.0.0.rc1 - 2017-03-31
+
 ## v1.0.0.beta3 - 2017-03-17
 ### Added
 - [Luca Guidi] Introduced `Hanami::Model.disconnect` to disconnect all the active database connections

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.0.0.beta1', require: false, github: 'hanami/utils', branch: '1.0.x'
+gem 'hanami-utils', '~> 1.0.0.rc1', require: false, github: 'hanami/utils', branch: '1.0.x'
 
 platforms :ruby do
   gem 'sqlite3', require: false
@@ -20,6 +20,6 @@ platforms :jruby do
   gem 'jdbc-mysql',    require: false
 end
 
-gem 'simplecov',          require: false
-gem 'coveralls',          require: false
-gem 'rubocop', '~> 0.45', require: false
+gem 'simplecov',         require: false
+gem 'coveralls',         require: false
+gem 'rubocop', '0.48.0', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rake'
 require 'rake/testtask'
 require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
@@ -24,21 +25,18 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-namespace :test do
+namespace :spec do
+  RSpec::Core::RakeTask.new(:unit) do |task|
+    file_list = FileList['spec/**/*_spec.rb']
+    file_list = file_list.exclude("spec/{integration,isolation}/**/*_spec.rb")
+
+    task.pattern = file_list
+  end
+
   task :coverage do
     ENV['COVERAGE'] = 'true'
-    Rake::Task['test'].invoke
-  end
-
-  desc 'Runs only unit tests'
-  task :unit do
-    Rake::Task['unit'].invoke
-  end
-
-  desc 'Run only integration tests'
-  task :integration do
-    Rake::Task['integration'].invoke
+    Rake::Task['spec:unit'].invoke
   end
 end
 
-task default: :test
+task default: 'spec:unit'

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_runtime_dependency 'hanami-utils',    '~> 1.0.0.beta'
+  spec.add_runtime_dependency 'hanami-utils',    '~> 1.0.0.rc1'
   spec.add_runtime_dependency 'rom-sql',         '~> 1.1'
   spec.add_runtime_dependency 'rom-repository',  '~> 1.2'
   spec.add_runtime_dependency 'dry-types',       '~> 0.9'

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hanami/model/version'

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -6,8 +6,8 @@ require 'hanami/model/version'
 Gem::Specification.new do |spec|
   spec.name          = 'hanami-model'
   spec.version       = Hanami::Model::VERSION
-  spec.authors       = ['Luca Guidi', 'Trung Lê', 'Alfonso Uceda']
-  spec.email         = ['me@lucaguidi.com', 'trung.le@ruby-journal.com', 'uceda73@gmail.com']
+  spec.authors       = ['Luca Guidi']
+  spec.email         = ['me@lucaguidi.com']
   spec.summary       = 'A persistence layer for Hanami'
   spec.description   = 'A persistence framework with entities and repositories'
   spec.homepage      = 'http://hanamirb.org'

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler',  '~> 1.6'
   spec.add_development_dependency 'minitest', '~> 5'
   spec.add_development_dependency 'rake',     '~> 11'
+  spec.add_development_dependency 'rspec', '~> 3.5'
 end

--- a/lib/hanami/model/version.rb
+++ b/lib/hanami/model/version.rb
@@ -3,6 +3,6 @@ module Hanami
     # Defines the version
     #
     # @since 0.1.0
-    VERSION = '1.0.0.beta3'.freeze
+    VERSION = '1.0.0.rc1'.freeze
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Configuration do
+  before do
+    database_directory = Pathname.pwd.join('tmp', 'db')
+    database_directory.join('migrations').mkpath
+
+    FileUtils.touch database_directory.join('schema.sql')
+  end
+
+  let(:subject) { Hanami::Model::Configuration.new(configurator) }
+
+  let(:configurator) do
+    adapter_url = url
+
+    Hanami::Model::Configurator.build do
+      adapter :sql, adapter_url
+
+      migrations 'tmp/db/migrations'
+      schema     'tmp/db/schema.sql'
+    end
+  end
+
+  let(:url) do
+    db = 'tmp/db/bookshelf.sqlite'
+
+    Platform.match do
+      engine(:ruby)  { "sqlite://#{db}" }
+      engine(:jruby) { "jdbc:sqlite://#{db}" }
+    end
+  end
+
+  describe '#url' do
+    it 'equals to the configured url' do
+      expect(subject.url).to eq(url)
+    end
+  end
+
+  describe '#connection' do
+    it 'returns a raw connection aganist the database' do
+      connection = subject.connection
+
+      expect(connection).to be_a_kind_of(Sequel::Database)
+      expect(connection.url).to eq(url)
+    end
+  end
+
+  describe '#gateway' do
+    it 'returns default ROM gateway' do
+      gateway = subject.gateway
+
+      expect(gateway).to be_a_kind_of(ROM::Gateway)
+      expect(gateway.connection).to eq(subject.connection)
+    end
+  end
+
+  describe '#root' do
+    it 'returns current directory' do
+      expect(subject.root).to eq(Pathname.pwd)
+    end
+  end
+
+  describe '#migrations' do
+    it 'returns path to migrations' do
+      expected = subject.root.join('tmp', 'db', 'migrations')
+
+      expect(subject.migrations).to eq(expected)
+    end
+  end
+
+  describe '#schema' do
+    it 'returns path to database schema' do
+      expected = subject.root.join('tmp', 'db', 'schema.sql')
+
+      expect(subject.schema).to eq(expected)
+    end
+  end
+end

--- a/spec/entity/automatic_schema_spec.rb
+++ b/spec/entity/automatic_schema_spec.rb
@@ -1,0 +1,160 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Entity do
+  describe 'automatic schema' do
+    let(:described_class) { Author }
+
+    let(:input) do
+      Class.new do
+        def to_hash
+          Hash[id: 1]
+        end
+      end.new
+    end
+
+    describe '#initialize' do
+      it 'can be instantiated without attributes' do
+        entity = described_class.new
+
+        expect(entity).to be_a_kind_of(described_class)
+      end
+
+      it 'accepts a hash' do
+        entity = described_class.new(id: 1, name: 'Luca', books: books = [Book.new], created_at: now = Time.now.utc)
+
+        expect(entity.id).to eq(1)
+        expect(entity.name).to eq('Luca')
+        expect(entity.books).to eq(books)
+        expect(entity.created_at).to be_within(2).of(now)
+      end
+
+      it 'accepts object that implements #to_hash' do
+        entity = described_class.new(input)
+
+        expect(entity.id).to eq(1)
+      end
+
+      it 'freezes the intance' do
+        entity = described_class.new
+
+        expect(entity).to be_frozen
+      end
+
+      it 'coerces values' do
+        now = Time.now
+        entity = described_class.new(created_at: now.to_s)
+
+        expect(entity.created_at).to be_within(2).of(now)
+      end
+
+      it 'coerces values for array of objects' do
+        entity = described_class.new(books: books = [{ title: 'TDD' }, { title: 'Refactoring' }])
+
+        books.each_with_index do |book, i|
+          b = entity.books[i]
+
+          expect(b).to be_a_kind_of(Book)
+          expect(b.title).to eq(book.fetch(:title))
+        end
+      end
+
+      it 'raises error if initialized with wrong array object' do
+        object = Object.new
+        expect { described_class.new(books: [object]) }.to raise_error do |error|
+          expect(error).to be_a(TypeError)
+          expect(error.message).to include('[#<Object:0x')
+          expect(error.message).to include('>] (Array) has invalid type for :books')
+        end
+      end
+    end
+
+    describe '#id' do
+      it 'returns the value' do
+        entity = described_class.new(id: 1)
+
+        expect(entity.id).to eq(1)
+      end
+
+      it 'returns nil if not present in attributes' do
+        entity = described_class.new
+
+        expect(entity.id).to be_nil
+      end
+    end
+
+    describe 'accessors' do
+      it 'exposes accessors from schema' do
+        entity = described_class.new(name: 'Luca')
+
+        expect(entity.name).to eq('Luca')
+      end
+
+      it 'raises error for unknown methods' do
+        entity = described_class.new
+
+        expect { entity.foo }
+          .to raise_error(NoMethodError, /undefined method `foo'/)
+      end
+
+      it 'raises error when #attributes is invoked' do
+        entity = described_class.new
+
+        expect { entity.attributes }
+          .to raise_error(NoMethodError, /private method `attributes' called for #<Author/)
+      end
+    end
+
+    describe '#to_h' do
+      it 'serializes attributes into hash' do
+        entity = described_class.new(id: 1, name: 'Luca')
+
+        expect(entity.to_h).to eq(Hash[id: 1, name: 'Luca'])
+      end
+
+      it 'must be an instance of ::Hash' do
+        entity = described_class.new
+
+        expect(entity.to_h).to be_an_instance_of(::Hash)
+      end
+
+      it 'ignores unknown attributes' do
+        entity = described_class.new(foo: 'bar')
+
+        expect(entity.to_h).to eq(Hash[])
+      end
+
+      it 'prevents information escape' do
+        entity = described_class.new(books: books = [Book.new(id: 1), Book.new(id: 2)])
+
+        entity.to_h[:books].reverse!
+        expect(entity.books).to eq(books)
+      end
+
+      it 'is aliased as #to_hash' do
+        entity = described_class.new(name: 'Luca')
+
+        expect(entity.to_hash).to eq(entity.to_h)
+      end
+    end
+
+    describe '#respond_to?' do
+      it 'returns ture for id' do
+        entity = described_class.new
+
+        expect(entity).to respond_to(:id)
+      end
+
+      it 'returns true for methods with the same name of attributes defined by schema' do
+        entity = described_class.new
+
+        expect(entity).to respond_to(:name)
+      end
+
+      it 'returns false for methods not in the set of attributes defined by schema' do
+        entity = described_class.new(foo: 'bar')
+
+        expect(entity).to_not respond_to(:foo)
+      end
+    end
+  end
+end

--- a/spec/entity/manual_schema_spec.rb
+++ b/spec/entity/manual_schema_spec.rb
@@ -1,0 +1,184 @@
+require 'test_helper'
+
+describe Hanami::Entity do
+  describe 'manual schema' do
+    let(:described_class) { Account }
+
+    let(:input) do
+      Class.new do
+        def to_hash
+          Hash[id: 1]
+        end
+      end.new
+    end
+
+    describe '#initialize' do
+      it 'can be instantiated without attributes' do
+        entity = described_class.new
+
+        expect(entity).to be_a_kind_of(described_class)
+      end
+
+      it 'accepts a hash' do
+        entity = described_class.new(id: 1, users: users = [User.new], name: 'Acme Inc.', codes: [1, 2, 3], email: 'account@acme-inc.test', created_at: now = DateTime.now)
+
+        expect(entity.id).to eq(1)
+        expect(entity.name).to eq('Acme Inc.')
+        expect(entity.users).to eq(users)
+        expect(entity.codes).to eq([1, 2, 3])
+        expect(entity.email).to eq('account@acme-inc.test')
+        expect(entity.created_at).to be_within(1).of(now)
+      end
+
+      it 'accepts object that implements #to_hash' do
+        entity = described_class.new(input)
+
+        expect(entity.id).to eq(1)
+      end
+
+      it 'freezes the intance' do
+        entity = described_class.new
+
+        expect(entity).to be_frozen
+      end
+
+      it 'coerces values' do
+        now = DateTime.now
+        entity = described_class.new(created_at: now.to_s)
+
+        expect(entity.created_at).to be_a_kind_of(DateTime)
+        expect(entity.created_at).to be_within(1).of(now)
+      end
+
+      it 'coerces values for array of primitives' do
+        entity = described_class.new(codes: %w(4 5 6))
+
+        expect(entity.codes).to eq([4, 5, 6])
+      end
+
+      it 'coerces values for array of objects' do
+        entity = described_class.new(users: users = [{ name: 'L' }, { name: 'MG' }])
+
+        users.each_with_index do |user, i|
+          u = entity.users[i]
+
+          expect(u).to be_a_kind_of(User)
+          expect(u.name).to eq(user.fetch(:name))
+        end
+      end
+
+      it 'raises error if initialized with wrong primitive' do
+        expect { described_class.new(id: :foo) }
+          .to raise_error(TypeError, ':foo (Symbol) has invalid type for :id')
+      end
+
+      it 'raises error if initialized with wrong array primitive' do
+        message = Platform.match do
+          engine(:jruby) { "no implicit conversion of Object into Integer" }
+          default        { "can't convert Object into Integer" }
+        end
+
+        expect { described_class.new(codes: [Object.new]) }.to raise_error(TypeError, message)
+      end
+
+      it "raises error if type constraint isn't honored" do
+        expect { described_class.new(email: 'test') }
+          .to raise_error(TypeError, '"test" (String) has invalid type for :email')
+      end
+
+      it "doesn't override manual defined schema" do
+        expect { Warehouse.new(code: 'foo') }
+          .to raise_error(TypeError, '"foo" (String) has invalid type for :code')
+      end
+    end
+
+    describe '#id' do
+      it 'returns the value' do
+        entity = described_class.new(id: 1)
+
+        expect(entity.id).to eq(1)
+      end
+
+      it 'returns nil if not present in attributes' do
+        entity = described_class.new
+
+        expect(entity.id).to be_nil
+      end
+    end
+
+    describe 'accessors' do
+      it 'exposes accessors from schema' do
+        entity = described_class.new(name: 'Acme Inc.')
+
+        expect(entity.name).to eq('Acme Inc.')
+      end
+
+      it 'raises error for unknown methods' do
+        entity = described_class.new
+
+        expect { entity.foo }
+          .to raise_error(NoMethodError, /undefined method `foo'/)
+      end
+
+      it 'raises error when #attributes is invoked' do
+        entity = described_class.new
+
+        expect { entity.attributes }
+          .to raise_error(NoMethodError, /private method `attributes' called for #<Account/)
+      end
+    end
+
+    describe '#to_h' do
+      it 'serializes attributes into hash' do
+        entity = described_class.new(id: 1, name: 'Acme Inc.')
+
+        expect(entity.to_h).to eq(Hash[id: 1, name: 'Acme Inc.'])
+      end
+
+      it 'must be an instance of ::Hash' do
+        entity = described_class.new
+
+        expect(entity.to_h).to be_an_instance_of(::Hash)
+      end
+
+      it 'ignores unknown attributes' do
+        entity = described_class.new(foo: 'bar')
+
+        expect(entity.to_h).to eq(Hash[])
+      end
+
+      it 'prevents information escape' do
+        entity = described_class.new(users: users = [User.new(id: 1), User.new(id: 2)])
+
+        entity.to_h[:users].reverse!
+        expect(entity.users).to eq(users)
+      end
+
+      it 'is aliased as #to_hash' do
+        entity = described_class.new(name: 'Acme Inc.')
+
+        expect(entity.to_hash).to eq(entity.to_h)
+      end
+    end
+
+    describe '#respond_to?' do
+      it 'returns ture for id' do
+        entity = described_class.new
+
+        expect(entity).to respond_to(:id)
+      end
+
+      it 'returns true for methods with the same name of attributes defined by schema' do
+        entity = described_class.new
+
+        expect(entity).to respond_to(:name)
+      end
+
+      it 'returns false for methods not in the set of attributes defined by schema' do
+        entity = described_class.new(foo: 'bar')
+
+        expect(entity).to_not respond_to(:foo)
+      end
+    end
+  end
+end

--- a/spec/entity/schema/definition_spec.rb
+++ b/spec/entity/schema/definition_spec.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Entity::Schema::Definition do
+  let(:described_class) { Hanami::Entity::Schema::Definition }
+  let(:subject) do
+    described_class.new do
+      attribute :id, Hanami::Model::Types::Coercible::Int
+    end
+  end
+
+  describe '#initialize' do
+    it 'returns frozen instance' do
+      subject = described_class.new {}
+
+      expect(subject).to be_frozen
+    end
+
+    it "raises error if block isn't given" do
+      expect { described_class.new }.to raise_error(LocalJumpError)
+    end
+  end
+
+  describe '#call' do
+    it 'returns empty hash when nil is given' do
+      result = subject.call(nil)
+
+      expect(result).to eq({})
+    end
+
+    it 'processes attributes' do
+      result = subject.call(id: 1)
+
+      expect(result).to eq(id: 1)
+    end
+
+    it 'ignores unknown attributes' do
+      result = subject.call(foo: 'bar')
+
+      expect(result).to eq({})
+    end
+
+    it 'raises error if the process fails' do
+      message = Platform.match do
+        engine(:jruby) { "no implicit conversion of Symbol into Integer" }
+        default        { "can't convert Symbol into Integer" }
+      end
+
+      expect { subject.call(id: :foo) }.to raise_error(TypeError, message)
+    end
+  end
+
+  describe '#attribute?' do
+    it 'returns true for known attributes' do
+      expect(subject.attribute?(:id)).to eq(true)
+    end
+
+    it 'returns false for unknown attributes' do
+      expect(subject.attribute?(:foo)).to eq(false)
+    end
+  end
+end

--- a/spec/entity/schema/schemaless_spec.rb
+++ b/spec/entity/schema/schemaless_spec.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Entity::Schema::Schemaless do
+  let(:subject) { Hanami::Entity::Schema::Schemaless.new }
+
+  describe '#initialize' do
+    it 'returns frozen instance' do
+      expect(subject).to be_frozen
+    end
+  end
+
+  describe '#call' do
+    it 'returns empty hash when nil is given' do
+      result = subject.call(nil)
+
+      expect(result).to eq({})
+    end
+
+    it 'returns duped hash' do
+      input = { foo: 'bar' }
+      result = subject.call(input)
+
+      expect(result).to eq(input)
+      expect(result.object_id).to_not eq(input.object_id)
+    end
+  end
+
+  describe '#attribute?' do
+    it 'always returns true' do
+      expect(subject.attribute?(:foo)).to eq(true)
+    end
+  end
+end

--- a/spec/entity/schema_spec.rb
+++ b/spec/entity/schema_spec.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Entity::Schema do
+  let(:described_class) { Hanami::Entity::Schema }
+
+  describe 'without definition' do
+    let(:subject) { described_class.new }
+
+    describe '#call' do
+      it 'processes attributes' do
+        result = subject.call('foo' => 'bar')
+
+        expect(result).to eq(foo: 'bar')
+      end
+    end
+
+    describe '#attribute?' do
+      it 'always returns true' do
+        expect(subject.attribute?(:foo)).to eq true
+      end
+    end
+  end
+
+  describe 'with definition' do
+    let(:subject) do
+      described_class.new do
+        attribute :id, Hanami::Model::Types::Coercible::Int
+      end
+    end
+
+    describe '#call' do
+      it 'processes attributes' do
+        result = subject.call(id: '1')
+
+        expect(result).to eq(id: 1)
+      end
+
+      it 'ignores unknown attributes' do
+        result = subject.call(foo: 'bar')
+
+        expect(result).to eq({})
+      end
+    end
+
+    describe '#attribute?' do
+      it 'returns true for known attributes' do
+        expect(subject.attribute?(:id)).to eq true
+      end
+
+      it 'returns false for unknown attributes' do
+        expect(subject.attribute?(:foo)).to eq false
+      end
+    end
+  end
+end

--- a/spec/entity/schemaless_spec.rb
+++ b/spec/entity/schemaless_spec.rb
@@ -1,0 +1,126 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Entity do
+  describe 'schemaless' do
+    let(:described_class) do
+      Class.new(Hanami::Entity)
+    end
+
+    let(:input) do
+      Class.new do
+        def to_hash
+          Hash[a: 1]
+        end
+      end.new
+    end
+
+    describe '#initialize' do
+      it 'can be instantiated without attributes' do
+        entity = described_class.new
+
+        expect(entity).to be_a_kind_of(described_class)
+      end
+
+      it 'accepts a hash' do
+        entity = described_class.new(foo: 1, 'bar' => 2)
+
+        expect(entity.foo).to eq(1)
+        expect(entity.bar).to eq(2)
+      end
+
+      it 'accepts object that implements #to_hash' do
+        entity = described_class.new(input)
+
+        expect(entity.a).to eq(1)
+      end
+
+      it 'freezes the intance' do
+        entity = described_class.new
+
+        expect(entity).to be_frozen
+      end
+    end
+
+    describe '#id' do
+      it 'returns the value' do
+        entity = described_class.new(id: 1)
+
+        expect(entity.id).to eq(1)
+      end
+
+      it 'returns nil if not present in attributes' do
+        entity = described_class.new
+
+        expect(entity.id).to be_nil
+      end
+    end
+
+    describe 'accessors' do
+      it 'exposes accessors for given keys' do
+        entity = described_class.new(name: 'Luca')
+
+        expect(entity.name).to eq('Luca')
+      end
+
+      it 'returns nil for unknown methods' do
+        entity = described_class.new
+
+        expect(entity.foo).to be_nil
+      end
+
+      it 'returns nil for #attributes' do
+        entity = described_class.new
+
+        expect(entity.attributes).to be_nil
+      end
+    end
+
+    describe '#to_h' do
+      it 'serializes attributes into hash' do
+        entity = described_class.new(foo: 1, 'bar' => { 'baz' => 2 })
+
+        expect(entity.to_h).to eq(Hash[foo: 1, bar: { baz: 2 }])
+      end
+
+      it 'must be an instance of ::Hash' do
+        entity = described_class.new
+
+        expect(entity.to_h).to be_an_instance_of(::Hash)
+      end
+
+      it 'prevents information escape' do
+        entity = described_class.new(a: [1, 2, 3])
+
+        entity.to_h[:a].reverse!
+        expect(entity.a).to eq([1, 2, 3])
+      end
+
+      it 'is aliased as #to_hash' do
+        entity = described_class.new(foo: 'bar')
+
+        expect(entity.to_h).to eq(entity.to_hash)
+      end
+    end
+
+    describe '#respond_to?' do
+      it 'returns ture for id' do
+        entity = described_class.new
+
+        expect(entity).to respond_to(:id)
+      end
+
+      it 'returns true for present keys' do
+        entity = described_class.new(foo: 1, 'bar' => 2)
+
+        expect(entity).to respond_to(:foo)
+        expect(entity).to respond_to(:bar)
+      end
+
+      it 'returns false for missing keys' do
+        entity = described_class.new
+
+        expect(entity).to respond_to(:baz)
+      end
+    end
+  end
+end

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+require 'ostruct'
+
+RSpec.describe Hanami::Entity do
+  let(:described_class) do
+    Class.new(Hanami::Entity)
+  end
+
+  describe 'equality' do
+    it 'returns true if same class and same id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = described_class.new(id: 1)
+
+      expect(entity1).to eq(entity2), "Expected #{entity1.inspect} to equal #{entity2.inspect}"
+    end
+
+    it 'returns false if same class but different id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = described_class.new(id: 1000)
+
+      expect(entity1).to_not eq(entity2), "Expected #{entity1.inspect} to NOT equal #{entity2.inspect}"
+    end
+
+    it 'returns false if different class but same id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = OpenStruct.new(id: 1)
+
+      expect(entity1).to_not eq(entity2), "Expected #{entity1.inspect} to NOT equal #{entity2.inspect}"
+    end
+
+    it 'returns false if different class and different id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = OpenStruct.new(id: 1000)
+
+      expect(entity1).to_not eq(entity2), "Expected #{entity1.inspect} to NOT equal #{entity2.inspect}"
+    end
+
+    it 'returns true when both the ids are nil' do
+      entity1 = described_class.new
+      entity2 = described_class.new
+
+      expect(entity1).to eq(entity2), "Expected #{entity1.inspect} to equal #{entity2.inspect}"
+    end
+  end
+
+  describe '#hash' do
+    it 'returns predictable object hashing' do
+      entity1 = described_class.new(id: 1)
+      entity2 = described_class.new(id: 1)
+
+      expect(entity1.hash).to eq(entity2.hash), "Expected #{entity1.hash} to equal #{entity2.hash}"
+    end
+
+    it 'returns different object hash for same class but different id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = described_class.new(id: 1000)
+
+      expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
+    end
+
+    it 'returns different object hash for different class but same id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = Class.new(Hanami::Entity).new(id: 1)
+
+      expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
+    end
+
+    it 'returns different object hash for different class and different id' do
+      entity1 = described_class.new(id: 1)
+      entity2 = Class.new(Hanami::Entity).new(id: 2)
+
+      expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
+    end
+  end
+end

--- a/spec/hanami/model/disconnect_spec.rb
+++ b/spec/hanami/model/disconnect_spec.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+# This test is tightly coupled to Sequel
+#
+# We should improve connection management via ROM
+RSpec.describe "Hanami::Model.disconnect" do
+  before do
+    # warm up
+    connection[:users].to_a
+  end
+
+  let(:connection) { Hanami::Model.configuration.connection }
+
+  it "disconnects from database" do
+    # Sequel returns a collection of SQLite3::Database instances that were
+    # active and has been disconnected from the database
+    connections = Hanami::Model.disconnect
+    expect(connections.size).to eq(1)
+
+    # If we don't hit the database, the next disconnection returns an empty set
+    # of SQLite3::Database
+    connections = Hanami::Model.disconnect
+    expect(connections.size).to eq(0)
+
+    # If we try to use the database again, it's able to transparently reconnect
+    expect(connection[:users].to_a).to be_a_kind_of(Array)
+
+    # Now that we hit the database again, on this time the collection of
+    # disconnected SQLite3::Database instances has size of 1
+    connections = Hanami::Model.disconnect
+    expect(connections.size).to eq(1)
+  end
+
+  it "doesn't disconnect from the database when not connected yet" do
+    Hanami::Model.configuration.stub(:connection, nil) do
+      expect(Hanami::Model.disconnect).to be_nil
+    end
+  end
+end

--- a/spec/hanami/model/load_spec.rb
+++ b/spec/hanami/model/load_spec.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+RSpec.describe "Hanami::Model.load!" do
+  let(:message) { "Cannot find corresponding type for form" }
+
+  before do
+    allow(ROM).to receive(:container) { raise ROM::SQL::UnknownDBTypeError, message }
+  end
+
+  it "raises unknown database error when repository automapping spots an unknown type" do
+    expect { Hanami::Model.load! }.to raise_error(Hanami::Model::UnknownDatabaseTypeError, message)
+  end
+end

--- a/spec/integration/associations/has_many_spec.rb
+++ b/spec/integration/associations/has_many_spec.rb
@@ -1,0 +1,185 @@
+require 'test_helper'
+
+RSpec.describe 'Associations (has_many)' do
+  it "returns nil if association wasn't preloaded" do
+    repository = AuthorRepository.new
+    author = repository.create(name: 'L')
+    found = repository.find(author.id)
+
+    expect(found.books).to be_nil
+  end
+
+  it 'preloads associated records' do
+    repository = AuthorRepository.new
+
+    author = repository.create(name: 'Umberto Eco')
+    book = BookRepository.new.create(author_id: author.id, title: 'Foucault Pendulum')
+
+    found = repository.find_with_books(author.id)
+
+    expect(found).to eq(author)
+    expect(found.books).to eq([book])
+  end
+
+  it 'creates an object with a collection of associated objects' do
+    repository = AuthorRepository.new
+    author = repository.create_with_books(name: 'Henry Thoreau', books: [{ title: 'Walden' }])
+
+    expect(author).to be_an_instance_of(Author)
+    expect(author.name).to eq('Henry Thoreau')
+    expect(author.books).to be_an_instance_of(Array)
+    expect(author.books.first).to be_an_instance_of(Book)
+    expect(author.books.first.title).to eq('Walden')
+  end
+
+  ##############################################################################
+  # OPERATIONS                                                                 #
+  ##############################################################################
+
+  ##
+  # ADD
+  #
+  it 'adds an object to the collection' do
+    repository = AuthorRepository.new
+
+    author = repository.create(name: 'Alexandre Dumas')
+    book = repository.add_book(author, title: 'The Count of Monte Cristo')
+
+    expect(book.id).to_not be_nil
+    expect(book.title).to eq('The Count of Monte Cristo')
+    expect(book.author_id).to eq(author.id)
+  end
+
+  ##
+  # REMOVE
+  #
+  it 'removes an object from the collection'
+  # it 'removes an object from the collection' do
+  #   repository = AuthorRepository.new
+  #   books = BookRepository.new
+
+  #   # Book under test
+  #   author = repository.create(name: 'Douglas Adams')
+  #   book = books.create(author_id: author.id, title: "The Hitchhiker's Guide to the Galaxy")
+
+  #   # Different book
+  #   a = repository.create(name: 'William Finnegan')
+  #   b = books.create(author_id: a.id, title: 'Barbarian Days: A Surfing Life')
+
+  #   repository.remove_book(author, book.id)
+
+  #   # Check the book under test has removed foreign key
+  #   found_book = books.find(book.id)
+  #   expect(found_book).to_not be_nil
+  #   expect(found_book.author_id).to be_nil
+
+  #   found_author = repository.find_with_books(author.id)
+  #   expect(found_author.books.map(&:id)).to_not include(found_book.id)
+
+  #   # Check that the other book was left untouched
+  #   found_b = books.find(b.id)
+  #   expect(found_b.author_id).to eq(a.id)
+  # end
+
+  ##
+  # TO_A
+  #
+  it 'returns an array of books' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'Nikolai Gogol')
+    expected = books.create(author_id: author.id, title: 'Dead Souls')
+    expect(expected).to be_an_instance_of(Book)
+
+    actual = repository.books_for(author).to_a
+    expect(actual).to eq([expected])
+  end
+
+  ##
+  # EACH
+  #
+  it 'iterates through the books' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'José Saramago')
+    expected = books.create(author_id: author.id, title: 'The Cave')
+
+    actual = []
+    repository.books_for(author).each do |book|
+      expect(book).to be_an_instance_of(Book)
+      actual << book
+    end
+
+    expect(actual).to eq([expected])
+  end
+
+  ##
+  # MAP
+  #
+  it 'iterates through the books and returns an array' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'José Saramago')
+    expected = books.create(author_id: author.id, title: 'The Cave')
+    expect(expected).to be_an_instance_of(Book)
+
+    actual = repository.books_for(author).map { |book| book }
+    expect(actual).to eq([expected])
+  end
+
+  ##
+  # COUNT
+  #
+  it 'returns the count of the associated books' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'Fyodor Dostoevsky')
+    books.create(author_id: author.id, title: 'Crime and Punishment')
+    books.create(author_id: author.id, title: 'The Brothers Karamazov')
+
+    expect(repository.books_count(author)).to eq(2)
+  end
+
+  it 'returns the count of on sale associated books' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'Steven Pinker')
+    books.create(author_id: author.id, title: 'The Sense of Style', on_sale: true)
+
+    expect(repository.on_sales_books_count(author)).to eq(1)
+  end
+
+  ##
+  # DELETE
+  #
+  it 'deletes all the books' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'Grazia Deledda')
+    book = books.create(author_id: author.id, title: 'Reeds In The Wind')
+
+    repository.delete_books(author)
+
+    expect(books.find(book.id)).to be_nil
+  end
+
+  it 'deletes scoped books' do
+    repository = AuthorRepository.new
+    books = BookRepository.new
+
+    author = repository.create(name: 'Harper Lee')
+    book = books.create(author_id: author.id, title: 'To Kill A Mockingbird')
+    on_sale = books.create(author_id: author.id, title: 'Go Set A Watchman', on_sale: true)
+
+    repository.delete_on_sales_books(author)
+
+    expect(books.find(book.id)).to eq(book)
+    expect(books.find(on_sale.id)).to be_nil
+  end
+end

--- a/spec/integration/migration/mysql.rb
+++ b/spec/integration/migration/mysql.rb
@@ -1,0 +1,465 @@
+require 'test_helper'
+
+RSpec.describe 'MySQL' do
+  before do
+    @schema = Pathname.new("#{__dir__}/../../../tmp/schema.sql").expand_path
+    @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])
+
+    Hanami::Model::Migrator::Adapter.for(Hanami::Model.configuration).dump
+  end
+
+  describe 'columns' do
+    it 'defines column types' do
+      table = @connection.schema(:column_types)
+
+      name, options = table[0]
+      expect(name).to eq(:integer1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:integer2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:integer3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[3]
+      expect(name).to eq(:string1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[4]
+      expect(name).to eq(:string2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(3)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[5]
+      expect(name).to eq(:string5)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(50)')
+      expect(options.fetch(:max_length)).to eq(50)
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[6]
+      expect(name).to eq(:string6)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('char(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[7]
+      expect(name).to eq(:string7)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('char(64)')
+      expect(options.fetch(:max_length)).to eq(64)
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[8]
+      expect(name).to eq(:string8)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[9]
+      expect(name).to eq(:file1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:blob)
+      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[10]
+      expect(name).to eq(:file2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:blob)
+      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[11]
+      expect(name).to eq(:number1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[12]
+      expect(name).to eq(:number2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('bigint(20)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[13]
+      expect(name).to eq(:number3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:float)
+      expect(options.fetch(:db_type)).to eq('double')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[14]
+      expect(name).to eq(:number4)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[15]
+      expect(name).to eq(:number5)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[16]
+      expect(name).to eq(:number6)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('decimal(10,2)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[17]
+      expect(name).to eq(:number7)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[18]
+      expect(name).to eq(:date1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:date)
+      expect(options.fetch(:db_type)).to eq('date')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[19]
+      expect(name).to eq(:date2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:datetime)
+      expect(options.fetch(:db_type)).to eq('datetime')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[20]
+      expect(name).to eq(:time1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:datetime)
+      expect(options.fetch(:db_type)).to eq('datetime')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[21]
+      expect(name).to eq(:time2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:time)
+      expect(options.fetch(:db_type)).to eq('time')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[22]
+      expect(name).to eq(:boolean1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[23]
+      expect(name).to eq(:boolean2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:primary_key)).to eq(false)
+    end
+
+    it 'defines column defaults' do
+      table = @connection.schema(:default_values)
+
+      name, options = table[0]
+      expect(name).to eq(:a)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('23')
+      expect(options.fetch(:ruby_default)).to eq(23)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:b)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('Hanami')
+      expect(options.fetch(:ruby_default)).to eq('Hanami')
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:c)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('-1')
+      expect(options.fetch(:ruby_default)).to eq(-1)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[3]
+      expect(name).to eq(:d)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:ruby_default)).to eq(0)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('bigint(20)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[4]
+      expect(name).to eq(:e)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('3.14')
+      expect(options.fetch(:ruby_default)).to eq(3.14)
+      expect(options.fetch(:type)).to eq(:float)
+      expect(options.fetch(:db_type)).to eq('double')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[5]
+      expect(name).to eq(:f)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('1')
+      expect(options.fetch(:ruby_default)).to eq(1.0)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[6]
+      expect(name).to eq(:g)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('943943')
+      expect(options.fetch(:ruby_default)).to eq(943_943)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[10]
+      expect(name).to eq(:k)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('1')
+      expect(options.fetch(:ruby_default)).to eq(true)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[11]
+      expect(name).to eq(:l)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:ruby_default)).to eq(false)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:primary_key)).to eq(false)
+    end
+
+    it 'defines null constraint' do
+      table = @connection.schema(:null_constraints)
+
+      name, options = table[0]
+      expect(name).to eq(:a)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+
+      name, options = table[1]
+      expect(name).to eq(:b)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:c)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+    end
+
+    it 'defines column index' do
+      indexes = @connection.indexes(:column_indexes)
+
+      expect(indexes.fetch(:column_indexes_a_index, nil)).to be_nil
+      expect(indexes.fetch(:column_indexes_b_index, nil)).to be_nil
+
+      index = indexes.fetch(:column_indexes_c_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:c])
+    end
+
+    it 'defines index via #index' do
+      indexes = @connection.indexes(:column_indexes)
+
+      index = indexes.fetch(:column_indexes_d_index)
+      expect(index[:unique]).to eq(true)
+      expect(index[:columns]).to eq([:d])
+
+      index = indexes.fetch(:column_indexes_b_c_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:b, :c])
+
+      index = indexes.fetch(:column_indexes_coords_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:lat, :lng])
+    end
+
+    it 'defines primary key (via #primary_key :id)' do
+      table = @connection.schema(:primary_keys_1)
+
+      name, options = table[0]
+      expect(name).to eq(:id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(true)
+    end
+
+    it 'defines composite primary key (via #primary_key [:column1, :column2])' do
+      table = @connection.schema(:primary_keys_3)
+
+      name, options = table[0]
+      expect(name).to eq(:group_id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+
+      expected = Platform.match do
+        os(:linux) { '0' }
+        os(:macos) { nil }
+      end
+
+      expect(options.fetch(:default)).to eq(expected)
+
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:position)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+
+      expected = Platform.match do
+        os(:linux) { '0' }
+        os(:macos) { nil }
+      end
+
+      expect(options.fetch(:default)).to eq(expected)
+
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+    end
+
+    it 'defines primary key (via #column primary_key: true)' do
+      table = @connection.schema(:primary_keys_2)
+
+      name, options = table[0]
+      expect(name).to eq(:name)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+    end
+
+    it 'defines foreign key (via #foreign_key)' do
+      table = @connection.schema(:albums)
+
+      name, options = table[1]
+      expect(name).to eq(:artist_id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      foreign_key = @connection.foreign_key_list(:albums).first
+      expect(foreign_key.fetch(:columns)).to eq([:artist_id])
+      expect(foreign_key.fetch(:table)).to eq(:artists)
+      expect(foreign_key.fetch(:key)).to eq([:id])
+      # expect(foreign_key.fetch(:on_update)).to eq(:no_action)
+      # expect(foreign_key.fetch(:on_delete)).to eq(:cascade)
+    end
+
+    it 'defines column constraint and check'
+    # it 'defines column constraint and check' do
+    #   expect(@schema.read).to include %(CREATE TABLE `table_constraints` (`age` integer, `role` varchar(255), CONSTRAINT `age_constraint` CHECK (`age` > 18), CHECK (role IN("contributor", "manager", "owner")));)
+    # end
+  end
+end

--- a/spec/integration/migration/mysql.rb
+++ b/spec/integration/migration/mysql.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-RSpec.describe 'MySQL' do
+RSpec.shared_examples 'migration_integration_mysql' do
   before do
     @schema = Pathname.new("#{__dir__}/../../../tmp/schema.sql").expand_path
     @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])

--- a/spec/integration/migration/postgresql.rb
+++ b/spec/integration/migration/postgresql.rb
@@ -1,0 +1,624 @@
+require 'test_helper'
+
+RSpec.describe 'PostgreSQL' do
+  before do
+    @schema = Pathname.new("#{__dir__}/../../../tmp/schema.sql").expand_path
+    @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])
+
+    Hanami::Model::Migrator::Adapter.for(Hanami::Model.configuration).dump
+  end
+
+  describe 'columns' do
+    it 'defines column types' do
+      table = @connection.schema(:column_types)
+
+      name, options = table[0]
+      expect(name).to eq(:integer1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:integer2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:integer3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[3]
+      expect(name).to eq(:string1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[4]
+      expect(name).to eq(:string2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[5]
+      expect(name).to eq(:string3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character varying(1)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[6]
+      expect(name).to eq(:string4)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character varying(2)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[7]
+      expect(name).to eq(:string5)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character(3)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[8]
+      expect(name).to eq(:string6)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character(4)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[9]
+      expect(name).to eq(:string7)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character varying(50)')
+      expect(options.fetch(:max_length)).to eq(50)
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[10]
+      expect(name).to eq(:string8)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[11]
+      expect(name).to eq(:string9)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('character(64)')
+      expect(options.fetch(:max_length)).to eq(64)
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[12]
+      expect(name).to eq(:string10)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[13]
+      expect(name).to eq(:file1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:blob)
+      expect(options.fetch(:db_type)).to eq('bytea')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[14]
+      expect(name).to eq(:file2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:blob)
+      expect(options.fetch(:db_type)).to eq('bytea')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[15]
+      expect(name).to eq(:number1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[16]
+      expect(name).to eq(:number2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[17]
+      expect(name).to eq(:number3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:float)
+      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[18]
+      expect(name).to eq(:number4)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[19]
+      expect(name).to eq(:number5)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric(10,0)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[20]
+      expect(name).to eq(:number6)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric(10,2)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[21]
+      expect(name).to eq(:number7)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[22]
+      expect(name).to eq(:date1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:date)
+      expect(options.fetch(:db_type)).to eq('date')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[23]
+      expect(name).to eq(:date2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:datetime)
+      expect(options.fetch(:db_type)).to eq('timestamp without time zone')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[24]
+      expect(name).to eq(:time1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:datetime)
+      expect(options.fetch(:db_type)).to eq('timestamp without time zone')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[25]
+      expect(name).to eq(:time2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:time)
+      expect(options.fetch(:db_type)).to eq('time without time zone')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[26]
+      expect(name).to eq(:boolean1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[27]
+      expect(name).to eq(:boolean2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[28]
+      expect(name).to eq(:array1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer[]')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[29]
+      expect(name).to eq(:array2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer[]')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[30]
+      expect(name).to eq(:array3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text[]')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[31]
+      expect(name).to eq(:money1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:money)
+      expect(options.fetch(:db_type)).to eq('money')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[32]
+      expect(name).to eq(:enum1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:mood)
+      expect(options.fetch(:db_type)).to eq('mood')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[33]
+      expect(name).to eq(:geometric1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:point)
+      expect(options.fetch(:db_type)).to eq('point')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[34]
+      expect(name).to eq(:geometric2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:line)
+      expect(options.fetch(:db_type)).to eq('line')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[35]
+      expect(name).to eq(:geometric3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq("'<(15,15),1>'::circle")
+      # expect(options.fetch(:type)).to eq(:circle)
+      expect(options.fetch(:db_type)).to eq('circle')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[36]
+      expect(name).to eq(:net1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq("'192.168.0.0/24'::cidr")
+      # expect(options.fetch(:type)).to eq(:cidr)
+      expect(options.fetch(:db_type)).to eq('cidr')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[37]
+      expect(name).to eq(:uuid1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('uuid_generate_v4()')
+      # expect(options.fetch(:type)).to eq(:uuid)
+      expect(options.fetch(:db_type)).to eq('uuid')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[38]
+      expect(name).to eq(:xml1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:xml)
+      expect(options.fetch(:db_type)).to eq('xml')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[39]
+      expect(name).to eq(:json1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:json)
+      expect(options.fetch(:db_type)).to eq('json')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[40]
+      expect(name).to eq(:json2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:jsonb)
+      expect(options.fetch(:db_type)).to eq('jsonb')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[41]
+      expect(name).to eq(:composite1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq("ROW('fuzzy dice'::text, 42, 1.99)")
+      # expect(options.fetch(:type)).to eq(:inventory_item)
+      expect(options.fetch(:db_type)).to eq('inventory_item')
+      expect(options.fetch(:primary_key)).to eq(false)
+    end
+
+    it 'defines column defaults' do
+      table = @connection.schema(:default_values)
+
+      name, options = table[0]
+      expect(name).to eq(:a)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('23')
+      expect(options.fetch(:ruby_default)).to eq(23)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:b)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq("'Hanami'::text")
+      expect(options.fetch(:ruby_default)).to eq('Hanami')
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:c)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+
+      expected = Platform.match do
+        os(:linux) { '(-1)' }
+        os(:macos) { "'-1'::integer" }
+      end
+
+      expect(options.fetch(:default)).to eq(expected)
+
+      # expect(options.fetch(:ruby_default)).to eq(-1)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[3]
+      expect(name).to eq(:d)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:ruby_default)).to eq(0)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[4]
+      expect(name).to eq(:e)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('3.14')
+      expect(options.fetch(:ruby_default)).to eq(3.14)
+      expect(options.fetch(:type)).to eq(:float)
+      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[5]
+      expect(name).to eq(:f)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('1.0')
+      expect(options.fetch(:ruby_default)).to eq(1.0)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[6]
+      expect(name).to eq(:g)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('943943')
+      expect(options.fetch(:ruby_default)).to eq(943_943)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[10]
+      expect(name).to eq(:k)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('true')
+      expect(options.fetch(:ruby_default)).to eq(true)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[11]
+      expect(name).to eq(:l)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('false')
+      expect(options.fetch(:ruby_default)).to eq(false)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+    end
+
+    it 'defines null constraint' do
+      table = @connection.schema(:null_constraints)
+
+      name, options = table[0]
+      expect(name).to eq(:a)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+
+      name, options = table[1]
+      expect(name).to eq(:b)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:c)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+    end
+
+    it 'defines column index' do
+      indexes = @connection.indexes(:column_indexes)
+
+      expect(indexes.fetch(:column_indexes_a_index, nil)).to be_nil
+      expect(indexes.fetch(:column_indexes_b_index, nil)).to be_nil
+
+      index = indexes.fetch(:column_indexes_c_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:c])
+    end
+
+    it 'defines index via #index' do
+      indexes = @connection.indexes(:column_indexes)
+
+      index = indexes.fetch(:column_indexes_d_index)
+      expect(index[:unique]).to eq(true)
+      expect(index[:columns]).to eq([:d])
+
+      index = indexes.fetch(:column_indexes_b_c_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:b, :c])
+
+      index = indexes.fetch(:column_indexes_coords_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:lat, :lng])
+    end
+
+    it 'defines primary key (via #primary_key :id)' do
+      table = @connection.schema(:primary_keys_1)
+
+      name, options = table[0]
+      expect(name).to eq(:id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq("nextval('primary_keys_1_id_seq'::regclass)")
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(true)
+    end
+
+    it 'defines composite primary key (via #primary_key [:column1, :column2])' do
+      table = @connection.schema(:primary_keys_3)
+
+      name, options = table[0]
+      expect(name).to eq(:group_id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:position)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+    end
+
+    it 'defines primary key (via #column primary_key: true)' do
+      table = @connection.schema(:primary_keys_2)
+
+      name, options = table[0]
+      expect(name).to eq(:name)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+    end
+
+    it 'defines foreign key (via #foreign_key)' do
+      table = @connection.schema(:albums)
+
+      name, options = table[1]
+      expect(name).to eq(:artist_id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      foreign_key = @connection.foreign_key_list(:albums).first
+      expect(foreign_key.fetch(:columns)).to eq([:artist_id])
+      expect(foreign_key.fetch(:table)).to eq(:artists)
+      expect(foreign_key.fetch(:key)).to eq([:id])
+      expect(foreign_key.fetch(:on_update)).to eq(:no_action)
+      expect(foreign_key.fetch(:on_delete)).to eq(:cascade)
+    end
+
+    unless Platform.ci?
+      it 'defines column constraint and check' do
+        actual = @schema.read
+
+        expect(actual).to include %(CONSTRAINT age_constraint CHECK ((age > 18)))
+        expect(actual).to include %(CONSTRAINT table_constraints_role_check CHECK ((role = ANY (ARRAY['contributor'::text, 'manager'::text, 'owner'::text]))))
+      end
+    end
+  end
+end

--- a/spec/integration/migration/postgresql.rb
+++ b/spec/integration/migration/postgresql.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-RSpec.describe 'PostgreSQL' do
+RSpec.shared_examples 'migration_integration_postgresql' do
   before do
     @schema = Pathname.new("#{__dir__}/../../../tmp/schema.sql").expand_path
     @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])

--- a/spec/integration/migration/sqlite.rb
+++ b/spec/integration/migration/sqlite.rb
@@ -1,0 +1,468 @@
+require 'test_helper'
+
+RSpec.describe 'SQLite' do
+  before do
+    @schema = Pathname.new("#{__dir__}/../../../tmp/schema.sql").expand_path
+    @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])
+
+    Hanami::Model::Migrator::Adapter.for(Hanami::Model.configuration).dump
+  end
+
+  describe 'columns' do
+    it 'defines column types' do
+      table = @connection.schema(:column_types)
+
+      name, options = table[0]
+      expect(name).to eq(:integer1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:integer2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:integer3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[3]
+      expect(name).to eq(:string1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[4]
+      expect(name).to eq(:string2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('string')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[5]
+      expect(name).to eq(:string3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('string')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[6]
+      expect(name).to eq(:string4)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(3)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[7]
+      expect(name).to eq(:string5)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(50)')
+      expect(options.fetch(:max_length)).to eq(50)
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[8]
+      expect(name).to eq(:string6)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('char(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[9]
+      expect(name).to eq(:string7)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('char(64)')
+      expect(options.fetch(:max_length)).to eq(64)
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[10]
+      expect(name).to eq(:string8)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[11]
+      expect(name).to eq(:file1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:blob)
+      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[12]
+      expect(name).to eq(:file2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:blob)
+      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[13]
+      expect(name).to eq(:number1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[14]
+      expect(name).to eq(:number2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[15]
+      expect(name).to eq(:number3)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:float)
+      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[16]
+      expect(name).to eq(:number4)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[17]
+      expect(name).to eq(:number5)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      # expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric(10)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[18]
+      expect(name).to eq(:number6)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric(10, 2)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[19]
+      expect(name).to eq(:number7)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[20]
+      expect(name).to eq(:date1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:date)
+      expect(options.fetch(:db_type)).to eq('date')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[21]
+      expect(name).to eq(:date2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:datetime)
+      expect(options.fetch(:db_type)).to eq('timestamp')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[22]
+      expect(name).to eq(:time1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:datetime)
+      expect(options.fetch(:db_type)).to eq('timestamp')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[23]
+      expect(name).to eq(:time2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:time)
+      expect(options.fetch(:db_type)).to eq('time')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[24]
+      expect(name).to eq(:boolean1)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[25]
+      expect(name).to eq(:boolean2)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+    end
+
+    it 'defines column defaults' do
+      table = @connection.schema(:default_values)
+
+      name, options = table[0]
+      expect(name).to eq(:a)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('23')
+      expect(options.fetch(:ruby_default)).to eq(23)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:b)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq("'Hanami'")
+      expect(options.fetch(:ruby_default)).to eq('Hanami')
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:c)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('-1')
+      expect(options.fetch(:ruby_default)).to eq(-1)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[3]
+      expect(name).to eq(:d)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:ruby_default)).to eq(0)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[4]
+      expect(name).to eq(:e)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('3.14')
+      expect(options.fetch(:ruby_default)).to eq(3.14)
+      expect(options.fetch(:type)).to eq(:float)
+      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[5]
+      expect(name).to eq(:f)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('1.0')
+      expect(options.fetch(:ruby_default)).to eq(1.0)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[6]
+      expect(name).to eq(:g)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('943943')
+      expect(options.fetch(:ruby_default)).to eq(943_943)
+      expect(options.fetch(:type)).to eq(:decimal)
+      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[10]
+      expect(name).to eq(:k)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('1')
+      expect(options.fetch(:ruby_default)).to eq(true)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      name, options = table[11]
+      expect(name).to eq(:l)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:ruby_default)).to eq(false)
+      expect(options.fetch(:type)).to eq(:boolean)
+      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:primary_key)).to eq(false)
+    end
+
+    it 'defines null constraint' do
+      table = @connection.schema(:null_constraints)
+
+      name, options = table[0]
+      expect(name).to eq(:a)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+
+      name, options = table[1]
+      expect(name).to eq(:b)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+
+      name, options = table[2]
+      expect(name).to eq(:c)
+
+      expect(options.fetch(:allow_null)).to eq(true)
+    end
+
+    it 'defines column index' do
+      indexes = @connection.indexes(:column_indexes)
+
+      expect(indexes.fetch(:column_indexes_a_index, nil)).to be_nil
+      expect(indexes.fetch(:column_indexes_b_index, nil)).to be_nil
+
+      index = indexes.fetch(:column_indexes_c_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:c])
+    end
+
+    it 'defines index via #index' do
+      indexes = @connection.indexes(:column_indexes)
+
+      index = indexes.fetch(:column_indexes_d_index)
+      expect(index[:unique]).to eq(true)
+      expect(index[:columns]).to eq([:d])
+
+      index = indexes.fetch(:column_indexes_b_c_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:b, :c])
+
+      index = indexes.fetch(:column_indexes_coords_index)
+      expect(index[:unique]).to eq(false)
+      expect(index[:columns]).to eq([:lat, :lng])
+    end
+
+    it 'defines primary key (via #primary_key :id)' do
+      table = @connection.schema(:primary_keys_1)
+
+      name, options = table[0]
+      expect(name).to eq(:id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(true)
+    end
+
+    it 'defines composite primary key (via #primary_key [:column1, :column2])' do
+      table = @connection.schema(:primary_keys_3)
+
+      name, options = table[0]
+      expect(name).to eq(:group_id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+
+      name, options = table[1]
+      expect(name).to eq(:position)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+    end
+
+    it 'defines primary key (via #column primary_key: true)' do
+      table = @connection.schema(:primary_keys_2)
+
+      name, options = table[0]
+      expect(name).to eq(:name)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:string)
+      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:primary_key)).to eq(true)
+      expect(options.fetch(:auto_increment)).to eq(false)
+    end
+
+    it 'defines foreign key (via #foreign_key)' do
+      table = @connection.schema(:albums)
+
+      name, options = table[1]
+      expect(name).to eq(:artist_id)
+
+      expect(options.fetch(:allow_null)).to eq(false)
+      expect(options.fetch(:default)).to eq(nil)
+      expect(options.fetch(:type)).to eq(:integer)
+      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:primary_key)).to eq(false)
+
+      foreign_key = @connection.foreign_key_list(:albums).first
+      expect(foreign_key.fetch(:columns)).to eq([:artist_id])
+      expect(foreign_key.fetch(:table)).to eq(:artists)
+      expect(foreign_key.fetch(:key)).to eq(nil)
+      expect(foreign_key.fetch(:on_update)).to eq(:no_action)
+      expect(foreign_key.fetch(:on_delete)).to eq(:cascade)
+    end
+
+    it 'defines column constraint and check' do
+      expect(@schema.read).to include %(CREATE TABLE `table_constraints` (`age` integer, `role` varchar(255), CONSTRAINT `age_constraint` CHECK (`age` > 18), CHECK (role IN("contributor", "manager", "owner")));)
+    end
+  end
+end

--- a/spec/integration/migration/sqlite.rb
+++ b/spec/integration/migration/sqlite.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-RSpec.describe 'SQLite' do
+RSpec.shared_examples 'migration_integration_sqlite' do
   before do
     @schema = Pathname.new("#{__dir__}/../../../tmp/schema.sql").expand_path
     @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])

--- a/spec/integration/migration_spec.rb
+++ b/spec/integration/migration_spec.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+require_relative "./migration/#{Database.engine}.rb"
+
+describe 'Hanami::Model.migration' do
+  include_examples "migration_integration_#{Database.engine}"
+end

--- a/spec/integration/migration_test.rb
+++ b/spec/integration/migration_test.rb
@@ -1,0 +1,5 @@
+# require 'test_helper'
+
+# describe 'Hanami::Model.migration' do
+#   load "test/integration/migration/#{Database.engine}.rb"
+# end

--- a/spec/integration/migration_test.rb
+++ b/spec/integration/migration_test.rb
@@ -1,5 +1,0 @@
-# require 'test_helper'
-
-# describe 'Hanami::Model.migration' do
-#   load "test/integration/migration/#{Database.engine}.rb"
-# end

--- a/spec/integration/repository/base_spec.rb
+++ b/spec/integration/repository/base_spec.rb
@@ -1,0 +1,620 @@
+require 'test_helper'
+require 'securerandom'
+
+RSpec.describe 'Repository (base)' do
+  extend PlatformHelpers
+
+  describe '#find' do
+    it 'finds record by primary key' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      found = repository.find(user.id)
+
+      expect(found).to eq(user)
+    end
+
+    it 'returns nil when nil is given' do
+      repository = UserRepository.new
+      repository.create(name: 'L')
+      found = repository.find(nil)
+
+      expect(found).to be_nil
+    end
+
+    it 'returns nil for missing record' do
+      repository = UserRepository.new
+      found = repository.find('9999999')
+
+      expect(found).to be_nil
+    end
+
+    # See https://github.com/hanami/model/issues/374
+    describe 'with non-autoincrement primary key' do
+      before do
+        repository.clear
+      end
+
+      let(:repository) { LabelRepository.new }
+      let(:id)         { 1 }
+
+      it 'raises error' do
+        repository.create(id: id)
+
+        expect { repository.find(id) }
+          .to raise_error(Hanami::Model::MissingPrimaryKeyError, "Missing primary key for :labels")
+      end
+    end
+  end
+
+  describe '#all' do
+    it 'returns all the records' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+
+      expect(repository.all).to be_an_instance_of(Array)
+      expect(repository.all).to include(user)
+    end
+  end
+
+  describe '#first' do
+    it 'returns first record from table' do
+      repository = UserRepository.new
+      repository.clear
+
+      user = repository.create(name: 'James Hetfield')
+      repository.create(name: 'Tom')
+
+      expect(repository.first).to eq(user)
+    end
+  end
+
+  describe '#last' do
+    it 'returns last record from table' do
+      repository = UserRepository.new
+      repository.clear
+
+      repository.create(name: 'Tom')
+      user = repository.create(name: 'Ella Fitzgerald')
+
+      expect(repository.last).to eq(user)
+    end
+  end
+
+  describe '#clear' do
+    it 'clears all the records' do
+      repository = UserRepository.new
+      repository.create(name: 'L')
+
+      repository.clear
+      expect(repository.all).to be_empty
+    end
+  end
+
+  describe 'relation' do
+    describe 'read' do
+      it 'reads records from the database given a raw query string' do
+        repository = UserRepository.new
+        repository.create(name: 'L')
+
+        users = repository.find_all_by_manual_query
+        expect(users).to be_a_kind_of(Array)
+
+        user = users.first
+        expect(user).to be_a_kind_of(User)
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'creates record from data' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+
+      expect(user).to be_an_instance_of(User)
+      expect(user.id).to_not be_nil
+      expect(user.name).to eq('L')
+    end
+
+    it 'creates record from entity' do
+      entity = User.new(name: 'L')
+      repository = UserRepository.new
+      user = repository.create(entity)
+
+      # It doesn't mutate original entity
+      expect(entity.id).to be_nil
+
+      expect(user).to be_an_instance_of(User)
+      expect(user.id).to_not be_nil
+      expect(user.name).to eq('L')
+    end
+
+    with_platform(engine: :jruby, db: :sqlite) do
+      it 'automatically touches timestamps'
+    end
+
+    unless_platform(engine: :jruby, db: :sqlite) do
+      it 'automatically touches timestamps' do
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+
+        expect(user.created_at).to be_within(2).of(Time.now.utc)
+        expect(user.updated_at).to be_within(2).of(Time.now.utc)
+      end
+
+      it 'respects given timestamps' do
+        repository = UserRepository.new
+        given_time = Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
+
+        user = repository.create(name: 'L', created_at: given_time, updated_at: given_time)
+
+        expect(user.created_at).to be_within(2).of(given_time)
+        expect(user.updated_at).to be_within(2).of(given_time)
+      end
+
+      it 'can update timestamps' do
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+        expect(user.created_at).to be_within(2).of(Time.now.utc)
+        expect(user.updated_at).to be_within(2).of(Time.now.utc)
+
+        given_time = Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
+        updated = repository.update(
+          user.id,
+          created_at: given_time,
+          updated_at: given_time
+        )
+
+        expect(updated.name).to eq('L')
+        expect(updated.created_at).to be_within(2).of(given_time)
+        expect(updated.updated_at).to be_within(2).of(given_time)
+      end
+    end
+
+    # Bug: https://github.com/hanami/model/issues/237
+    it 'respects database defaults' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+
+      expect(user.comments_count).to eq(0)
+    end
+
+    # Bug: https://github.com/hanami/model/issues/272
+    it 'accepts booleans as attributes' do
+      user = UserRepository.new.create(name: 'L', active: false)
+      expect(user.active).to eq(false)
+    end
+
+    it 'raises error when generic database error is raised'
+    # it 'raises error when generic database error is raised' do
+    #   expected_error = Hanami::Model::DatabaseError
+    #   message = Platform.match do
+    #     engine(:ruby).db(:sqlite)  { 'SQLite3::SQLException: table users has no column named bogus' }
+    #     engine(:jruby).db(:sqlite) { 'Java::JavaSql::SQLException: table users has no column named bogus' }
+
+    #     engine(:ruby).db(:postgresql)  { 'PG::UndefinedColumn: ERROR:  column "bogus" of relation "users" does not exist' }
+    #     engine(:jruby).db(:postgresql) { 'bogus' }
+
+    #     engine(:ruby).db(:mysql)  { "Mysql2::Error: Unknown column 'bogus' in 'field list'" }
+    #     engine(:jruby).db(:mysql) { 'bogus' }
+    #   end
+
+    #   expect { UserRepository.new.create(name: 'L', bogus: 23) }.to raise_error do |error|
+    #     expect(error).to be_a(expected_error)
+    #     expect(error.message).to include(message)
+    #   end
+    # end
+
+    it 'raises error when "not null" database constraint is violated' do
+      expected_error = Hanami::Model::NotNullConstraintViolationError
+      message = Platform.match do
+        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_NOTNULL]  A NOT NULL constraint failed (NOT NULL constraint failed: users.active)' }
+
+        engine(:ruby).db(:postgresql)  { 'PG::NotNullViolation: ERROR:  null value in column "active" violates not-null constraint' }
+        engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: null value in column "active" violates not-null constraint' }
+
+        engine(:ruby).db(:mysql)  { "Mysql2::Error: Column 'active' cannot be null" }
+        engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Column 'active' cannot be null" }
+      end
+
+      expect { UserRepository.new.create(name: 'L', active: nil) }.to raise_error do |error|
+        expect(error).to be_a(expected_error)
+        expect(error.message).to include(message)
+      end
+    end
+
+    it 'raises error when "unique constraint" is violated' do
+      email = "user@#{SecureRandom.uuid}.test"
+
+      expected_error = Hanami::Model::UniqueConstraintViolationError
+      message = Platform.match do
+        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_UNIQUE]  A UNIQUE constraint failed (UNIQUE constraint failed: users.email)' }
+
+        engine(:ruby).db(:postgresql)  { 'PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "users_email_index"' }
+        engine(:jruby).db(:postgresql) { %(Java::OrgPostgresqlUtil::PSQLException: ERROR: duplicate key value violates unique constraint "users_email_index"\n  Detail: Key (email)=(#{email}) already exists.) }
+
+        engine(:ruby).db(:mysql)  { "Mysql2::Error: Duplicate entry '#{email}' for key 'users_email_index'" }
+        engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Duplicate entry '#{email}' for key 'users_email_index'" }
+      end
+
+      repository = UserRepository.new
+      repository.create(name: 'Test', email: email)
+
+      expect { repository.create(name: 'L', email: email) }.to raise_error do |error|
+        expect(error).to be_a(expected_error)
+        expect(error.message).to include(message)
+      end
+    end
+
+    it 'raises error when "foreign key" constraint is violated' do
+      expected_error = Hanami::Model::ForeignKeyConstraintViolationError
+      message = Platform.match do
+        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_FOREIGNKEY]  A foreign key constraint failed (FOREIGN KEY constraint failed)' }
+
+        engine(:ruby).db(:postgresql)  { 'PG::ForeignKeyViolation: ERROR:  insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
+        engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
+
+        engine(:ruby).db(:mysql)  { 'Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails' }
+        engine(:jruby).db(:mysql) { 'Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)' }
+      end
+
+      expect { AvatarRepository.new.create(user_id: 999_999_999) }.to raise_error do |error|
+        expect(error).to be_a(expected_error)
+        expect(error.message).to include(message)
+      end
+    end
+
+    # For MySQL [...] The CHECK clause is parsed but ignored by all storage engines.
+    # http://dev.mysql.com/doc/refman/5.7/en/create-table.html
+    unless_platform(db: :mysql) do
+      it 'raises error when "check" constraint is violated' do
+        expected_error = Platform.match do
+          os(:linux).engine(:ruby).db(:sqlite) { Hanami::Model::ConstraintViolationError }
+          default                              { Hanami::Model::CheckConstraintViolationError }
+        end
+
+        message = Platform.match do
+          engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+          engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: users)' }
+
+          engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "users_age_check"' }
+          engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "users_age_check"' }
+        end
+
+        expect { UserRepository.new.create(name: 'L', age: 1) }.to raise_error do |error|
+          expect(error).to be_a(expected_error)
+          expect(error.message).to include(message)
+        end
+      end
+
+      it 'raises error when constraint is violated' do
+        expected_error = Platform.match do
+          os(:linux).engine(:ruby).db(:sqlite) { Hanami::Model::ConstraintViolationError }
+          default                              { Hanami::Model::CheckConstraintViolationError }
+        end
+
+        message = Platform.match do
+          engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+          engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: comments_count_constraint)' }
+
+          engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "comments_count_constraint"' }
+          engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "comments_count_constraint"' }
+        end
+
+        expect { UserRepository.new.create(name: 'L', comments_count: -1) }.to raise_error do |error|
+          expect(error).to be_a(expected_error)
+          expect(error.message).to include(message)
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    it 'updates record from data' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      updated = repository.update(user.id, name: 'Luca')
+
+      expect(updated).to be_an_instance_of(User)
+      expect(updated.id).to eq(user.id)
+      expect(updated.name).to eq('Luca')
+    end
+
+    it 'updates record from entity' do
+      entity = User.new(name: 'Luca')
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      updated = repository.update(user.id, entity)
+
+      # It doesn't mutate original entity
+      expect(entity.id).to be_nil
+
+      expect(updated).to be_an_instance_of(User)
+      expect(updated.id).to eq(user.id)
+      expect(updated.name).to eq('Luca')
+    end
+
+    it 'returns nil when record cannot be found' do
+      repository = UserRepository.new
+      updated = repository.update('9999999', name: 'Luca')
+
+      expect(updated).to be_nil
+    end
+
+    with_platform(engine: :jruby, db: :sqlite) do
+      it 'automatically touches timestamps'
+    end
+
+    unless_platform(engine: :jruby, db: :sqlite) do
+      it 'automatically touches timestamps' do
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+        sleep 0.1
+        updated = repository.update(user.id, name: 'Luca')
+
+        expect(updated.created_at).to be_within(2).of(user.created_at)
+        expect(updated.updated_at).to be_within(2).of(Time.now)
+      end
+    end
+
+    it 'raises error when generic database error is raised'
+    # it 'raises error when generic database error is raised' do
+    #   expected_error = Hanami::Model::DatabaseError
+    #   message = Platform.match do
+    #     engine(:ruby).db(:sqlite)  { 'SQLite3::SQLException: no such column: bogus' }
+    #     engine(:jruby).db(:sqlite) { 'Java::JavaSql::SQLException: no such column: bogus' }
+
+    #     engine(:ruby).db(:postgresql)  { 'PG::UndefinedColumn: ERROR:  column "bogus" of relation "users" does not exist' }
+    #     engine(:jruby).db(:postgresql) { 'bogus' }
+
+    #     engine(:ruby).db(:mysql)  { "Mysql2::Error: Unknown column 'bogus' in 'field list'" }
+    #     engine(:jruby).db(:mysql) { 'bogus' }
+    #   end
+
+    #   repository = UserRepository.new
+    #   user = repository.create(name: 'L')
+
+    #   expect { repository.update(user.id, bogus: 23) }.to raise_error do |error|
+    #     expect(error).to be_a(expected_error)
+    #     expect(error.message).to include(message)
+    #   end
+    # end
+
+    # MySQL doesn't raise an error on CI
+    unless_platform(os: :linux, engine: :ruby, db: :mysql) do
+      it 'raises error when "not null" database constraint is violated' do
+        expected_error = Hanami::Model::NotNullConstraintViolationError
+        message = Platform.match do
+          engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+          engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_NOTNULL]  A NOT NULL constraint failed (NOT NULL constraint failed: users.active)' }
+
+          engine(:ruby).db(:postgresql)  { 'PG::NotNullViolation: ERROR:  null value in column "active" violates not-null constraint' }
+          engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: null value in column "active" violates not-null constraint' }
+
+          engine(:ruby).db(:mysql)  { "Mysql2::Error: Column 'active' cannot be null" }
+          engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Column 'active' cannot be null" }
+        end
+
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+
+        expect { repository.update(user.id, active: nil) }.to raise_error do |error|
+          expect(error).to be_a(expected_error)
+          expect(error.message).to include(message)
+        end
+      end
+    end
+
+    it 'raises error when "unique constraint" is violated' do
+      email = "update@#{SecureRandom.uuid}.test"
+
+      expected_error = Hanami::Model::UniqueConstraintViolationError
+      message = Platform.match do
+        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_UNIQUE]  A UNIQUE constraint failed (UNIQUE constraint failed: users.email)' }
+
+        engine(:ruby).db(:postgresql)  { 'PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "users_email_index"' }
+        engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: duplicate key value violates unique constraint "users_email_index"' }
+
+        engine(:ruby).db(:mysql)  { "Mysql2::Error: Duplicate entry '#{email}' for key 'users_email_index'" }
+        engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Duplicate entry '#{email}' for key 'users_email_index'" }
+      end
+
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      repository.create(name: 'UpdateTest', email: email)
+
+      expect { repository.update(user.id, email: email) }.to raise_error do |error|
+        expect(error).to be_a(expected_error)
+        expect(error.message).to include(message)
+      end
+    end
+
+    it 'raises error when "foreign key" constraint is violated' do
+      expected_error = Hanami::Model::ForeignKeyConstraintViolationError
+      message = Platform.match do
+        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
+        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_FOREIGNKEY]  A foreign key constraint failed (FOREIGN KEY constraint failed)' }
+
+        engine(:ruby).db(:postgresql)  { 'PG::ForeignKeyViolation: ERROR:  insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
+        engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
+
+        engine(:ruby).db(:mysql)  { 'Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails' }
+        engine(:jruby).db(:mysql) { 'Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)' }
+      end
+
+      user = UserRepository.new.create(name: 'L')
+      repository = AvatarRepository.new
+      avatar = repository.create(user_id: user.id)
+
+      expect { repository.update(avatar.id, user_id: 999_999_999) }.to raise_error do |error|
+        expect(error).to be_a(expected_error)
+        expect(error.message).to include(message)
+      end
+    end
+
+    # For MySQL [...] The CHECK clause is parsed but ignored by all storage engines.
+    # http://dev.mysql.com/doc/refman/5.7/en/create-table.html
+    unless_platform(db: :mysql) do
+      it 'raises error when "check" constraint is violated' do
+        expected_error = Platform.match do
+          os(:linux).engine(:ruby).db(:sqlite) { Hanami::Model::ConstraintViolationError }
+          default                              { Hanami::Model::CheckConstraintViolationError }
+        end
+
+        message = Platform.match do
+          engine(:ruby).db(:sqlite)   { 'SQLite3::ConstraintException' }
+          engine(:jruby).db(:sqlite)  { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: users)' }
+
+          engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "users_age_check"' }
+          engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "users_age_check"' }
+        end
+
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+
+        expect { repository.update(user.id, age: 17) }.to raise_error do |error|
+          expect(error).to be_a(expected_error)
+          expect(error.message).to include(message)
+        end
+      end
+
+      it 'raises error when constraint is violated' do
+        expected_error = Platform.match do
+          os(:linux).engine(:ruby).db(:sqlite) { Hanami::Model::ConstraintViolationError }
+          default                              { Hanami::Model::CheckConstraintViolationError }
+        end
+
+        message = Platform.match do
+          engine(:ruby).db(:sqlite)   { 'SQLite3::ConstraintException' }
+          engine(:jruby).db(:sqlite)  { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: comments_count_constraint)' }
+
+          engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "comments_count_constraint"' }
+          engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "comments_count_constraint"' }
+        end
+
+        repository = UserRepository.new
+        user = repository.create(name: 'L')
+
+        expect { repository.update(user.id, comments_count: -2) }.to raise_error do |error|
+          expect(error).to be_a(expected_error)
+          expect(error.message).to include(message)
+        end
+      end
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes record' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      deleted = repository.delete(user.id)
+
+      expect(deleted).to be_an_instance_of(User)
+      expect(deleted.id).to eq(user.id)
+      expect(deleted.name).to eq('L')
+
+      found = repository.find(user.id)
+      expect(found).to be_nil
+    end
+
+    it 'returns nil when record cannot be found' do
+      repository = UserRepository.new
+      deleted = repository.delete('9999999')
+
+      expect(deleted).to be_nil
+    end
+  end
+
+  describe '#transaction' do
+  end
+
+  describe 'custom finder' do
+    it 'returns records' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      found = repository.by_name('L')
+
+      expect(found.to_a).to include(user)
+    end
+
+    it 'uses root relation' do
+      repository = UserRepository.new
+      user = repository.create(name: 'L')
+      found = repository.by_name_with_root('L')
+
+      expect(found.to_a).to include(user)
+    end
+  end
+
+  with_platform(db: :postgresql) do
+    describe 'PostgreSQL' do
+      it 'finds record by primary key (UUID)' do
+        repository = SourceFileRepository.new
+        file = repository.create(name: 'path/to/file.rb', languages: ['ruby'], metadata: { coverage: 100.0 }, content: 'class Foo; end')
+        found = repository.find(file.id)
+
+        expect(file.languages).to eq(['ruby'])
+        expect(file.metadata).to eq(coverage: 100.0)
+
+        expect(found).to eq(file)
+      end
+
+      it 'returns nil for nil primary key (UUID)' do
+        repository = SourceFileRepository.new
+
+        found = repository.find(nil)
+        expect(found).to be_nil
+      end
+
+      # FIXME: This raises the following error
+      #
+      #   Sequel::DatabaseError: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for uuid: "9999999"
+      #   LINE 1: ...", "updated_at" FROM "source_files" WHERE ("id" = '9999999')...
+      it 'returns nil for missing record (UUID)'
+      # it 'returns nil for missing record (UUID)' do
+      #   repository = SourceFileRepository.new
+
+      #   found = repository.find('9999999')
+      #   expect(found).to be_nil
+      # end
+      describe "when timestamps aren't enabled" do
+        it 'writes the proper PG types' do
+          repository = ProductRepository.new
+
+          product = repository.create(name: 'NeoVim', categories: ['software'])
+          found = repository.find(product.id)
+
+          expect(product.categories).to eq(['software'])
+
+          expect(found).to eq(product)
+        end
+      end
+    end
+
+    describe 'enum database type' do
+      it 'allows to write data' do
+        repository = ColorRepository.new
+        color = repository.create(name: 'red')
+
+        expect(color).to be_a_kind_of(Color)
+        expect(color.name).to eq('red')
+      end
+
+      it 'raises error if the value is not included in the enum' do
+        repository = ColorRepository.new
+        message = Platform.match do
+          engine(:ruby)  { %(PG::InvalidTextRepresentation: ERROR:  invalid input value for enum rainbow: "grey") }
+          engine(:jruby) { %(Java::OrgPostgresqlUtil::PSQLException: ERROR: invalid input value for enum rainbow: "grey") }
+        end
+
+        expect { repository.create(name: 'grey') }.to raise_error do |error|
+          expect(error).to be_a(Hanami::Model::Error)
+          expect(error.message).to include(message)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/repository/legacy_spec.rb
+++ b/spec/integration/repository/legacy_spec.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+RSpec.describe 'Repository (legacy)' do
+  describe '#find' do
+    it 'finds record by primary key' do
+      repository = OperatorRepository.new
+      operator = repository.create(name: 'F')
+      found = repository.find(operator.id)
+
+      expect(operator).to eq(found)
+    end
+
+    it 'returns nil for missing record' do
+      repository = OperatorRepository.new
+      found = repository.find('9999999')
+
+      expect(found).to be_nil
+    end
+  end
+
+  describe '#all' do
+    it 'returns all the records' do
+      repository = OperatorRepository.new
+      operator = repository.create(name: 'F')
+
+      expect(repository.all).to be_an_instance_of(Array)
+      expect(repository.all).to include(operator)
+    end
+  end
+
+  describe '#first' do
+    it 'returns first record from table' do
+      repository = OperatorRepository.new
+      repository.clear
+
+      operator = repository.create(name: 'Janis Joplin')
+      repository.create(name: 'Jon')
+
+      expect(repository.first).to eq(operator)
+    end
+  end
+
+  describe '#last' do
+    it 'returns last record from table' do
+      repository = OperatorRepository.new
+      repository.clear
+
+      repository.create(name: 'Rob')
+      operator = repository.create(name: 'Amy Winehouse')
+
+      expect(repository.last).to eq(operator)
+    end
+  end
+
+  describe '#clear' do
+    it 'clears all the records' do
+      repository = OperatorRepository.new
+      repository.create(name: 'F')
+
+      repository.clear
+      expect(repository.all).to be_empty
+    end
+  end
+
+  describe '#execute' do
+  end
+
+  describe '#fetch' do
+  end
+
+  describe '#create' do
+    it 'creates record' do
+      repository = OperatorRepository.new
+      operator = repository.create(name: 'F')
+
+      expect(operator).to be_an_instance_of(Operator)
+      expect(operator.id).to_not be_nil
+      expect(operator.name).to eq('F')
+    end
+  end
+
+  describe '#update' do
+    it 'updates record' do
+      repository = OperatorRepository.new
+      operator = repository.create(name: 'F')
+      updated = repository.update(operator.id, name: 'Flo')
+
+      expect(updated).to be_an_instance_of(Operator)
+      expect(updated.id).to eq(operator.id)
+      expect(updated.name).to eq('Flo')
+    end
+
+    it 'returns nil when record cannot be found' do
+      repository = OperatorRepository.new
+      updated = repository.update('9999999', name: 'Flo')
+
+      expect(updated).to be_nil
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes record' do
+      repository = OperatorRepository.new
+      operator = repository.create(name: 'F')
+      deleted = repository.delete(operator.id)
+
+      expect(deleted).to be_an_instance_of(Operator)
+      expect(deleted.id).to eq(operator.id)
+      expect(deleted.name).to eq('F')
+
+      found = repository.find(operator.id)
+      expect(found).to be_nil
+    end
+
+    it 'returns nil when record cannot be found' do
+      repository = OperatorRepository.new
+      deleted = repository.delete('9999999')
+
+      expect(deleted).to be_nil
+    end
+  end
+
+  describe '#transaction' do
+  end
+end

--- a/spec/migrator/connection_spec.rb
+++ b/spec/migrator/connection_spec.rb
@@ -1,0 +1,187 @@
+require 'test_helper'
+require 'hanami/model/migrator/connection'
+
+RSpec.describe Hanami::Model::Migrator::Connection do
+  let(:connection) { Hanami::Model::Migrator::Connection.new(hanami_model_configuration) }
+
+  describe 'when not a jdbc connection' do
+    let(:hanami_model_configuration) do
+      OpenStruct.new(
+        url: 'postgresql://postgres:s3cr3T@127.0.0.1:5432/database'
+      )
+    end
+
+    describe '#jdbc?' do
+      it 'returns false' do
+        expect(connection.jdbc?).to eq(false)
+      end
+    end
+
+    describe '#global_uri' do
+      it 'returns connection URI without database' do
+        expect(connection.global_uri.scan('database').empty?).to eq(true)
+      end
+    end
+
+    describe '#parsed_uri?' do
+      it 'returns an URI instance' do
+        expect(connection.parsed_uri).to be_a_kind_of(URI)
+      end
+    end
+
+    describe '#host' do
+      it 'returns configured host' do
+        expect(connection.host).to eq('127.0.0.1')
+      end
+    end
+
+    describe '#port' do
+      it 'returns configured port' do
+        expect(connection.port).to eq(5432)
+      end
+    end
+
+    describe '#database' do
+      it 'returns configured database' do
+        expect(connection.database).to eq('database')
+      end
+    end
+
+    describe '#user' do
+      it 'returns configured user' do
+        expect(connection.user).to eq('postgres')
+      end
+
+      describe 'when there is no user option' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(url: 'postgresql://127.0.0.1:5432/database')
+        end
+
+        it 'returns nil' do
+          expect(connection.user).to be_nil
+        end
+      end
+    end
+
+    describe '#password' do
+      it 'returns configured password' do
+        expect(connection.password).to eq('s3cr3T')
+      end
+
+      describe 'when there is no password option' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(url: 'postgresql://127.0.0.1/database')
+        end
+
+        it 'returns nil' do
+          expect(connection.password).to be_nil
+        end
+      end
+    end
+
+    # See https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+    describe 'when connection components in uri params' do
+      let(:hanami_model_configuration) do
+        OpenStruct.new(
+          url: 'postgresql:///mydb?host=localhost&port=6433&user=postgres&password=testpasswd'
+        )
+      end
+
+      it 'returns configured database' do
+        expect(connection.database).to eq('mydb')
+      end
+
+      it 'returns configured user' do
+        expect(connection.user).to eq('postgres')
+      end
+
+      it 'returns configured password' do
+        expect(connection.password).to eq('testpasswd')
+      end
+
+      it 'returns configured host' do
+        expect(connection.host).to eq('localhost')
+      end
+
+      it 'returns configured port' do
+        expect(connection.port).to eq(6433)
+      end
+
+      describe 'with blank port' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(
+            url: 'postgresql:///mydb?host=localhost&port=&user=postgres&password=testpasswd'
+          )
+        end
+
+        it 'raises an error' do
+          expect(connection.port).to be_nil
+        end
+      end
+    end
+  end
+
+  describe 'when jdbc connection' do
+    let(:hanami_model_configuration) do
+      OpenStruct.new(
+        url: 'jdbc:postgresql://127.0.0.1:5432/database?user=postgres&password=s3cr3T'
+      )
+    end
+
+    describe '#jdbc?' do
+      it 'returns true' do
+        expect(connection.jdbc?).to eq(true)
+      end
+    end
+
+    describe '#host' do
+      it 'returns configured host' do
+        expect(connection.host).to eq('127.0.0.1')
+      end
+    end
+
+    describe '#port' do
+      it 'returns configured port' do
+        expect(connection.port).to eq(5432)
+      end
+    end
+
+    describe '#user' do
+      it 'returns configured user' do
+        expect(connection.user).to eq('postgres')
+      end
+
+      describe 'when there is no user option' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(url: 'jdbc:postgresql://127.0.0.1/database')
+        end
+
+        it 'returns nil' do
+          expect(connection.user).to be_nil
+        end
+      end
+    end
+
+    describe '#password' do
+      it 'returns configured password' do
+        expect(connection.password).to eq('s3cr3T')
+      end
+
+      describe 'when there is no password option' do
+        let(:hanami_model_configuration) do
+          OpenStruct.new(url: 'jdbc:postgresql://127.0.0.1/database')
+        end
+
+        it 'returns nil' do
+          expect(connection.password).to be_nil
+        end
+      end
+    end
+
+    describe '#database' do
+      it 'returns configured database' do
+        expect(connection.database).to eq('database')
+      end
+    end
+  end
+end

--- a/spec/migrator/mysql.rb
+++ b/spec/migrator/mysql.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 require 'securerandom'
 
-describe 'MySQL Database migrations' do
+RSpec.shared_examples 'migrator_mysql' do
   let(:migrator) do
     Hanami::Model::Migrator.new(configuration: configuration)
   end
@@ -24,7 +24,7 @@ describe 'MySQL Database migrations' do
   end
 
   describe 'MySQL' do
-    let(:database) { "#{name.gsub(/[^\w]/, '_')}_#{random}" }
+    let(:database) { "mysql_#{random}" }
 
     let(:url) do
       db = database
@@ -90,7 +90,7 @@ describe 'MySQL Database migrations' do
         it 'drops the database' do
           migrator.drop
 
-          expect { Sequel.connect(url).tables }.to_raise(Sequel::DatabaseConnectionError)
+          expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
         end
       end
     end
@@ -101,7 +101,7 @@ describe 'MySQL Database migrations' do
       end
 
       describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../fixtures/empty_migrations') }
+        let(:migrations) { Pathname.new(__dir__ + '/../support/fixtures/empty_migrations') }
 
         it "it doesn't alter database" do
           migrator.migrate
@@ -121,32 +121,32 @@ describe 'MySQL Database migrations' do
           table = connection.schema(:reviews)
 
           name, options = table[0] # id
-          name.to eq(:id)
+          expect(name).to eq(:id)
 
-          options.fetch(:allow_null).to eq(false)
-          options.fetch(:default).to be_nil
-          options.fetch(:type).to eq(:integer)
-          options.fetch(:db_type).to eq('int(11)')
-          options.fetch(:primary_key).to eq(true)
-          options.fetch(:auto_increment).to eq(true)
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:primary_key)).to eq(true)
+          expect(options.fetch(:auto_increment)).to eq(true)
 
           name, options = table[1] # title
-          name.to eq(:title)
+          expect(name).to eq(:title)
 
-          options.fetch(:allow_null).to eq(false)
-          options.fetch(:default).to be_nil
-          options.fetch(:type).to eq(:string)
-          options.fetch(:db_type).to eq('varchar(255)')
-          options.fetch(:primary_key).to eq(false)
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:string)
+          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
-          name.to eq(:rating)
+          expect(name).to eq(:rating)
 
-          options.fetch(:allow_null).to eq(true)
-          options.fetch(:default).to eq('0')
-          options.fetch(:type).to eq(:integer)
-          options.fetch(:db_type).to eq('int(11)')
-          options.fetch(:primary_key).to eq(false)
+          expect(options.fetch(:allow_null)).to eq(true)
+          expect(options.fetch(:default)).to eq('0')
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:primary_key)).to eq(false)
         end
       end
 
@@ -170,7 +170,7 @@ describe 'MySQL Database migrations' do
         end
 
         it 'migrates the database' do
-          migrator.migrate(version: '20160831073534') # see test/fixtures/migrations
+          migrator.migrate(version: '20160831073534') # see spec/support/fixtures/migrations
 
           connection = Sequel.connect(url)
           expect(connection.tables).to_not be_empty
@@ -178,23 +178,23 @@ describe 'MySQL Database migrations' do
           table = connection.schema(:reviews)
 
           name, options = table[0] # id
-          name.to eq(:id)
+          expect(name).to eq(:id)
 
-          options.fetch(:allow_null).to eq(false)
-          options.fetch(:default).to be_nil
-          options.fetch(:type).to eq(:integer)
-          options.fetch(:db_type).to eq('int(11)')
-          options.fetch(:primary_key).to eq(true)
-          options.fetch(:auto_increment).to eq(true)
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:primary_key)).to eq(true)
+          expect(options.fetch(:auto_increment)).to eq(true)
 
           name, options = table[1] # title
-          name.to eq(:title)
+          expect(name).to eq(:title)
 
-          options.fetch(:allow_null).to eq(false)
-          options.fetch(:default).to be_nil
-          options.fetch(:type).to eq(:string)
-          options.fetch(:db_type).to eq('varchar(255)')
-          options.fetch(:primary_key).to eq(false)
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:string)
+          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (rolled back second migration)
           expect(name).to be_nil
@@ -221,7 +221,7 @@ describe 'MySQL Database migrations' do
         connection = Sequel.connect(url)
         migration = connection[:schema_migrations].to_a.last
 
-        expect(migration.fetch(:filename)).to include('20160831090612') # see test/fixtures/migrations
+        expect(migration.fetch(:filename)).to include('20160831090612') # see spec/support/fixtures/migrations
       end
 
       it 'dumps database schema.sql' do
@@ -335,7 +335,7 @@ RUBY
         end
 
         it 'returns current database version' do
-          migrator.version.to eq('20160831090612') # see test/fixtures/migrations)
+          expect(migrator.version).to eq('20160831090612') # see spec/support/fixtures/migrations)
         end
       end
     end

--- a/spec/migrator/mysql.rb
+++ b/spec/migrator/mysql.rb
@@ -1,0 +1,355 @@
+require 'ostruct'
+require 'securerandom'
+
+describe 'MySQL Database migrations' do
+  let(:migrator) do
+    Hanami::Model::Migrator.new(configuration: configuration)
+  end
+
+  let(:random) { SecureRandom.hex(4) }
+
+  # General variables
+  let(:migrations)     { Pathname.new(__dir__ + '/../support/fixtures/migrations') }
+  let(:schema)         { nil }
+  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV['HANAMI_DATABASE_LOGGER'])) }
+  let(:configuration)  { Hanami::Model::Configuration.new(config) }
+
+  # Variables for `apply` and `prepare`
+  let(:root)              { Pathname.new("#{__dir__}/../../tmp").expand_path }
+  let(:source_migrations) { Pathname.new("#{__dir__}/../support/fixtures/migrations") }
+  let(:target_migrations) { root.join("migrations-#{random}") }
+
+  after do
+    migrator.drop rescue nil # rubocop:disable Style/RescueModifier
+  end
+
+  describe 'MySQL' do
+    let(:database) { "#{name.gsub(/[^\w]/, '_')}_#{random}" }
+
+    let(:url) do
+      db = database
+
+      Platform.match do
+        engine(:ruby)  { "mysql2://localhost/#{db}?user=#{ENV['HANAMI_DATABASE_USERNAME']}" }
+        engine(:jruby) { "jdbc:mysql://localhost/#{db}?user=#{ENV['HANAMI_DATABASE_USERNAME']}&useSSL=false" }
+      end
+    end
+
+    describe 'create' do
+      before do
+        migrator.create
+      end
+
+      it 'creates the database' do
+        connection = Sequel.connect(url)
+        expect(connection.tables).to be_empty
+      end
+
+      it 'raises error if database is busy' do
+        Sequel.connect(url).tables
+        expect { migrator.create }.to raise_error do |error|
+          expect(error).to be_a(Hanami::Model::MigrationError)
+          expect(error.message).to include('Database creation failed. If the database exists,')
+          expect(error.message).to include('then its console may be open. See this issue for more details:')
+          expect(error.message).to include('https://github.com/hanami/model/issues/250')
+        end
+      end
+
+      # See https://github.com/hanami/model/issues/381
+      describe 'when database name contains a dash' do
+        let(:database) { "db-name-create_#{random}" }
+
+        it 'creates the database' do
+          connection = Sequel.connect(url)
+          expect(connection.tables).to be_empty
+        end
+      end
+    end
+
+    describe 'drop' do
+      before do
+        migrator.create
+      end
+
+      it 'drops the database' do
+        migrator.drop
+        expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
+      end
+
+      it "raises error if database doesn't exist" do
+        migrator.drop # remove the first time
+
+        expect { migrator.drop }
+          .to raise_error(Hanami::Model::MigrationError, "Cannot find database: #{database}")
+      end
+
+      # See https://github.com/hanami/model/issues/381
+      describe 'when database name contains a dash' do
+        let(:database) { "db-name-drop_#{random}" }
+
+        it 'drops the database' do
+          migrator.drop
+
+          expect { Sequel.connect(url).tables }.to_raise(Sequel::DatabaseConnectionError)
+        end
+      end
+    end
+
+    describe 'migrate' do
+      before do
+        migrator.create
+      end
+
+      describe 'when no migrations' do
+        let(:migrations) { Pathname.new(__dir__ + '/../fixtures/empty_migrations') }
+
+        it "it doesn't alter database" do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to be_empty
+        end
+      end
+
+      describe 'when migrations are present' do
+        it 'migrates the database' do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to_not be_empty
+
+          table = connection.schema(:reviews)
+
+          name, options = table[0] # id
+          name.to eq(:id)
+
+          options.fetch(:allow_null).to eq(false)
+          options.fetch(:default).to be_nil
+          options.fetch(:type).to eq(:integer)
+          options.fetch(:db_type).to eq('int(11)')
+          options.fetch(:primary_key).to eq(true)
+          options.fetch(:auto_increment).to eq(true)
+
+          name, options = table[1] # title
+          name.to eq(:title)
+
+          options.fetch(:allow_null).to eq(false)
+          options.fetch(:default).to be_nil
+          options.fetch(:type).to eq(:string)
+          options.fetch(:db_type).to eq('varchar(255)')
+          options.fetch(:primary_key).to eq(false)
+
+          name, options = table[2] # rating (second migration)
+          name.to eq(:rating)
+
+          options.fetch(:allow_null).to eq(true)
+          options.fetch(:default).to eq('0')
+          options.fetch(:type).to eq(:integer)
+          options.fetch(:db_type).to eq('int(11)')
+          options.fetch(:primary_key).to eq(false)
+        end
+      end
+
+      describe 'when migrations are ran twice' do
+        before do
+          migrator.migrate
+        end
+
+        it "doesn't alter the schema" do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to_not be_empty
+          expect(connection.tables).to eq([:reviews, :schema_migrations])
+        end
+      end
+
+      describe 'migrate down' do
+        before do
+          migrator.migrate
+        end
+
+        it 'migrates the database' do
+          migrator.migrate(version: '20160831073534') # see test/fixtures/migrations
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to_not be_empty
+
+          table = connection.schema(:reviews)
+
+          name, options = table[0] # id
+          name.to eq(:id)
+
+          options.fetch(:allow_null).to eq(false)
+          options.fetch(:default).to be_nil
+          options.fetch(:type).to eq(:integer)
+          options.fetch(:db_type).to eq('int(11)')
+          options.fetch(:primary_key).to eq(true)
+          options.fetch(:auto_increment).to eq(true)
+
+          name, options = table[1] # title
+          name.to eq(:title)
+
+          options.fetch(:allow_null).to eq(false)
+          options.fetch(:default).to be_nil
+          options.fetch(:type).to eq(:string)
+          options.fetch(:db_type).to eq('varchar(255)')
+          options.fetch(:primary_key).to eq(false)
+
+          name, options = table[2] # rating (rolled back second migration)
+          expect(name).to be_nil
+          expect(options).to be_nil
+        end
+      end
+    end
+
+    describe 'apply' do
+      let(:migrations) { target_migrations }
+      let(:schema) { root.join("schema-#{random}.sql") }
+
+      before do
+        prepare_migrations_directory
+        migrator.create
+        migrator.apply
+      end
+
+      after do
+        clean_migrations
+      end
+
+      it 'migrates to latest version' do
+        connection = Sequel.connect(url)
+        migration = connection[:schema_migrations].to_a.last
+
+        expect(migration.fetch(:filename)).to include('20160831090612') # see test/fixtures/migrations
+      end
+
+      it 'dumps database schema.sql' do
+        actual = schema.read
+
+        expect(actual).to include %(DROP TABLE IF EXISTS `reviews`;)
+
+        expect(actual).to include %(CREATE TABLE `reviews`)
+        expect(actual).to include %(`id` int\(11\) NOT NULL AUTO_INCREMENT,)
+
+        expect(actual).to include %(`title` varchar(255))
+
+        expect(actual).to include %(`rating` int\(11\) DEFAULT '0',)
+        expect(actual).to include %(PRIMARY KEY \(`id`\))
+
+        expect(actual).to include %(DROP TABLE IF EXISTS `schema_migrations`;)
+
+        expect(actual).to include %(CREATE TABLE `schema_migrations` \()
+
+        expect(actual).to include %(`filename` varchar(255))
+        expect(actual).to include %(PRIMARY KEY (`filename`))
+
+        expect(actual).to include %(LOCK TABLES `schema_migrations` WRITE;)
+
+        # expect(actual).to include %(INSERT INTO `schema_migrations` VALUES \('20150610133853_create_books.rb'\),\('20150610141017_add_price_to_books.rb'\);)
+
+        expect(actual).to include %(UNLOCK TABLES;)
+      end
+
+      it 'deletes all the migrations' do
+        expect(target_migrations.children).to be_empty
+      end
+    end
+
+    describe 'prepare' do
+      let(:migrations) { target_migrations }
+      let(:schema)     { root.join("schema-#{random}.sql") }
+
+      before do
+        prepare_migrations_directory
+        migrator.create
+        migrator.migrate
+      end
+
+      after do
+        clean_migrations
+      end
+
+      it 'creates database, loads schema and migrate' do
+        # Simulate already existing schema.sql, without existing database and pending migrations
+        connection = Sequel.connect(url)
+        Hanami::Model::Migrator::Adapter.for(configuration).dump
+
+        migration = target_migrations.join('20160831095616_create_abuses.rb')
+        File.open(migration, 'w+') do |f|
+          f.write <<-RUBY
+Hanami::Model.migration do
+  change do
+    create_table :abuses do
+      primary_key :id
+    end
+  end
+end
+RUBY
+        end
+
+        migrator.prepare
+
+        tables = connection.tables
+        expect(tables).to include(:schema_migrations)
+        expect(tables).to include(:reviews)
+        expect(tables).to include(:abuses)
+
+        FileUtils.rm_f migration
+      end
+
+      it "works even if schema doesn't exist" do
+        # Simulate no database, no schema and pending migrations
+        FileUtils.rm_f schema
+
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        expect(connection.tables).to include(:schema_migrations)
+        expect(connection.tables).to include(:reviews)
+      end
+
+      it 'drops the database and recreates it' do
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        expect(connection.tables).to include(:schema_migrations)
+        expect(connection.tables).to include(:reviews)
+      end
+    end
+
+    describe 'version' do
+      before do
+        migrator.create
+      end
+
+      describe 'when no migrations were ran' do
+        it 'returns nil' do
+          expect(migrator.version).to be_nil
+        end
+      end
+
+      describe 'with migrations' do
+        before do
+          migrator.migrate
+        end
+
+        it 'returns current database version' do
+          migrator.version.to eq('20160831090612') # see test/fixtures/migrations)
+        end
+      end
+    end
+  end
+
+  private
+
+  def prepare_migrations_directory
+    target_migrations.mkpath
+    FileUtils.cp_r(Dir.glob("#{source_migrations}/*.rb"), target_migrations)
+  end
+
+  def clean_migrations
+    FileUtils.rm_rf(target_migrations)
+    FileUtils.rm(schema) if schema.exist?
+  end
+end

--- a/spec/migrator/postgresql.rb
+++ b/spec/migrator/postgresql.rb
@@ -1,0 +1,384 @@
+require 'ostruct'
+require 'securerandom'
+
+describe 'PostgreSQL Database migrations' do
+  let(:migrator) do
+    Hanami::Model::Migrator.new(configuration: configuration)
+  end
+
+  let(:random) { SecureRandom.hex(4) }
+
+  # General variables
+  let(:migrations)     { Pathname.new(__dir__ + '/../support/fixtures/migrations') }
+  let(:schema)         { nil }
+  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV['HANAMI_DATABASE_LOGGER'])) }
+  let(:configuration)  { Hanami::Model::Configuration.new(config) }
+
+  # Variables for `apply` and `prepare`
+  let(:root)              { Pathname.new("#{__dir__}/../../tmp").expand_path }
+  let(:source_migrations) { Pathname.new("#{__dir__}/../fixtures/migrations") }
+  let(:source_migrations) { Pathname.new("#{__dir__}/../support/fixtures/migrations") }
+
+  let(:target_migrations) { root.join("migrations-#{random}") }
+
+  after do
+    migrator.drop rescue nil # rubocop:disable Style/RescueModifier
+  end
+
+  describe 'PostgreSQL' do
+    let(:database) { "#{name.gsub(/[^\w]/, '_')}_#{random}" }
+
+    let(:url) do
+      db = database
+
+      Platform.match do
+        engine(:ruby)  { "postgresql://127.0.0.1/#{db}?user=#{ENV['HANAMI_DATABASE_USERNAME']}" }
+        engine(:jruby) { "jdbc:postgresql://127.0.0.1/#{db}?user=#{ENV['HANAMI_DATABASE_USERNAME']}" }
+      end
+    end
+
+    describe 'create' do
+      before do
+        migrator.create
+      end
+
+      it 'creates the database' do
+        connection = Sequel.connect(url)
+        expect(connection.tables).to be_empty
+      end
+
+      it 'raises error if database is busy' do
+        Sequel.connect(url).tables
+        expect { migrator.create }.to raise_error do |error|
+          expect(error).to be_a(Hanami::Model::MigrationError)
+
+          expect(error.message).to incldue('createdb: database creation failed. If the database exists,')
+          expect(error.message).to incldue('then its console may be open. See this issue for more details:')
+          expect(error.message).to incldue('https://github.com/hanami/model/issues/250')
+        end
+
+        describe "when a command isn't available" do
+          before do
+            # We accomplish having a command not be available by setting PATH
+            # to an empty string, which means *no commands* are available.
+            @original_path = ENV['PATH']
+            ENV['PATH'] = ''
+          end
+
+          after do
+            ENV['PATH'] = @original_path
+          end
+
+          it 'raises MigrationError on create' do
+            message = Platform.match do
+              os(:macos).engine(:jruby) { 'Unknown error - createdb' }
+              default                   { 'No such file or directory - createdb' }
+            end
+
+            expect { migrator.create }.to raise_error(Hanami::Model::MigrationError, message)
+          end
+        end
+      end
+
+      describe 'drop' do
+        before do
+          migrator.create
+        end
+
+        it 'drops the database' do
+          migrator.drop
+
+          expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
+        end
+
+        it "raises error if database doesn't exist" do
+          migrator.drop # remove the first time
+
+          expect { migrator.drop }
+            .to raise_error(Hanami::Model::MigrationError, "Cannot find database: #{database}")
+        end
+      end
+
+      describe 'migrate' do
+        before do
+          migrator.create
+        end
+
+        describe 'when no migrations' do
+          let(:migrations) { Pathname.new(__dir__ + '/../fixtures/empty_migrations') }
+
+          it "it doesn't alter database" do
+            migrator.migrate
+
+            connection = Sequel.connect(url)
+            expect(connection.tables).to be_empty
+          end
+        end
+
+        describe 'when migrations are present' do
+          it 'migrates the database' do
+            migrator.migrate
+
+            connection = Sequel.connect(url)
+            expect(connection.tables).to_not be_empty
+
+            table = connection.schema(:reviews)
+
+            name, options = table[0] # id
+            expect(name).to eq(:id)
+
+            expect(options.fetch(:allow_null)).to eq(false)
+            expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
+            expect(options.fetch(:type)).to eq(:integer)
+            expect(options.fetch(:db_type)).to eq('integer')
+            expect(options.fetch(:primary_key)).to eq(true)
+            expect(options.fetch(:auto_increment)).to eq(true)
+
+            name, options = table[1] # title
+            expect(name).to eq(:title)
+
+            expect(options.fetch(:allow_null)).to eq(false)
+            expect(options.fetch(:default)).to be_nil
+            expect(options.fetch(:type)).to eq(:string)
+            expect(options.fetch(:db_type)).to eq('text')
+            expect(options.fetch(:primary_key)).to eq(false)
+
+            name, options = table[2] # rating (second migration)
+            expect(name).to eq(:rating)
+
+            expect(options.fetch(:allow_null)).to eq(true)
+            expect(options.fetch(:default)).to eq('0')
+            expect(options.fetch(:type)).to eq(:integer)
+            expect(options.fetch(:db_type)).to eq('integer')
+            expect(options.fetch(:primary_key)).to eq(false)
+          end
+        end
+
+        describe 'when migrations are ran twice' do
+          before do
+            migrator.migrate
+          end
+
+          it "doesn't alter the schema" do
+            migrator.migrate
+
+            connection = Sequel.connect(url)
+            connection.tables.wont_be :empty?
+            expect(connection.tables).to include(:schema_migrations)
+            expect(connection.tables).to include(:reviews)
+          end
+        end
+
+        describe 'migrate down' do
+          before do
+            migrator.migrate
+          end
+
+          it 'migrates the database' do
+            migrator.migrate(version: '20160831073534') # see test/fixtures/migrations
+
+            connection = Sequel.connect(url)
+            connection.tables.wont_be :empty?
+
+            table = connection.schema(:reviews)
+
+            name, options = table[0] # id
+            expect(name).to eq(:id)
+
+            expect(options.fetch(:allow_null)).to eq(false)
+            expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
+            expect(options.fetch(:type)).to eq(:integer)
+            expect(options.fetch(:db_type)).to eq('integer')
+            expect(options.fetch(:primary_key)).to eq(true)
+            expect(options.fetch(:auto_increment)).to eq(true)
+
+            name, options = table[1] # title
+            expect(name).to eq(:title)
+
+            expect(options.fetch(:allow_null)).to eq(false)
+            expect(options.fetch(:default)).to be_nil
+            expect(options.fetch(:type)).to eq(:string)
+            expect(options.fetch(:db_type)).to eq('text')
+            expect(options.fetch(:primary_key)).to eq(false)
+
+            name, options = table[2] # rating (rolled back second migration)
+            expect(name).to be_nil
+            expect(options).to be_nil
+          end
+        end
+      end
+
+      describe 'apply' do
+        let(:migrations) { target_migrations }
+        let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
+
+        before do
+          prepare_migrations_directory
+          migrator.create
+          migrator.apply
+        end
+
+        after do
+          clean_migrations
+        end
+
+        it 'migrates to latest version' do
+          connection = Sequel.connect(url)
+          migration = connection[:schema_migrations].to_a.last
+
+          expect(migration.fetch(:filename)).to include('20160831090612') # see test/fixtures/migrations
+        end
+
+        it 'dumps database schema.sql' do
+          actual = schema.read
+
+          expect(actual).to include <<-SQL
+CREATE TABLE reviews (
+    id integer NOT NULL,
+    title text NOT NULL,
+    rating integer DEFAULT 0
+);
+          SQL
+
+          expect(actual).to include <<-SQL
+CREATE SEQUENCE reviews_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+          SQL
+
+          expect(actual).to include <<-SQL
+ALTER SEQUENCE reviews_id_seq OWNED BY reviews.id;
+          SQL
+
+          expect(actual).to include <<-SQL
+ALTER TABLE ONLY reviews ALTER COLUMN id SET DEFAULT nextval('reviews_id_seq'::regclass);
+          SQL
+
+          expect(actual).to include <<-SQL
+ALTER TABLE ONLY reviews
+    ADD CONSTRAINT reviews_pkey PRIMARY KEY (id);
+          SQL
+
+          expect(actual).to include <<-SQL
+CREATE TABLE schema_migrations (
+    filename text NOT NULL
+);
+          SQL
+
+          expect(actual).to include <<-SQL
+COPY schema_migrations (filename) FROM stdin;
+20160831073534_create_reviews.rb
+20160831090612_add_rating_to_reviews.rb
+          SQL
+
+          expect(actual).to include <<-SQL
+ALTER TABLE ONLY schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (filename);
+          SQL
+        end
+
+        it 'deletes all the migrations' do
+          expect(target_migrations.children).to be_empty
+        end
+      end
+
+      describe 'prepare' do
+        let(:migrations) { target_migrations }
+        let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
+
+        before do
+          prepare_migrations_directory
+          migrator.create
+        end
+
+        after do
+          clean_migrations
+        end
+
+        it 'creates database, loads schema and migrate' do
+          # Simulate already existing schema.sql, without existing database and pending migrations
+          Hanami::Model::Migrator::Adapter.for(configuration).dump
+
+          migration = target_migrations.join('20160831095616_create_abuses.rb')
+          File.open(migration, 'w+') do |f|
+            f.write <<-RUBY
+Hanami::Model.migration do
+  change do
+    create_table :abuses do
+      primary_key :id
+    end
+  end
+end
+            RUBY
+          end
+
+          migrator.prepare
+
+          connection = Sequel.connect(url)
+          tables = connection.tables
+          expect(tables).to include(:schema_migrations)
+          expect(tables).to include(:reviews)
+          expect(tables).to include(:abuses)
+
+          FileUtils.rm_f migration
+        end
+
+        it "works even if schema doesn't exist" do
+          # Simulate no database, no schema and pending migrations
+          FileUtils.rm_f schema
+
+          migrator.prepare
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to include(:schema_migrations)
+          expect(connection.tables).to include(:reviews)
+        end
+
+        it 'drops the database and recreates it' do
+          migrator.prepare
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to include(:schema_migrations)
+          expect(connection.tables).to include(:reviews)
+        end
+      end
+
+      describe 'version' do
+        before do
+          migrator.create
+        end
+
+        describe 'when no migrations were ran' do
+          it 'returns nil' do
+            expect(migrator.version).to be_nil
+          end
+        end
+
+        describe 'with migrations' do
+          before do
+            migrator.migrate
+          end
+
+          it 'returns current database version' do
+            expect(migrator.version).to eq('20160831090612') # see test/fixtures/migrations)
+          end
+        end
+      end
+    end
+
+    private
+
+    def prepare_migrations_directory
+      target_migrations.mkpath
+      FileUtils.cp_r(Dir.glob("#{source_migrations}/*.rb"), target_migrations)
+    end
+
+    def clean_migrations
+      FileUtils.rm_rf(target_migrations)
+      FileUtils.rm(schema) if schema.exist?
+    end
+  end
+end

--- a/spec/migrator/postgresql.rb
+++ b/spec/migrator/postgresql.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 require 'securerandom'
 
-describe 'PostgreSQL Database migrations' do
+RSpec.shared_examples 'migrator_postgresql' do
   let(:migrator) do
     Hanami::Model::Migrator.new(configuration: configuration)
   end
@@ -16,7 +16,6 @@ describe 'PostgreSQL Database migrations' do
 
   # Variables for `apply` and `prepare`
   let(:root)              { Pathname.new("#{__dir__}/../../tmp").expand_path }
-  let(:source_migrations) { Pathname.new("#{__dir__}/../fixtures/migrations") }
   let(:source_migrations) { Pathname.new("#{__dir__}/../support/fixtures/migrations") }
 
   let(:target_migrations) { root.join("migrations-#{random}") }
@@ -26,8 +25,7 @@ describe 'PostgreSQL Database migrations' do
   end
 
   describe 'PostgreSQL' do
-    let(:database) { "#{name.gsub(/[^\w]/, '_')}_#{random}" }
-
+    let(:database) { random }
     let(:url) do
       db = database
 
@@ -52,333 +50,332 @@ describe 'PostgreSQL Database migrations' do
         expect { migrator.create }.to raise_error do |error|
           expect(error).to be_a(Hanami::Model::MigrationError)
 
-          expect(error.message).to incldue('createdb: database creation failed. If the database exists,')
-          expect(error.message).to incldue('then its console may be open. See this issue for more details:')
-          expect(error.message).to incldue('https://github.com/hanami/model/issues/250')
-        end
-
-        describe "when a command isn't available" do
-          before do
-            # We accomplish having a command not be available by setting PATH
-            # to an empty string, which means *no commands* are available.
-            @original_path = ENV['PATH']
-            ENV['PATH'] = ''
-          end
-
-          after do
-            ENV['PATH'] = @original_path
-          end
-
-          it 'raises MigrationError on create' do
-            message = Platform.match do
-              os(:macos).engine(:jruby) { 'Unknown error - createdb' }
-              default                   { 'No such file or directory - createdb' }
-            end
-
-            expect { migrator.create }.to raise_error(Hanami::Model::MigrationError, message)
-          end
+          expect(error.message).to include('createdb: database creation failed. If the database exists,')
+          expect(error.message).to include('then its console may be open. See this issue for more details:')
+          expect(error.message).to include('https://github.com/hanami/model/issues/250')
         end
       end
 
-      describe 'drop' do
+      describe "when a command isn't available" do
         before do
-          migrator.create
-        end
-
-        it 'drops the database' do
-          migrator.drop
-
-          expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
-        end
-
-        it "raises error if database doesn't exist" do
-          migrator.drop # remove the first time
-
-          expect { migrator.drop }
-            .to raise_error(Hanami::Model::MigrationError, "Cannot find database: #{database}")
-        end
-      end
-
-      describe 'migrate' do
-        before do
-          migrator.create
-        end
-
-        describe 'when no migrations' do
-          let(:migrations) { Pathname.new(__dir__ + '/../fixtures/empty_migrations') }
-
-          it "it doesn't alter database" do
-            migrator.migrate
-
-            connection = Sequel.connect(url)
-            expect(connection.tables).to be_empty
-          end
-        end
-
-        describe 'when migrations are present' do
-          it 'migrates the database' do
-            migrator.migrate
-
-            connection = Sequel.connect(url)
-            expect(connection.tables).to_not be_empty
-
-            table = connection.schema(:reviews)
-
-            name, options = table[0] # id
-            expect(name).to eq(:id)
-
-            expect(options.fetch(:allow_null)).to eq(false)
-            expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
-            expect(options.fetch(:type)).to eq(:integer)
-            expect(options.fetch(:db_type)).to eq('integer')
-            expect(options.fetch(:primary_key)).to eq(true)
-            expect(options.fetch(:auto_increment)).to eq(true)
-
-            name, options = table[1] # title
-            expect(name).to eq(:title)
-
-            expect(options.fetch(:allow_null)).to eq(false)
-            expect(options.fetch(:default)).to be_nil
-            expect(options.fetch(:type)).to eq(:string)
-            expect(options.fetch(:db_type)).to eq('text')
-            expect(options.fetch(:primary_key)).to eq(false)
-
-            name, options = table[2] # rating (second migration)
-            expect(name).to eq(:rating)
-
-            expect(options.fetch(:allow_null)).to eq(true)
-            expect(options.fetch(:default)).to eq('0')
-            expect(options.fetch(:type)).to eq(:integer)
-            expect(options.fetch(:db_type)).to eq('integer')
-            expect(options.fetch(:primary_key)).to eq(false)
-          end
-        end
-
-        describe 'when migrations are ran twice' do
-          before do
-            migrator.migrate
-          end
-
-          it "doesn't alter the schema" do
-            migrator.migrate
-
-            connection = Sequel.connect(url)
-            connection.tables.wont_be :empty?
-            expect(connection.tables).to include(:schema_migrations)
-            expect(connection.tables).to include(:reviews)
-          end
-        end
-
-        describe 'migrate down' do
-          before do
-            migrator.migrate
-          end
-
-          it 'migrates the database' do
-            migrator.migrate(version: '20160831073534') # see test/fixtures/migrations
-
-            connection = Sequel.connect(url)
-            connection.tables.wont_be :empty?
-
-            table = connection.schema(:reviews)
-
-            name, options = table[0] # id
-            expect(name).to eq(:id)
-
-            expect(options.fetch(:allow_null)).to eq(false)
-            expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
-            expect(options.fetch(:type)).to eq(:integer)
-            expect(options.fetch(:db_type)).to eq('integer')
-            expect(options.fetch(:primary_key)).to eq(true)
-            expect(options.fetch(:auto_increment)).to eq(true)
-
-            name, options = table[1] # title
-            expect(name).to eq(:title)
-
-            expect(options.fetch(:allow_null)).to eq(false)
-            expect(options.fetch(:default)).to be_nil
-            expect(options.fetch(:type)).to eq(:string)
-            expect(options.fetch(:db_type)).to eq('text')
-            expect(options.fetch(:primary_key)).to eq(false)
-
-            name, options = table[2] # rating (rolled back second migration)
-            expect(name).to be_nil
-            expect(options).to be_nil
-          end
-        end
-      end
-
-      describe 'apply' do
-        let(:migrations) { target_migrations }
-        let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
-
-        before do
-          prepare_migrations_directory
-          migrator.create
-          migrator.apply
+          # We accomplish having a command not be available by setting PATH
+          # to an empty string, which means *no commands* are available.
+          @original_path = ENV['PATH']
+          ENV['PATH'] = ''
         end
 
         after do
-          clean_migrations
+          ENV['PATH'] = @original_path
         end
 
-        it 'migrates to latest version' do
+        it 'raises MigrationError on create' do
+          message = Platform.match do
+            os(:macos).engine(:jruby) { 'Unknown error - createdb' }
+            default                   { 'No such file or directory - createdb' }
+          end
+
+          expect { migrator.create }.to raise_error(Hanami::Model::MigrationError, message)
+        end
+      end
+    end
+    describe 'drop' do
+      before do
+        migrator.create
+      end
+
+      it 'drops the database' do
+        migrator.drop
+
+        expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
+      end
+
+      it "raises error if database doesn't exist" do
+        migrator.drop # remove the first time
+
+        expect { migrator.drop }
+          .to raise_error(Hanami::Model::MigrationError, "Cannot find database: #{database}")
+      end
+    end
+
+    describe 'migrate' do
+      before do
+        migrator.create
+      end
+
+      describe 'when no migrations' do
+        let(:migrations) { Pathname.new(__dir__ + '/../support/fixtures/empty_migrations') }
+
+        it "it doesn't alter database" do
+          migrator.migrate
+
           connection = Sequel.connect(url)
-          migration = connection[:schema_migrations].to_a.last
+          expect(connection.tables).to be_empty
+        end
+      end
 
-          expect(migration.fetch(:filename)).to include('20160831090612') # see test/fixtures/migrations
+      describe 'when migrations are present' do
+        it 'migrates the database' do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to_not be_empty
+
+          table = connection.schema(:reviews)
+
+          name, options = table[0] # id
+          expect(name).to eq(:id)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:primary_key)).to eq(true)
+          expect(options.fetch(:auto_increment)).to eq(true)
+
+          name, options = table[1] # title
+          expect(name).to eq(:title)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:string)
+          expect(options.fetch(:db_type)).to eq('text')
+          expect(options.fetch(:primary_key)).to eq(false)
+
+          name, options = table[2] # rating (second migration)
+          expect(name).to eq(:rating)
+
+          expect(options.fetch(:allow_null)).to eq(true)
+          expect(options.fetch(:default)).to eq('0')
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:primary_key)).to eq(false)
+        end
+      end
+
+      describe 'when migrations are ran twice' do
+        before do
+          migrator.migrate
         end
 
-        it 'dumps database schema.sql' do
-          actual = schema.read
+        it "doesn't alter the schema" do
+          migrator.migrate
 
-          expect(actual).to include <<-SQL
+          connection = Sequel.connect(url)
+          expect(connection.tables).to_not be_empty
+          expect(connection.tables).to include(:schema_migrations)
+          expect(connection.tables).to include(:reviews)
+        end
+      end
+
+      describe 'migrate down' do
+        before do
+          migrator.migrate
+        end
+
+        it 'migrates the database' do
+          migrator.migrate(version: '20160831073534') # see spec/support/fixtures/migrations
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to_not be_empty
+
+          table = connection.schema(:reviews)
+
+          name, options = table[0] # id
+          expect(name).to eq(:id)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:primary_key)).to eq(true)
+          expect(options.fetch(:auto_increment)).to eq(true)
+
+          name, options = table[1] # title
+          expect(name).to eq(:title)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:string)
+          expect(options.fetch(:db_type)).to eq('text')
+          expect(options.fetch(:primary_key)).to eq(false)
+
+          name, options = table[2] # rating (rolled back second migration)
+          expect(name).to be_nil
+          expect(options).to be_nil
+        end
+      end
+    end
+
+    describe 'apply' do
+      let(:migrations) { target_migrations }
+      let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
+
+      before do
+        prepare_migrations_directory
+        migrator.create
+        migrator.apply
+      end
+
+      after do
+        clean_migrations
+      end
+
+      it 'migrates to latest version' do
+        connection = Sequel.connect(url)
+        migration = connection[:schema_migrations].to_a.last
+
+        expect(migration.fetch(:filename)).to include('20160831090612') # see spec/support/fixtures/migrations
+      end
+
+      it 'dumps database schema.sql' do
+        actual = schema.read
+
+        expect(actual).to include <<-SQL
 CREATE TABLE reviews (
     id integer NOT NULL,
     title text NOT NULL,
     rating integer DEFAULT 0
 );
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 CREATE SEQUENCE reviews_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 ALTER SEQUENCE reviews_id_seq OWNED BY reviews.id;
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 ALTER TABLE ONLY reviews ALTER COLUMN id SET DEFAULT nextval('reviews_id_seq'::regclass);
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 ALTER TABLE ONLY reviews
     ADD CONSTRAINT reviews_pkey PRIMARY KEY (id);
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 CREATE TABLE schema_migrations (
     filename text NOT NULL
 );
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 COPY schema_migrations (filename) FROM stdin;
 20160831073534_create_reviews.rb
 20160831090612_add_rating_to_reviews.rb
-          SQL
+        SQL
 
-          expect(actual).to include <<-SQL
+        expect(actual).to include <<-SQL
 ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (filename);
-          SQL
+        SQL
+      end
+
+      it 'deletes all the migrations' do
+        expect(target_migrations.children).to be_empty
+      end
+    end
+
+    describe 'prepare' do
+      let(:migrations) { target_migrations }
+      let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
+
+      before do
+        prepare_migrations_directory
+        migrator.create
+      end
+
+      after do
+        clean_migrations
+      end
+
+      it 'creates database, loads schema and migrate' do
+        # Simulate already existing schema.sql, without existing database and pending migrations
+        Hanami::Model::Migrator::Adapter.for(configuration).dump
+
+        migration = target_migrations.join('20160831095616_create_abuses.rb')
+        File.open(migration, 'w+') do |f|
+          f.write <<-RUBY
+          Hanami::Model.migration do
+            change do
+              create_table :abuses do
+                primary_key :id
+              end
+            end
+          end
+          RUBY
         end
 
-        it 'deletes all the migrations' do
-          expect(target_migrations.children).to be_empty
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        tables = connection.tables
+        expect(tables).to include(:schema_migrations)
+        expect(tables).to include(:reviews)
+        expect(tables).to include(:abuses)
+
+        FileUtils.rm_f migration
+      end
+
+      it "works even if schema doesn't exist" do
+        # Simulate no database, no schema and pending migrations
+        FileUtils.rm_f schema
+
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        expect(connection.tables).to include(:schema_migrations)
+        expect(connection.tables).to include(:reviews)
+      end
+
+      it 'drops the database and recreates it' do
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        expect(connection.tables).to include(:schema_migrations)
+        expect(connection.tables).to include(:reviews)
+      end
+    end
+
+    describe 'version' do
+      before do
+        migrator.create
+      end
+
+      describe 'when no migrations were ran' do
+        it 'returns nil' do
+          expect(migrator.version).to be_nil
         end
       end
 
-      describe 'prepare' do
-        let(:migrations) { target_migrations }
-        let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
-
+      describe 'with migrations' do
         before do
-          prepare_migrations_directory
-          migrator.create
+          migrator.migrate
         end
 
-        after do
-          clean_migrations
+        it 'returns current database version' do
+          expect(migrator.version).to eq('20160831090612') # see spec/support/fixtures/migrations)
         end
-
-        it 'creates database, loads schema and migrate' do
-          # Simulate already existing schema.sql, without existing database and pending migrations
-          Hanami::Model::Migrator::Adapter.for(configuration).dump
-
-          migration = target_migrations.join('20160831095616_create_abuses.rb')
-          File.open(migration, 'w+') do |f|
-            f.write <<-RUBY
-Hanami::Model.migration do
-  change do
-    create_table :abuses do
-      primary_key :id
+      end
     end
   end
-end
-            RUBY
-          end
 
-          migrator.prepare
+  private
 
-          connection = Sequel.connect(url)
-          tables = connection.tables
-          expect(tables).to include(:schema_migrations)
-          expect(tables).to include(:reviews)
-          expect(tables).to include(:abuses)
+  def prepare_migrations_directory
+    target_migrations.mkpath
+    FileUtils.cp_r(Dir.glob("#{source_migrations}/*.rb"), target_migrations)
+  end
 
-          FileUtils.rm_f migration
-        end
-
-        it "works even if schema doesn't exist" do
-          # Simulate no database, no schema and pending migrations
-          FileUtils.rm_f schema
-
-          migrator.prepare
-
-          connection = Sequel.connect(url)
-          expect(connection.tables).to include(:schema_migrations)
-          expect(connection.tables).to include(:reviews)
-        end
-
-        it 'drops the database and recreates it' do
-          migrator.prepare
-
-          connection = Sequel.connect(url)
-          expect(connection.tables).to include(:schema_migrations)
-          expect(connection.tables).to include(:reviews)
-        end
-      end
-
-      describe 'version' do
-        before do
-          migrator.create
-        end
-
-        describe 'when no migrations were ran' do
-          it 'returns nil' do
-            expect(migrator.version).to be_nil
-          end
-        end
-
-        describe 'with migrations' do
-          before do
-            migrator.migrate
-          end
-
-          it 'returns current database version' do
-            expect(migrator.version).to eq('20160831090612') # see test/fixtures/migrations)
-          end
-        end
-      end
-    end
-
-    private
-
-    def prepare_migrations_directory
-      target_migrations.mkpath
-      FileUtils.cp_r(Dir.glob("#{source_migrations}/*.rb"), target_migrations)
-    end
-
-    def clean_migrations
-      FileUtils.rm_rf(target_migrations)
-      FileUtils.rm(schema) if schema.exist?
-    end
+  def clean_migrations
+    FileUtils.rm_rf(target_migrations)
+    FileUtils.rm(schema) if schema.exist?
   end
 end

--- a/spec/migrator/sqlite.rb
+++ b/spec/migrator/sqlite.rb
@@ -1,0 +1,323 @@
+require 'ostruct'
+require 'securerandom'
+
+describe 'Filesystem SQLite Database migrations' do
+  let(:migrator) do
+    Hanami::Model::Migrator.new(configuration: configuration)
+  end
+
+  let(:random) { SecureRandom.hex }
+
+  # General variables
+  let(:migrations)     { Pathname.new(__dir__ + '/../support/fixtures/migrations') }
+  let(:schema)         { nil }
+  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV['HANAMI_DATABASE_LOGGER'])) }
+  let(:configuration)  { Hanami::Model::Configuration.new(config) }
+  let(:url) do
+    db = database
+
+    Platform.match do
+      engine(:ruby)  { "sqlite://#{db}" }
+      engine(:jruby) { "jdbc:sqlite://#{db}" }
+    end
+  end
+
+  # Variables for `apply` and `prepare`
+  let(:root)              { Pathname.new("#{__dir__}/../tmp").expand_path }
+  let(:source_migrations) { Pathname.new("#{__dir__}/../support/fixtures/migrations") }
+  let(:target_migrations) { root.join("migrations-#{random}") }
+
+  after do
+    migrator.drop rescue nil # rubocop:disable Style/RescueModifier
+  end
+
+  describe 'SQLite filesystem' do
+    let(:database) do
+      Pathname.new("#{__dir__}/../../tmp/create-#{random}.sqlite3").expand_path
+    end
+
+    describe 'create' do
+      it 'creates the database' do
+        migrator.create
+        expect(File.exist?(database)).to be_true, "Expected database #{database} to exist"
+      end
+
+      describe "when it doesn't have write permissions" do
+        let(:database) { '/usr/bin/create.sqlite3' }
+
+        it 'raises an error' do
+          error = Platform.match do
+            os(:macos).engine(:jruby) { Java::JavaLang::RuntimeException }
+            default { Hanami::Model::MigrationError }
+          end
+
+          message = Platform.match do
+            os(:macos).engine(:jruby) { 'Unhandled IOException: java.io.IOException: unhandled errno: Operation not permitted' }
+            default { 'Permission denied: /usr/bin/create.sqlite3' }
+          end
+
+          expect { migrator.create }.to raise_error(error, message)
+        end
+      end
+
+      describe 'when the path is relative' do
+        let(:database) { 'create.sqlite3' }
+
+        it 'creates the database' do
+          migrator.create
+          expect(File.exist?(database)).to be_true, "Expected database #{database} to exist"
+        end
+      end
+    end
+
+    describe 'drop' do
+      before do
+        migrator.create
+      end
+
+      it 'drops the database' do
+        migrator.drop
+        expect(File.exist?(database)).to be_false, "Expected database #{database} to NOT exist"
+      end
+
+      it "raises error if database doesn't exist" do
+        migrator.drop # remove the first time
+
+        expect { migrator.drop }
+          .to raise_error(Hanami::Model::MigrationError, "Cannot find database: #{database}")
+      end
+    end
+
+    describe 'migrate' do
+      before do
+        migrator.create
+      end
+
+      describe 'when no migrations' do
+        let(:migrations) { Pathname.new(__dir__ + '/../fixtures/empty_migrations') }
+
+        it "it doesn't alter database" do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          expect(connection.tables).to be_empty
+        end
+      end
+
+      describe 'when migrations are present' do
+        it 'migrates the database' do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          connection.tables.wont_be :empty?
+
+          table = connection.schema(:reviews)
+
+          name, options = table[0] # id
+          expect(name).to eq(:id)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:primary_key)).to eq(true)
+          expect(options.fetch(:auto_increment)).to eq(true)
+
+          name, options = table[1] # title
+          expect(name).to eq(:title)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:string)
+          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:primary_key)).to eq(false)
+
+          name, options = table[2] # rating (second migration)
+          expect(name).to eq(:rating)
+
+          expect(options.fetch(:allow_null)).to eq(true)
+          expect(options.fetch(:default)).to eq('0')
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:primary_key)).to eq(false)
+        end
+      end
+
+      describe 'when migrations are ran twice' do
+        before do
+          migrator.migrate
+        end
+
+        it "doesn't alter the schema" do
+          migrator.migrate
+
+          connection = Sequel.connect(url)
+          connection.tables.wont_be :empty?
+          expect(connection.tables).to eq([:schema_migrations, :reviews])
+        end
+      end
+
+      describe 'migrate down' do
+        before do
+          migrator.migrate
+        end
+
+        it 'migrates the database' do
+          migrator.migrate(version: '20160831073534') # see test/fixtures/migrations
+
+          connection = Sequel.connect(url)
+          connection.tables.wont_be :empty?
+
+          table = connection.schema(:reviews)
+
+          name, options = table[0] # id
+          expect(name).to eq(:id)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:integer)
+          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:primary_key)).to eq(true)
+          expect(options.fetch(:auto_increment)).to eq(true)
+
+          name, options = table[1] # title
+          expect(name).to eq(:title)
+
+          expect(options.fetch(:allow_null)).to eq(false)
+          expect(options.fetch(:default)).to be_nil
+          expect(options.fetch(:type)).to eq(:string)
+          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:primary_key)).to eq(false)
+
+          name, options = table[2] # rating (rolled back second migration)
+          expect(name).to be_nil
+          expect(options).to be_nil
+        end
+      end
+    end
+
+    describe 'apply' do
+      let(:migrations) { target_migrations }
+      let(:schema)     { root.join("schema-sqlite-#{random}.sql") }
+
+      before do
+        prepare_migrations_directory
+        migrator.apply
+      end
+
+      after do
+        clean_migrations
+      end
+
+      it 'migrates to latest version' do
+        connection = Sequel.connect(url)
+        migration = connection[:schema_migrations].to_a.last
+
+        expect(migration.fetch(:filename)).to include('20160831090612') # see test/fixtures/migrations
+      end
+
+      it 'dumps database schema.sql' do
+        actual = schema.read
+
+        expect(actual).to include %(CREATE TABLE `schema_migrations` (`filename` varchar(255) NOT NULL PRIMARY KEY);)
+        expect(actual).to include %(CREATE TABLE `reviews` (`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT, `title` varchar(255) NOT NULL, `rating` integer DEFAULT (0));)
+        expect(actual).to include %(INSERT INTO "schema_migrations" VALUES('20160831073534_create_reviews.rb');)
+        expect(actual).to include %(INSERT INTO "schema_migrations" VALUES('20160831090612_add_rating_to_reviews.rb');)
+      end
+
+      it 'deletes all the migrations' do
+        expect(target_migrations.children).to be_empty
+      end
+    end
+
+    describe 'prepare' do
+      let(:migrations) { target_migrations }
+      let(:schema)     { root.join("schema-sqlite-#{random}.sql") }
+
+      before do
+        prepare_migrations_directory
+      end
+
+      after do
+        clean_migrations
+      end
+
+      it 'creates database, loads schema and migrate' do
+        # Simulate already existing schema.sql, without existing database and pending migrations
+        connection = Sequel.connect(url)
+        Hanami::Model::Migrator::Adapter.for(configuration).dump
+
+        migration = target_migrations.join('20160831095616_create_abuses.rb')
+        File.open(migration, 'w+') do |f|
+          f.write <<-RUBY
+Hanami::Model.migration do
+  change do
+    create_table :abuses do
+      primary_key :id
+    end
+  end
+end
+RUBY
+        end
+
+        migrator.prepare
+
+        expect(connection.tables).to eq([:schema_migrations, :reviews, :abuses])
+
+        FileUtils.rm_f migration
+      end
+
+      it "works even if schema doesn't exist" do
+        # Simulate no database, no schema and pending migrations
+        FileUtils.rm_f schema
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        expect(connection.tables).to eq([:schema_migrations, :reviews])
+      end
+
+      it 'drops the database and recreate it' do
+        migrator.create
+        migrator.prepare
+
+        connection = Sequel.connect(url)
+        expect(connection.tables).to include(:schema_migrations)
+        expect(connection.tables).to include(:reviews)
+      end
+    end
+
+    describe 'version' do
+      before do
+        migrator.create
+      end
+
+      describe 'when no migrations were ran' do
+        it 'returns nil' do
+          expect(migrator.version).to be_nil
+        end
+      end
+
+      describe 'with migrations' do
+        before do
+          migrator.migrate
+        end
+
+        it 'returns current database version' do
+          expect(migrator.version).to eq('20160831090612') # see test/fixtures/migrations)
+        end
+      end
+    end
+  end
+
+  private
+
+  def prepare_migrations_directory
+    target_migrations.mkpath
+    FileUtils.cp_r(Dir.glob("#{source_migrations}/*.rb"), target_migrations)
+  end
+
+  def clean_migrations
+    FileUtils.rm_rf(target_migrations)
+    FileUtils.rm(schema) if schema.exist?
+  end
+end

--- a/spec/migrator/sqlite.rb
+++ b/spec/migrator/sqlite.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 require 'securerandom'
 
-describe 'Filesystem SQLite Database migrations' do
+RSpec.shared_examples 'migrator_sqlite' do
   let(:migrator) do
     Hanami::Model::Migrator.new(configuration: configuration)
   end
@@ -39,7 +39,7 @@ describe 'Filesystem SQLite Database migrations' do
     describe 'create' do
       it 'creates the database' do
         migrator.create
-        expect(File.exist?(database)).to be_true, "Expected database #{database} to exist"
+        expect(File.exist?(database)).to be_truthy, "Expected database #{database} to exist"
       end
 
       describe "when it doesn't have write permissions" do
@@ -65,7 +65,7 @@ describe 'Filesystem SQLite Database migrations' do
 
         it 'creates the database' do
           migrator.create
-          expect(File.exist?(database)).to be_true, "Expected database #{database} to exist"
+          expect(File.exist?(database)).to be_truthy, "Expected database #{database} to exist"
         end
       end
     end
@@ -77,7 +77,7 @@ describe 'Filesystem SQLite Database migrations' do
 
       it 'drops the database' do
         migrator.drop
-        expect(File.exist?(database)).to be_false, "Expected database #{database} to NOT exist"
+        expect(File.exist?(database)).to be_falsey, "Expected database #{database} to NOT exist"
       end
 
       it "raises error if database doesn't exist" do
@@ -94,7 +94,7 @@ describe 'Filesystem SQLite Database migrations' do
       end
 
       describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../fixtures/empty_migrations') }
+        let(:migrations) { Pathname.new(__dir__ + '/../support/fixtures/empty_migrations') }
 
         it "it doesn't alter database" do
           migrator.migrate
@@ -109,7 +109,7 @@ describe 'Filesystem SQLite Database migrations' do
           migrator.migrate
 
           connection = Sequel.connect(url)
-          connection.tables.wont_be :empty?
+          expect(connection.tables).to_not be_empty
 
           table = connection.schema(:reviews)
 
@@ -152,7 +152,7 @@ describe 'Filesystem SQLite Database migrations' do
           migrator.migrate
 
           connection = Sequel.connect(url)
-          connection.tables.wont_be :empty?
+          expect(connection.tables).to_not be_empty
           expect(connection.tables).to eq([:schema_migrations, :reviews])
         end
       end
@@ -163,10 +163,10 @@ describe 'Filesystem SQLite Database migrations' do
         end
 
         it 'migrates the database' do
-          migrator.migrate(version: '20160831073534') # see test/fixtures/migrations
+          migrator.migrate(version: '20160831073534') # see spec/support/fixtures/migrations
 
           connection = Sequel.connect(url)
-          connection.tables.wont_be :empty?
+          expect(connection.tables).to_not be_empty
 
           table = connection.schema(:reviews)
 
@@ -213,7 +213,7 @@ describe 'Filesystem SQLite Database migrations' do
         connection = Sequel.connect(url)
         migration = connection[:schema_migrations].to_a.last
 
-        expect(migration.fetch(:filename)).to include('20160831090612') # see test/fixtures/migrations
+        expect(migration.fetch(:filename)).to include('20160831090612') # see spec/support/fixtures/migrations
       end
 
       it 'dumps database schema.sql' do
@@ -303,7 +303,7 @@ RUBY
         end
 
         it 'returns current database version' do
-          expect(migrator.version).to eq('20160831090612') # see test/fixtures/migrations)
+          expect(migrator.version).to eq('20160831090612') # see spec/support/fixtures/migrations)
         end
       end
     end

--- a/spec/migrator_spec.rb
+++ b/spec/migrator_spec.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+require 'hanami/model/migrator'
+
+describe Hanami::Model::Migrator do
+  # load "spec/migrator/#{Database.engine}.rb"
+end

--- a/spec/migrator_spec.rb
+++ b/spec/migrator_spec.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 require 'hanami/model/migrator'
+require_relative "./migrator/#{Database.engine}.rb"
 
 describe Hanami::Model::Migrator do
-  # load "spec/migrator/#{Database.engine}.rb"
+  include_examples "migrator_#{Database.engine}"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/spec/sql/console/mysql.rb
+++ b/spec/sql/console/mysql.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+require 'hanami/model/sql/consoles/mysql'
+
+describe Hanami::Model::Sql::Consoles::Mysql do
+  let(:console) { Hanami::Model::Sql::Consoles::Mysql.new(uri) }
+
+  describe '#connection_string' do
+    let(:uri) { URI.parse('mysql://username:password@localhost:1234/foo_development') }
+
+    it 'returns a connection string' do
+      expect(console.connection_string).to eq('mysql -h localhost -D foo_development -P 1234 -u username -p password')
+    end
+  end
+end

--- a/spec/sql/console/postgresql.rb
+++ b/spec/sql/console/postgresql.rb
@@ -1,0 +1,19 @@
+require 'hanami/model/sql/consoles/postgresql'
+
+describe Hanami::Model::Sql::Consoles::Postgresql do
+  let(:console) { Hanami::Model::Sql::Consoles::Postgresql.new(uri) }
+
+  describe '#connection_string' do
+    let(:uri) { URI.parse('postgres://username:password@localhost:1234/foo_development') }
+
+    it 'returns a connection string' do
+      expect(console.connection_string).to eq('psql -h localhost -d foo_development -p 1234 -U username')
+    end
+
+    it 'sets the PGPASSWORD environment variable' do
+      console.connection_string
+      expect(ENV['PGPASSWORD']).to eq('password')
+      ENV.delete('PGPASSWORD')
+    end
+  end
+end

--- a/spec/sql/console/sqlite.rb
+++ b/spec/sql/console/sqlite.rb
@@ -1,0 +1,21 @@
+require 'hanami/model/sql/consoles/sqlite'
+
+describe Hanami::Model::Sql::Consoles::Sqlite do
+  let(:console) { Hanami::Model::Sql::Consoles::Sqlite.new(uri) }
+
+  describe '#connection_string' do
+    describe 'with shell ok database uri' do
+      let(:uri) { URI.parse('sqlite://foo/bar.db') }
+      it 'returns a connection string for Sqlite3' do
+        expect(console.connection_string).to eq('sqlite3 foo/bar.db')
+      end
+    end
+
+    describe 'with non shell ok database uri' do
+      let(:uri) { URI.parse('sqlite://foo/%20bar.db') }
+      it 'returns an escaped connection string for Sqlite3' do
+        expect(console.connection_string).to eq('sqlite3 foo/\\%20bar.db')
+      end
+    end
+  end
+end

--- a/spec/sql/console_spec.rb
+++ b/spec/sql/console_spec.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'hanami/model/sql/console'
+
+RSpec.describe Hanami::Model::Sql::Console do
+  describe 'deciding on which SQL console class to use, based on URI scheme' do
+    let(:uri) { 'username:password@localhost:1234/foo_development' }
+
+    case Database.engine
+    when :sqlite
+      it 'sqlite:// uri returns an instance of Console::Sqlite' do
+        console = Hanami::Model::Sql::Console.new("sqlite://#{uri}").send(:console)
+        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Sqlite)
+      end
+    when :postgresql
+      it 'postgres:// uri returns an instance of Console::Postgresql' do
+        console = Hanami::Model::Sql::Console.new("postgres://#{uri}").send(:console)
+        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
+      end
+
+      it 'postgresql:// uri returns an instance of Console::Postgresql' do
+        console = Hanami::Model::Sql::Console.new("postgresql://#{uri}").send(:console)
+        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
+      end
+    when :mysql
+      it 'mysql:// uri returns an instance of Console::Mysql' do
+        console = Hanami::Model::Sql::Console.new("mysql://#{uri}").send(:console)
+        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
+      end
+
+      it 'mysql2:// uri returns an instance of Console::Mysql' do
+        console = Hanami::Model::Sql::Console.new("mysql2://#{uri}").send(:console)
+        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
+      end
+    end
+  end
+
+  describe Database.engine.to_s do
+    # load "test/sql/console/#{Database.engine}.rb" #TODO FFS
+  end
+end

--- a/spec/sql/entity/schema/automatic_spec.rb
+++ b/spec/sql/entity/schema/automatic_spec.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Entity::Schema do
+  describe 'automatic' do
+    let(:subject) { Author.schema }
+
+    describe '#initialize' do
+      it 'returns frozen instance' do
+        expect(subject).to be_frozen
+      end
+    end
+
+    describe '#call' do
+      it 'returns empty hash when nil is given' do
+        result = subject.call(nil)
+
+        expect(result).to eq({})
+      end
+
+      it 'processes attributes' do
+        now = Time.now
+        result = subject.call(id: 1, created_at: now.to_s)
+
+        expect(result.fetch(:id)).to eq(1)
+        expect(result.fetch(:created_at)).to be_within(2).of(now)
+      end
+
+      it 'ignores unknown attributes' do
+        result = subject.call(foo: 'bar')
+
+        expect(result).to eq({})
+      end
+    end
+
+    describe '#attribute?' do
+      it 'returns true for known attributes' do
+        expect(subject.attribute?(:id)).to eq(true)
+      end
+
+      it 'returns false for unknown attributes' do
+        expect(subject.attribute?(:foo)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/sql/entity/schema/mapping_spec.rb
+++ b/spec/sql/entity/schema/mapping_spec.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Entity::Schema do
+  describe 'mapping' do
+    let(:subject) { Operator.schema }
+
+    describe '#initialize' do
+      it 'returns frozen instance' do
+        expect(subject).to be_frozen
+      end
+    end
+
+    describe '#call' do
+      it 'returns empty hash when nil is given' do
+        result = subject.call(nil)
+
+        expect(result).to eq({})
+      end
+
+      it 'processes attributes' do
+        result = subject.call(id: 1, name: :foo)
+
+        expect(result).to eq(id: 1, name: 'foo')
+      end
+
+      it 'ignores unknown attributes' do
+        result = subject.call(foo: 'bar')
+
+        expect(result).to eq({})
+      end
+    end
+
+    describe '#attribute?' do
+      it 'returns true for known attributes' do
+        expect(subject.attribute?(:id)).to eq(true)
+      end
+
+      it 'returns false for unknown attributes' do
+        expect(subject.attribute?(:foo)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/sql/schema/array_spec.rb
+++ b/spec/sql/schema/array_spec.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Array do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Array }
+  let(:input) do
+    Class.new do
+      def to_ary
+        []
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_ary' do
+    expect(described_class[input]).to eq(input.to_ary)
+  end
+
+  it 'coerces string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for symbol' do
+    input = :foo
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for integer' do
+    input = 11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for float' do
+    input = 3.14
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for date' do
+    input = Date.today
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for datetime' do
+    input = DateTime.new
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'raises error for time' do
+    input = Time.now
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+
+  it 'coerces array' do
+    input = []
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
+  end
+end

--- a/spec/sql/schema/bool_spec.rb
+++ b/spec/sql/schema/bool_spec.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Bool do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Bool }
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'returns true for true' do
+    input = true
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'returns false for false' do
+    input = true
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'raises error for string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for symbol' do
+    input = :foo
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for integer' do
+    input = 11
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for float' do
+    input = 3.14
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for date' do
+    input = Date.today
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for datetime' do
+    input = DateTime.new
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for time' do
+    input = Time.now
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+  end
+end

--- a/spec/sql/schema/date_spec.rb
+++ b/spec/sql/schema/date_spec.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Date do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Date }
+  let(:input) do
+    Class.new do
+      def to_date
+        Date.today
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_date' do
+    expect(described_class[input]).to eq(input.to_date)
+  end
+
+  it 'coerces string' do
+    date = Date.today
+    input = date.to_s
+
+    expect(described_class[input]).to eq(date)
+  end
+
+  it 'coerces Hanami string' do
+    input = Hanami::Utils::String.new(Date.today)
+    expect(described_class[input]).to eq(Date.parse(input))
+  end
+
+  it 'raises error for meaningless string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, 'invalid date')
+  end
+
+  it 'raises error for symbol' do
+    input = :foo
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
+  end
+
+  it 'raises error for integer' do
+    input = 11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
+  end
+
+  it 'raises error for float' do
+    input = 3.14
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
+  end
+
+  it 'raises error for bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
+  end
+
+  it 'coerces date' do
+    input = Date.today
+    date = input
+
+    expect(described_class[input]).to eq(date)
+  end
+
+  it 'coerces datetime' do
+    input = DateTime.new
+    date = input.to_date
+
+    expect(described_class[input]).to eq(date)
+  end
+
+  it 'coerces time' do
+    input = Time.now
+    date = input.to_date
+
+    expect(described_class[input]).to eq(date)
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
+  end
+end

--- a/spec/sql/schema/date_time_spec.rb
+++ b/spec/sql/schema/date_time_spec.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::DateTime do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::DateTime }
+  let(:input) do
+    Class.new do
+      def to_datetime
+        DateTime.new
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_datetime' do
+    expect(described_class[input]).to eq(input.to_datetime)
+  end
+
+  it 'coerces string' do
+    date = DateTime.new
+    input = date.to_s
+
+    expect(described_class[input]).to eq(date)
+  end
+
+  it 'coerces Hanami string' do
+    input = Hanami::Utils::String.new(DateTime.new)
+    expect(described_class[input]).to eq(DateTime.parse(input))
+  end
+
+  it 'raises error for meaningless string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, 'invalid date')
+  end
+
+  it 'raises error for symbol' do
+    input = :foo
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
+  end
+
+  it 'raises error for integer' do
+    input = 11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
+  end
+
+  it 'raises error for float' do
+    input = 3.14
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
+  end
+
+  it 'raises error for bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
+  end
+
+  it 'coerces date' do
+    input = Date.today
+    date_time = input.to_datetime
+
+    expect(described_class[input]).to eq(date_time)
+  end
+
+  it 'coerces datetime' do
+    input = DateTime.new
+    date_time = input
+
+    expect(described_class[input]).to eq(date_time)
+  end
+
+  it 'coerces time' do
+    input = Time.now
+    date_time = input.to_datetime
+
+    expect(described_class[input]).to be_within(2).of(date_time)
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
+  end
+end

--- a/spec/sql/schema/decimal_spec.rb
+++ b/spec/sql/schema/decimal_spec.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Decimal do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Decimal }
+  let(:input) do
+    Class.new do
+      def to_d
+        BigDecimal.new(10)
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_d' do
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'coerces string representing int' do
+    input = '1'
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'coerces Hanami string representing int' do
+    input = Hanami::Utils::String.new('1')
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'coerces string representing float' do
+    input = '3.14'
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'coerces Hanami string representing float' do
+    input = Hanami::Utils::String.new('3.14')
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'raises error for symbol' do
+    input = :house_11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
+  end
+
+  it 'coerces integer' do
+    input = 23
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'coerces float' do
+    input = 3.14
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'coerces bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect(described_class[input]).to eq(input.to_d)
+  end
+
+  it 'raises error for date' do
+    input = Date.today
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
+  end
+
+  it 'raises error for datetime' do
+    input = DateTime.new
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
+  end
+
+  it 'raises error for time' do
+    input = Time.now
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
+  end
+end

--- a/spec/sql/schema/float_spec.rb
+++ b/spec/sql/schema/float_spec.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Float do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Float }
+  let(:input) do
+    Class.new do
+      def to_f
+        3.14
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_f' do
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'coerces string representing int' do
+    input = '1'
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'coerces Hanami string representing int' do
+    input = Hanami::Utils::String.new('1')
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'coerces string representing float' do
+    input = '3.14'
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'coerces Hanami string representing float' do
+    input = Hanami::Utils::String.new('3.14')
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'raises error for meaningless string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+
+  it 'raises error for symbol' do
+    input = :house_11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+
+  it 'coerces integer' do
+    input = 23
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'coerces float' do
+    input = 3.14
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'coerces bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect(described_class[input]).to eq(input.to_f)
+  end
+
+  it 'raises error for date' do
+    input = Date.today
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+
+  it 'raises error for datetime' do
+    input = DateTime.new
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+
+  it 'raises error for time' do
+    input = Time.now
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
+  end
+end

--- a/spec/sql/schema/hash_spec.rb
+++ b/spec/sql/schema/hash_spec.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+require 'hanami/utils/hash'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Hash do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Hash }
+  let(:input) do
+    Class.new do
+      def to_hash
+        Hash[]
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_hash' do
+    expect(described_class[input]).to eq(input.to_hash)
+  end
+
+  it 'coerces string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for symbol' do
+    input = :foo
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for integer' do
+    input = 11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for float' do
+    input = 3.14
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for date' do
+    input = Date.today
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for datetime' do
+    input = DateTime.new
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for time' do
+    input = Time.now
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
+  end
+
+  it 'coerces hash' do
+    input = {}
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces Hanami hash' do
+    input = Hanami::Utils::Hash.new({})
+    expect(described_class[input]).to eq(input.to_h)
+  end
+end

--- a/spec/sql/schema/int_spec.rb
+++ b/spec/sql/schema/int_spec.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::Int do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Int }
+  let(:input) do
+    Class.new do
+      def to_int
+        23
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_int' do
+    expect(described_class[input]).to eq(input.to_int)
+  end
+
+  it 'coerces string representing int' do
+    input = '1'
+    expect(described_class[input]).to eq(input.to_i)
+  end
+
+  it 'coerces Hanami string representing int' do
+    input = Hanami::Utils::String.new('1')
+    expect(described_class[input]).to eq(input.to_i)
+  end
+
+  it 'raises error for meaningless string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+
+  it 'raises error for symbol' do
+    input = :house_11
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+
+  it 'coerces integer' do
+    input = 23
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces float' do
+    input = 3.14
+    expect(described_class[input]).to eq(input.to_i)
+  end
+
+  it 'coerces bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect(described_class[input]).to eq(input.to_i)
+  end
+
+  it 'raises error for date' do
+    input = Date.today
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+
+  it 'raises error for datetime' do
+    input = DateTime.new
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+
+  it 'raises error for time' do
+    input = Time.now
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
+  end
+end

--- a/spec/sql/schema/string_spec.rb
+++ b/spec/sql/schema/string_spec.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::Sql::Types::Schema::String do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::String }
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces string' do
+    input = 'foo'
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces symbol' do
+    input = :foo
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces integer' do
+    input = 23
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces float' do
+    input = 3.14
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces date' do
+    input = Date.today
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces datetime' do
+    input = DateTime.new
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces time' do
+    input = Time.now
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces array' do
+    input = []
+    expect(described_class[input]).to eq(input.to_s)
+  end
+
+  it 'coerces hash' do
+    input = {}
+    expect(described_class[input]).to eq(input.to_s)
+  end
+end

--- a/spec/sql/schema/time_spec.rb
+++ b/spec/sql/schema/time_spec.rb
@@ -1,0 +1,97 @@
+require 'test_helper'
+
+describe Hanami::Model::Sql::Types::Schema::Time do
+  let(:described_class) { Hanami::Model::Sql::Types::Schema::Time }
+  let(:input) do
+    Class.new do
+      def to_time
+        Time.now
+      end
+    end.new
+  end
+
+  it 'returns nil for nil' do
+    input = nil
+    expect(described_class[input]).to eq(input)
+  end
+
+  it 'coerces object that respond to #to_time' do
+    expect(described_class[input]).to be_within(2).of(input.to_time)
+  end
+
+  it 'coerces string' do
+    time = Time.now
+    input = time.to_s
+
+    expect(described_class[input]).to be_within(2).of(time)
+  end
+
+  it 'coerces Hanami string' do
+    input = Hanami::Utils::String.new(Time.now)
+    expect(described_class[input]).to be_within(2).of(Time.parse(input))
+  end
+
+  it 'raises error for meaningless string' do
+    input = 'foo'
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "no time information in #{input.inspect}")
+  end
+
+  it 'raises error for symbol' do
+    input = :foo
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
+  end
+
+  it 'coerces integer' do
+    input = 11
+    time = Time.at(input)
+
+    expect(described_class[input]).to be_within(2).of(time)
+  end
+
+  it 'raises error for float' do
+    input = 3.14
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
+  end
+
+  it 'raises error for bigdecimal' do
+    input = BigDecimal.new(3.14, 10)
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
+  end
+
+  it 'coerces date' do
+    input = Date.today
+    time = input.to_time
+
+    expect(described_class[input]).to be_within(2).of(time)
+  end
+
+  it 'coerces datetime' do
+    input = DateTime.new
+    time = input.to_time
+
+    expect(described_class[input]).to be_within(2).of(time)
+  end
+
+  it 'coerces time' do
+    input = Time.now
+    time = input
+
+    expect(described_class[input]).to be_within(2).of(time)
+  end
+
+  it 'raises error for array' do
+    input = []
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
+  end
+
+  it 'raises error for hash' do
+    input = {}
+    expect { described_class[input] }
+      .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
+  end
+end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,0 +1,51 @@
+module Database
+  class Setup
+    DEFAULT_ADAPTER = 'sqlite'.freeze
+
+    def initialize(adapter: ENV['DB'])
+      @strategy = Strategy.for(adapter || DEFAULT_ADAPTER)
+    end
+
+    def run
+      @strategy.run
+    end
+  end
+
+  module Strategies
+    require_relative './database/strategies/sqlite'
+    require_relative './database/strategies/postgresql'
+    require_relative './database/strategies/mysql'
+
+    def self.strategies
+      constants.map do |const|
+        const_get(const)
+      end
+    end
+  end
+
+  class Strategy
+    class << self
+      def for(adapter)
+        strategies.find do |strategy|
+          strategy.eligible?(adapter)
+        end.new
+      end
+
+      private
+
+      def strategies
+        Strategies.strategies
+      end
+    end
+  end
+
+  def self.engine
+    ENV['HANAMI_DATABASE_TYPE'].to_sym
+  end
+
+  def self.engine?(name)
+    engine == name.to_sym
+  end
+end
+
+Database::Setup.new.run

--- a/spec/support/database/strategies/abstract.rb
+++ b/spec/support/database/strategies/abstract.rb
@@ -1,0 +1,63 @@
+module Database
+  module Strategies
+    class Abstract
+      def self.eligible?(_adapter)
+        false
+      end
+
+      def run
+        before
+        load_dependencies
+        export_env
+        create_database
+        configure
+        after
+        sleep 1
+      end
+
+      protected
+
+      def before
+        # Optional hook for subclasses
+      end
+
+      def database_name
+        'hanami_model'
+      end
+
+      def load_dependencies
+        raise NotImplementedError
+      end
+
+      def export_env
+        ENV['HANAMI_DATABASE_NAME'] = database_name
+      end
+
+      def create_database
+        raise NotImplementedError
+      end
+
+      def configure
+        returing = Hanami::Model.configure do
+          adapter ENV['HANAMI_DATABASE_ADAPTER'].to_sym, ENV['HANAMI_DATABASE_URL']
+        end
+
+        returing == Hanami::Model or raise 'Hanami::Model.configure should return Hanami::Model'
+      end
+
+      def after
+        # Optional hook for subclasses
+      end
+
+      private
+
+      def jruby?
+        Platform::Engine.engine?(:jruby)
+      end
+
+      def ci?
+        Platform.ci?
+      end
+    end
+  end
+end

--- a/spec/support/database/strategies/mysql.rb
+++ b/spec/support/database/strategies/mysql.rb
@@ -1,0 +1,87 @@
+require_relative 'sql'
+
+module Database
+  module Strategies
+    class Mysql < Sql
+      module JrubyImplementation
+        protected
+
+        def load_dependencies
+          require 'hanami/model/sql'
+          require 'jdbc/mysql'
+        end
+
+        def export_env
+          super
+          ENV['HANAMI_DATABASE_URL'] = "jdbc:mysql://#{host}/#{database_name}?#{credentials}"
+        end
+
+        def host
+          ENV['HANAMI_DATABASE_HOST'] || '127.0.0.1'
+        end
+
+        def credentials
+          Hash[
+            'user'     => ENV['HANAMI_DATABASE_USERNAME'],
+            'password' => ENV['HANAMI_DATABASE_PASSWORD'],
+            'useSSL'   => 'false'
+          ].map do |key, value|
+            "#{key}=#{value}" unless Hanami::Utils::Blank.blank?(value)
+          end.compact.join('&')
+        end
+      end
+
+      module CiImplementation
+        protected
+
+        def export_env
+          super
+          ENV['HANAMI_DATABASE_USERNAME'] = 'travis'
+        end
+
+        private
+
+        def run_command(command)
+          result = system %(mysql -u root -e "#{command}")
+          raise "Failed command:\n#{command}" unless result
+        end
+      end
+
+      def self.eligible?(adapter)
+        adapter.start_with?('mysql')
+      end
+
+      def initialize
+        extend(CiImplementation)    if ci?
+        extend(JrubyImplementation) if jruby?
+      end
+
+      protected
+
+      def load_dependencies
+        require 'hanami/model/sql'
+        require 'mysql2'
+      end
+
+      def export_env
+        super
+        ENV['HANAMI_DATABASE_TYPE'] = 'mysql'
+        ENV['HANAMI_DATABASE_USERNAME'] ||= 'root'
+        ENV['HANAMI_DATABASE_PASSWORD'] ||= ''
+        ENV['HANAMI_DATABASE_URL'] = "mysql2://#{credentials}@#{host}/#{database_name}"
+      end
+
+      def create_database
+        run_command "DROP DATABASE IF EXISTS #{database_name}"
+        run_command "CREATE DATABASE #{database_name}"
+        run_command "GRANT ALL PRIVILEGES ON #{database_name}.* TO '#{ENV['HANAMI_DATABASE_USERNAME']}'@'#{host}'; FLUSH PRIVILEGES;"
+      end
+
+      private
+
+      def run_command(command)
+        system %(mysql -u #{ENV['HANAMI_DATABASE_USERNAME']} -e "#{command}")
+      end
+    end
+  end
+end

--- a/spec/support/database/strategies/postgresql.rb
+++ b/spec/support/database/strategies/postgresql.rb
@@ -1,0 +1,73 @@
+require_relative 'sql'
+
+module Database
+  module Strategies
+    class Postgresql < Sql
+      module JrubyImplementation
+        protected
+
+        def load_dependencies
+          require 'hanami/model/sql'
+          require 'jdbc/postgres'
+
+          Jdbc::Postgres.load_driver
+        end
+
+        def export_env
+          super
+          ENV['HANAMI_DATABASE_URL'] = "jdbc:postgresql://#{host}/#{database_name}"
+        end
+      end
+
+      module CiImplementation
+        protected
+
+        def export_env
+          super
+          ENV['HANAMI_DATABASE_USERNAME'] = 'postgres'
+        end
+      end
+
+      def self.eligible?(adapter)
+        adapter.start_with?('postgres')
+      end
+
+      def initialize
+        extend(CiImplementation)    if ci?
+        extend(JrubyImplementation) if jruby?
+      end
+
+      protected
+
+      def load_dependencies
+        require 'hanami/model/sql'
+        require 'pg'
+      end
+
+      def create_database
+        try("Failed to drop Postgres database: #{database_name}") do
+          system "dropdb #{database_name}"
+        end
+
+        try("Failed to create Postgres database: #{database_name}") do
+          system "createdb #{database_name}"
+        end
+      end
+
+      def export_env
+        super
+        ENV['HANAMI_DATABASE_TYPE'] = 'postgresql'
+        ENV['HANAMI_DATABASE_URL'] = "postgres://#{host}/#{database_name}"
+        ENV['HANAMI_DATABASE_USERNAME'] = `whoami`.strip.freeze
+      end
+
+      private
+
+      def try(message)
+        yield
+      rescue
+        warn message
+      end
+    end
+  end
+end

--- a/spec/support/database/strategies/sql.rb
+++ b/spec/support/database/strategies/sql.rb
@@ -1,0 +1,70 @@
+require_relative 'abstract'
+require 'hanami/utils/blank'
+require 'pathname'
+require 'stringio'
+
+module Database
+  module Strategies
+    class Sql < Abstract
+      def self.eligible?(_adapter)
+        false
+      end
+
+      protected
+
+      def before
+        super
+        logger.unlink if logger.exist?
+        logger.dirname.mkpath
+      end
+
+      def export_env
+        super
+        ENV['HANAMI_DATABASE_ADAPTER'] = 'sql'
+        ENV['HANAMI_DATABASE_LOGGER'] = logger.to_s
+      end
+
+      def configure # rubocop:disable Metrics/AbcSize
+        Hanami::Model.configure do
+          adapter    ENV['HANAMI_DATABASE_ADAPTER'].to_sym, ENV['HANAMI_DATABASE_URL']
+          logger     ENV['HANAMI_DATABASE_LOGGER'], level: :debug
+          migrations Dir.pwd + '/test/fixtures/database_migrations'
+          schema     Dir.pwd + '/tmp/schema.sql'
+
+          migrations_logger ENV['HANAMI_DATABASE_LOGGER']
+
+          gateway do |g|
+            g.connection.extension(:pg_enum) if Database.engine?(:postgresql)
+          end
+        end
+      end
+
+      def after
+        migrate
+        puts "Testing with `#{ENV['HANAMI_DATABASE_ADAPTER']}' adapter (#{ENV['HANAMI_DATABASE_TYPE']}) - jruby: #{jruby?}, ci: #{ci?}"
+        puts "Env: #{ENV.inspect}" if ci?
+      end
+
+      def migrate
+        TestIO.with_stdout do
+          require 'hanami/model/migrator'
+          Hanami::Model::Migrator.migrate
+        end
+      end
+
+      def credentials
+        [ENV['HANAMI_DATABASE_USERNAME'], ENV['HANAMI_DATABASE_PASSWORD']].reject do |token|
+          Hanami::Utils::Blank.blank?(token)
+        end.join(':')
+      end
+
+      def host
+        ENV['HANAMI_DATABASE_HOST'] || 'localhost'
+      end
+
+      def logger
+        Pathname.new('tmp').join('hanami_model.log')
+      end
+    end
+  end
+end

--- a/spec/support/database/strategies/sqlite.rb
+++ b/spec/support/database/strategies/sqlite.rb
@@ -1,0 +1,59 @@
+require_relative 'sql'
+require 'pathname'
+
+module Database
+  module Strategies
+    class Sqlite < Sql
+      module JrubyImplementation
+        protected
+
+        def load_dependencies
+          require 'hanami/model/sql'
+          require 'jdbc/sqlite3'
+          Jdbc::SQLite3.load_driver
+        end
+
+        def export_env
+          super
+          ENV['HANAMI_DATABASE_URL'] = "jdbc:sqlite://#{database_name}"
+        end
+      end
+
+      module CiImplementation
+      end
+
+      def self.eligible?(adapter)
+        adapter.start_with?('sqlite')
+      end
+
+      def initialize
+        extend(CiImplementation)    if ci?
+        extend(JrubyImplementation) if jruby?
+      end
+
+      protected
+
+      def database_name
+        Pathname.new(__dir__).join('..', '..', '..', '..', 'tmp', 'sqlite', "#{super}.sqlite3").to_s
+      end
+
+      def load_dependencies
+        require 'hanami/model/sql'
+        require 'sqlite3'
+      end
+
+      def create_database
+        path = Pathname.new(database_name)
+        path.dirname.mkpath        # create directory if not exist
+
+        path.delete if path.exist? # delete file if exist
+      end
+
+      def export_env
+        super
+        ENV['HANAMI_DATABASE_TYPE'] = 'sqlite'
+        ENV['HANAMI_DATABASE_URL'] = "sqlite://#{database_name}"
+      end
+    end
+  end
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,0 +1,156 @@
+class User < Hanami::Entity
+end
+
+class Avatar < Hanami::Entity
+end
+
+class Author < Hanami::Entity
+end
+
+class Book < Hanami::Entity
+end
+
+class Operator < Hanami::Entity
+end
+
+class SourceFile < Hanami::Entity
+end
+
+class Warehouse < Hanami::Entity
+  attributes do
+    attribute :id,   Types::Int
+    attribute :name, Types::String
+    attribute :code, Types::String.constrained(format: /\Awh\-/)
+  end
+end
+
+class Account < Hanami::Entity
+  attributes do
+    attribute :id,         Types::Strict::Int
+    attribute :name,       Types::String
+    attribute :codes,      Types::Collection(Types::Coercible::Int)
+    attribute :users,      Types::Collection(User)
+    attribute :email,      Types::String.constrained(format: /@/)
+    attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })
+  end
+end
+
+class Product < Hanami::Entity
+end
+
+class Color < Hanami::Entity
+end
+
+class Label < Hanami::Entity
+end
+
+class UserRepository < Hanami::Repository
+  def by_name(name)
+    users.where(name: name)
+  end
+
+  def by_name_with_root(name)
+    root.where(name: name).as(:entity)
+  end
+
+  def find_all_by_manual_query
+    users.read("select * from users").to_a
+  end
+end
+
+class AvatarRepository < Hanami::Repository
+end
+
+class AuthorRepository < Hanami::Repository
+  associations do
+    has_many :books
+  end
+
+  def create_with_books(data)
+    assoc(:books).create(data)
+  end
+
+  def find_with_books(id)
+    aggregate(:books).where(authors__id: id).as(Author).one
+  end
+
+  def books_for(author)
+    assoc(:books, author)
+  end
+
+  def add_book(author, data)
+    assoc(:books, author).add(data)
+  end
+
+  def remove_book(author, id)
+    assoc(:books, author).remove(id)
+  end
+
+  def delete_books(author)
+    assoc(:books, author).delete
+  end
+
+  def delete_on_sales_books(author)
+    assoc(:books, author).where(on_sale: true).delete
+  end
+
+  def books_count(author)
+    assoc(:books, author).count
+  end
+
+  def on_sales_books_count(author)
+    assoc(:books, author).where(on_sale: true).count
+  end
+
+  def find_book(author, id)
+    book_for(author, id).one
+  end
+
+  def book_exists?(author, id)
+    book_for(author, id).exists?
+  end
+
+  private
+
+  def book_for(author, id)
+    assoc(:books, author).where(id: id)
+  end
+end
+
+class BookRepository < Hanami::Repository
+  associations do
+    belongs_to :author
+  end
+end
+
+class OperatorRepository < Hanami::Repository
+  self.relation = :t_operator
+
+  mapping do
+    attribute :id,   from: :operator_id
+    attribute :name, from: :s_name
+  end
+end
+
+class SourceFileRepository < Hanami::Repository
+end
+
+class WarehouseRepository < Hanami::Repository
+end
+
+class ProductRepository < Hanami::Repository
+end
+
+class ColorRepository < Hanami::Repository
+  schema do
+    attribute :id,         Hanami::Model::Sql::Types::Int
+    attribute :name,       Hanami::Model::Sql::Types::String
+    attribute :created_at, Hanami::Model::Sql::Types::DateTime
+    attribute :updated_at, Hanami::Model::Sql::Types::DateTime
+  end
+end
+
+class LabelRepository < Hanami::Repository
+end
+
+Hanami::Model.load!

--- a/spec/support/fixtures/database_migrations/20150612081248_column_types.rb
+++ b/spec/support/fixtures/database_migrations/20150612081248_column_types.rb
@@ -1,0 +1,147 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :sqlite
+      create_table :column_types do
+        column :integer1, Integer
+        column :integer2, :integer
+        column :integer3, 'integer'
+
+        column :string1, String
+        column :string2, :string
+        column :string3, 'string'
+        column :string4, 'varchar(3)'
+
+        column :string5, String, size: 50
+        column :string6, String, fixed: true
+        column :string7, String, fixed: true, size: 64
+        column :string8, String, text: true
+
+        column :file1, File
+        column :file2, 'blob'
+
+        column :number1, Fixnum # rubocop:disable Lint/UnifiedInteger
+        column :number2, :Bignum
+        column :number3, Float
+        column :number4, BigDecimal
+        column :number5, BigDecimal, size: 10
+        column :number6, BigDecimal, size: [10, 2]
+        column :number7, Numeric
+
+        column :date1, Date
+        column :date2, DateTime
+
+        column :time1, Time
+        column :time2, Time, only_time: true
+
+        column :boolean1, TrueClass
+        column :boolean2, FalseClass
+      end
+    when :postgresql
+      execute 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
+      execute "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');"
+      execute %{
+        CREATE TYPE inventory_item AS (
+          name            text,
+          supplier_id     integer,
+          price           numeric
+        );
+      }
+
+      create_table :column_types do
+        column :integer1, Integer
+        column :integer2, :integer
+        column :integer3, 'integer'
+
+        column :string1, String
+        column :string2, 'text'
+        column :string3, 'character varying(1)'
+        column :string4, 'varchar(2)'
+        column :string5, 'character(3)'
+        column :string6, 'char(4)'
+
+        column :string7, String, size: 50
+        column :string8, String, fixed: true
+        column :string9, String, fixed: true, size: 64
+        column :string10, String, text: true
+
+        column :file1, File
+        column :file2, 'bytea'
+
+        column :number1, Fixnum # rubocop:disable Lint/UnifiedInteger
+        column :number2, :Bignum
+        column :number3, Float
+        column :number4, BigDecimal
+        column :number5, BigDecimal, size: 10
+        column :number6, BigDecimal, size: [10, 2]
+        column :number7, Numeric
+
+        column :date1, Date
+        column :date2, DateTime
+
+        column :time1, Time
+        column :time2, Time, only_time: true
+
+        column :boolean1, TrueClass
+        column :boolean2, FalseClass
+
+        column :array1, 'integer[]'
+        column :array2, 'integer[3]'
+        column :array3, 'text[][]'
+
+        column :money1, 'money'
+
+        column :enum1, 'mood'
+
+        column :geometric1, 'point'
+        column :geometric2, 'line'
+        column :geometric3, 'circle', default: '<(15,15), 1>'
+
+        column :net1, 'cidr', default: '192.168/24'
+
+        column :uuid1, 'uuid', default: Hanami::Model::Sql.function(:uuid_generate_v4)
+
+        column :xml1, 'xml'
+
+        column :json1, 'json'
+        column :json2, 'jsonb'
+
+        column :composite1, 'inventory_item', default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
+      end
+    when :mysql
+      create_table :column_types do
+        column :integer1, Integer
+        column :integer2, :integer
+        column :integer3, 'integer'
+
+        column :string1, String
+        column :string2, 'varchar(3)'
+
+        column :string5, String, size: 50
+        column :string6, String, fixed: true
+        column :string7, String, fixed: true, size: 64
+        column :string8, String, text: true
+
+        column :file1, File
+        column :file2, 'blob'
+
+        column :number1, Fixnum # rubocop:disable Lint/UnifiedInteger
+        column :number2, :Bignum
+        column :number3, Float
+        column :number4, BigDecimal
+        column :number5, BigDecimal, size: 10
+        column :number6, BigDecimal, size: [10, 2]
+        column :number7, Numeric
+
+        column :date1, Date
+        column :date2, DateTime
+
+        column :time1, Time
+        column :time2, Time, only_time: true
+
+        column :boolean1, TrueClass
+        column :boolean2, FalseClass
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612084656_default_values.rb
+++ b/spec/support/fixtures/database_migrations/20150612084656_default_values.rb
@@ -1,0 +1,51 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :sqlite
+      create_table :default_values do
+        column :a, Integer,    default: 23
+        column :b, String,     default: 'Hanami'
+        column :c, Fixnum,     default: -1 # rubocop:disable Lint/UnifiedInteger
+        column :d, :Bignum,    default: 0
+        column :e, Float,      default: 3.14
+        column :f, BigDecimal, default: 1.0
+        column :g, Numeric,    default: 943_943
+        column :h, Date,       default: Date.new
+        column :i, DateTime,   default: DateTime.now
+        column :j, Time,       default: Time.now
+        column :k, TrueClass,  default: true
+        column :l, FalseClass, default: false
+      end
+    when :postgresql
+      create_table :default_values do
+        column :a, Integer,    default: 23
+        column :b, String,     default: 'Hanami'
+        column :c, Fixnum,     default: -1 # rubocop:disable Lint/UnifiedInteger
+        column :d, :Bignum,    default: 0
+        column :e, Float,      default: 3.14
+        column :f, BigDecimal, default: 1.0
+        column :g, Numeric,    default: 943_943
+        column :h, Date,       default: 'now'
+        column :i, DateTime,   default: DateTime.now
+        column :j, Time,       default: Time.now
+        column :k, TrueClass,  default: true
+        column :l, FalseClass, default: false
+      end
+    when :mysql
+      create_table :default_values do
+        column :a, Integer,    default: 23
+        column :b, String,     default: 'Hanami'
+        column :c, Fixnum,     default: -1 # rubocop:disable Lint/UnifiedInteger
+        column :d, :Bignum,    default: 0
+        column :e, Float,      default: 3.14
+        column :f, BigDecimal, default: 1.0
+        column :g, Numeric,    default: 943_943
+        column :h, Date # ,       default: 'CURRENT_TIMESTAMP'
+        column :i, DateTime,   default: DateTime.now
+        column :j, Time,       default: Time.now
+        column :k, TrueClass,  default: true
+        column :l, FalseClass, default: false
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612093458_null_constraints.rb
+++ b/spec/support/fixtures/database_migrations/20150612093458_null_constraints.rb
@@ -1,0 +1,9 @@
+Hanami::Model.migration do
+  change do
+    create_table :null_constraints do
+      column :a, Integer
+      column :b, Integer, null: false
+      column :c, Integer, null: true
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612093810_column_indexes.rb
+++ b/spec/support/fixtures/database_migrations/20150612093810_column_indexes.rb
@@ -1,0 +1,17 @@
+Hanami::Model.migration do
+  change do
+    create_table :column_indexes do
+      column :a, Integer
+      column :b, Integer, index: false
+      column :c, Integer, index: true
+      column :d, Integer
+
+      column :lat, Float
+      column :lng, Float
+
+      index :d, unique: true
+      index [:b, :c]
+      index [:lat, :lng], name: :column_indexes_coords_index
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612094740_primary_keys.rb
+++ b/spec/support/fixtures/database_migrations/20150612094740_primary_keys.rb
@@ -1,0 +1,18 @@
+Hanami::Model.migration do
+  change do
+    create_table :primary_keys_1 do
+      primary_key :id
+    end
+
+    create_table :primary_keys_2 do
+      column :name, String, primary_key: true
+    end
+
+    create_table :primary_keys_3 do
+      column :group_id, Integer
+      column :position, Integer
+
+      primary_key [:group_id, :position], name: :primary_keys_3_pk
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612115204_foreign_keys.rb
+++ b/spec/support/fixtures/database_migrations/20150612115204_foreign_keys.rb
@@ -1,0 +1,12 @@
+Hanami::Model.migration do
+  change do
+    create_table :artists do
+      primary_key :id
+    end
+
+    create_table :albums do
+      primary_key :id
+      foreign_key :artist_id, :artists, on_delete: :cascade, null: false, type: :integer
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612122233_table_constraints.rb
+++ b/spec/support/fixtures/database_migrations/20150612122233_table_constraints.rb
@@ -1,0 +1,30 @@
+Hanami::Model.migration do
+  change do
+    case ENV['HANAMI_DATABASE_TYPE']
+    when 'sqlite'
+      create_table :table_constraints do
+        column :age, Integer
+        constraint(:age_constraint) { age > 18 }
+
+        column :role, String
+        check %(role IN("contributor", "manager", "owner"))
+      end
+    when 'postgresql'
+      create_table :table_constraints do
+        column :age, Integer
+        constraint(:age_constraint) { age > 18 }
+
+        column :role, String
+        check %(role IN('contributor', 'manager', 'owner'))
+      end
+    when 'mysql'
+      create_table :table_constraints do
+        column :age, Integer
+        constraint(:age_constraint) { age > 18 }
+
+        column :role, String
+        check %(role IN("contributor", "manager", "owner"))
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20150612124205_table_alterations.rb
+++ b/spec/support/fixtures/database_migrations/20150612124205_table_alterations.rb
@@ -1,0 +1,72 @@
+Hanami::Model.migration do
+  change do
+    case ENV['HANAMI_DATABASE_TYPE']
+    when 'sqlite'
+      create_table :songs do
+        column :title, String
+        column :useless, String
+
+        foreign_key :artist_id, :artists
+        index :artist_id
+
+        add_constraint(:useless_min_length) { char_length(useless) > 2 }
+      end
+
+      alter_table :songs do
+        add_primary_key :id
+
+        add_column      :downloads_count, Integer
+        set_column_type :useless,         File
+
+        rename_column :title, :primary_title
+        set_column_default :primary_title, 'Unknown title'
+
+        # add_index :album_id
+        # drop_index :artist_id
+
+        # add_foreign_key :album_id, :albums, on_delete: :cascade
+        # drop_foreign_key :artist_id
+
+        # add_constraint(:title_min_length) { char_length(title) > 2 }
+
+        # add_unique_constraint [:album_id, :title]
+
+        drop_constraint :useless_min_length
+        drop_column     :useless
+      end
+    when 'postgresql'
+      create_table :songs do
+        column :title, String
+        column :useless, String
+
+        foreign_key :artist_id, :artists
+        index :artist_id
+
+        # add_constraint(:useless_min_length) { char_length(useless) > 2 }
+      end
+
+      alter_table :songs do
+        add_primary_key :id
+
+        add_column    :downloads_count, Integer
+        # set_column_type :useless, File
+
+        rename_column :title, :primary_title
+        set_column_default :primary_title, 'Unknown title'
+
+        # add_index :album_id
+        # drop_index :artist_id
+
+        # add_foreign_key :album_id, :albums, on_delete: :cascade
+        # drop_foreign_key :artist_id
+
+        # add_constraint(:title_min_length) { char_length(title) > 2 }
+
+        # add_unique_constraint [:album_id, :title]
+
+        # drop_constraint :useless_min_length
+        drop_column :useless
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20160830094800_create_users.rb
+++ b/spec/support/fixtures/database_migrations/20160830094800_create_users.rb
@@ -1,0 +1,20 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :users
+    create_table? :users do
+      primary_key :id
+      column :name,           String
+      column :email,          String
+      column :age,            Integer,   null: false, default: 19
+      column :comments_count, Integer,   null: false, default: 0
+      column :active,         TrueClass, null: false, default: true
+      column :created_at,     DateTime,  null: false
+      column :updated_at,     DateTime,  null: false
+
+      check { age > 18 }
+      constraint(:comments_count_constraint) { comments_count >= 0 }
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/spec/support/fixtures/database_migrations/20160830094851_create_authors.rb
+++ b/spec/support/fixtures/database_migrations/20160830094851_create_authors.rb
@@ -1,0 +1,11 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :authors
+    create_table? :authors do
+      primary_key :id
+      column :name,       String
+      column :created_at, DateTime, null: false
+      column :updated_at, DateTime, null: false
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20160830094941_create_books.rb
+++ b/spec/support/fixtures/database_migrations/20160830094941_create_books.rb
@@ -1,0 +1,13 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :books
+    create_table? :books do
+      primary_key :id
+      foreign_key :author_id, :authors, on_delete: :cascade
+      column :title,      String
+      column :on_sale,    TrueClass, null: false, default: false
+      column :created_at, DateTime,  null: false
+      column :updated_at, DateTime,  null: false
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20160830095033_create_t_operator.rb
+++ b/spec/support/fixtures/database_migrations/20160830095033_create_t_operator.rb
@@ -1,0 +1,9 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :t_operator
+    create_table? :t_operator do
+      primary_key :operator_id
+      column :s_name, String
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
+++ b/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
@@ -1,0 +1,20 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :postgresql
+      create_table :source_files do
+        column :id,         'uuid',   primary_key: true, default: Hanami::Model::Sql.function(:uuid_generate_v4)
+        column :name,       String,   null: false
+        column :languages,  'text[]'
+        column :metadata,   'jsonb',  null: false
+        column :content,    File,     null: false
+        column :created_at, DateTime, null: false
+        column :updated_at, DateTime, null: false
+      end
+    else
+      create_table :source_files do
+        primary_key :id
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
+++ b/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
@@ -1,0 +1,11 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :avatars
+    create_table? :avatars do
+      primary_key :id
+      foreign_key :user_id, :users, on_delete: :cascade, null: false
+
+      column :url, String
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20161104143844_create_warehouses.rb
+++ b/spec/support/fixtures/database_migrations/20161104143844_create_warehouses.rb
@@ -1,0 +1,12 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :warehouses
+    create_table? :warehouses do
+      primary_key :id
+      column :name,       String
+      column :code,       String
+      column :created_at, DateTime,  null: false
+      column :updated_at, DateTime,  null: false
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20161114094644_create_products.rb
+++ b/spec/support/fixtures/database_migrations/20161114094644_create_products.rb
@@ -1,0 +1,16 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :postgresql
+      create_table :products do
+        primary_key :id
+        column :name,       String
+        column :categories, 'text[]'
+      end
+    else
+      create_table :products do
+        primary_key :id
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20170103142428_create_colors.rb
+++ b/spec/support/fixtures/database_migrations/20170103142428_create_colors.rb
@@ -1,0 +1,22 @@
+Hanami::Model.migration do
+  change do
+    case Database.engine
+    when :postgresql
+      extension :pg_enum
+      create_enum :rainbow, %w(red orange yellow green blue indigo violet)
+
+      create_table :colors do
+        primary_key :id
+
+        column :name, :rainbow, null: false
+
+        column :created_at, DateTime, null: false
+        column :updated_at, DateTime, null: false
+      end
+    else
+      create_table :colors do
+        primary_key :id
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/database_migrations/20170124081339_create_labels.rb
+++ b/spec/support/fixtures/database_migrations/20170124081339_create_labels.rb
@@ -1,0 +1,7 @@
+Hanami::Model.migration do
+  change do
+    create_table :labels do
+      column :id, Integer
+    end
+  end
+end

--- a/spec/support/fixtures/migrations/20160831073534_create_reviews.rb
+++ b/spec/support/fixtures/migrations/20160831073534_create_reviews.rb
@@ -1,0 +1,12 @@
+Hanami::Model.migration do
+  up do
+    create_table :reviews do
+      primary_key :id
+      column :title, String, null: false
+    end
+  end
+
+  down do
+    drop_table :reviews
+  end
+end

--- a/spec/support/fixtures/migrations/20160831090612_add_rating_to_reviews.rb
+++ b/spec/support/fixtures/migrations/20160831090612_add_rating_to_reviews.rb
@@ -1,0 +1,9 @@
+Hanami::Model.migration do
+  up do
+    add_column :reviews, :rating, 'integer', default: 0
+  end
+
+  down do
+    drop_column :reviews, :rating
+  end
+end

--- a/spec/support/platform.rb
+++ b/spec/support/platform.rb
@@ -1,0 +1,28 @@
+module Platform
+  require_relative 'platform/os'
+  require_relative 'platform/engine'
+  require_relative 'platform/db'
+  require_relative 'platform/matcher'
+
+  def self.ci?
+    ENV['TRAVIS'] == 'true'
+  end
+
+  def self.match(&blk)
+    Matcher.match(&blk)
+  end
+
+  def self.match?(**args)
+    Matcher.match?(**args)
+  end
+end
+
+module PlatformHelpers
+  def with_platform(**args)
+    yield if Platform.match?(**args)
+  end
+
+  def unless_platform(**args)
+    yield unless Platform.match?(**args)
+  end
+end

--- a/spec/support/platform/db.rb
+++ b/spec/support/platform/db.rb
@@ -1,0 +1,11 @@
+module Platform
+  module Db
+    def self.db?(name)
+      current == name
+    end
+
+    def self.current
+      Database.engine
+    end
+  end
+end

--- a/spec/support/platform/engine.rb
+++ b/spec/support/platform/engine.rb
@@ -1,0 +1,27 @@
+require 'hanami/utils'
+
+module Platform
+  module Engine
+    def self.engine?(name)
+      current == name
+    end
+
+    def self.current
+      if    ruby?  then :ruby
+      elsif jruby? then :jruby
+      end
+    end
+
+    class << self
+      private
+
+      def ruby?
+        RUBY_ENGINE == 'ruby'
+      end
+
+      def jruby?
+        Hanami::Utils.jruby?
+      end
+    end
+  end
+end

--- a/spec/support/platform/matcher.rb
+++ b/spec/support/platform/matcher.rb
@@ -1,0 +1,80 @@
+require 'hanami/utils/basic_object'
+
+module Platform
+  class Matcher
+    class Nope < Hanami::Utils::BasicObject
+      def or(other, &blk)
+        blk.nil? ? other : blk.call # rubocop:disable Performance/RedundantBlockCall
+      end
+
+      def method_missing(*)
+        self.class.new
+      end
+    end
+
+    def self.match(&blk)
+      catch :match do
+        new.__send__(:match, &blk)
+      end
+    end
+
+    def self.match?(os: Os.current, engine: Engine.current, db: Db.current)
+      catch :match do
+        new.os(os).engine(engine).db(db) { true }.or(false)
+      end
+    end
+
+    def initialize
+      freeze
+    end
+
+    def os(name, &blk)
+      return nope unless os?(name)
+      block_given? ? resolve(&blk) : yep
+    end
+
+    def engine(name, &blk)
+      return nope unless engine?(name)
+      block_given? ? resolve(&blk) : yep
+    end
+
+    def db(name, &blk)
+      return nope unless db?(name)
+      block_given? ? resolve(&blk) : yep
+    end
+
+    def default(&blk)
+      resolve(&blk)
+    end
+
+    private
+
+    def match(&blk)
+      instance_exec(&blk)
+    end
+
+    def nope
+      Nope.new
+    end
+
+    def yep
+      self.class.new
+    end
+
+    def resolve
+      throw :match, yield
+    end
+
+    def os?(name)
+      Os.os?(name)
+    end
+
+    def engine?(name)
+      Engine.engine?(name)
+    end
+
+    def db?(name)
+      Db.db?(name)
+    end
+  end
+end

--- a/spec/support/platform/os.rb
+++ b/spec/support/platform/os.rb
@@ -1,0 +1,16 @@
+require 'rbconfig'
+
+module Platform
+  module Os
+    def self.os?(name)
+      current == name
+    end
+
+    def self.current
+      case RbConfig::CONFIG['host_os']
+      when /linux/  then :linux
+      when /darwin/ then :macos
+      end
+    end
+  end
+end

--- a/spec/support/test_io.rb
+++ b/spec/support/test_io.rb
@@ -1,0 +1,14 @@
+module TestIO
+  def self.with_stdout
+    stdout = $stdout
+    $stdout = stream
+    yield
+  ensure
+    $stdout.close
+    $stdout = stdout
+  end
+
+  def self.stream
+    File.new(ENV['HANAMI_DATABASE_LOGGER'], "a+")
+  end
+end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,0 +1,17 @@
+require 'rubygems'
+require 'bundler/setup'
+
+if ENV['COVERALL']
+  require 'coveralls'
+  Coveralls.wear!
+end
+
+require 'minitest/autorun'
+
+$LOAD_PATH.unshift 'lib'
+require 'hanami/model'
+
+require_relative './support/test_io'
+require_relative './support/platform'
+require_relative './support/database'
+require_relative './support/fixtures'

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+RSpec.describe Hanami::Model::VERSION do
+  it 'exposes version' do
+    expect(Hanami::Model::VERSION).to eq('1.0.0.rc1')
+  end
+end

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe Hanami::Model::VERSION do
   it 'exposes version' do
-    Hanami::Model::VERSION.must_equal '1.0.0.beta3'
+    Hanami::Model::VERSION.must_equal '1.0.0.rc1'
   end
 end


### PR DESCRIPTION
Work for #392 

I'm not sure about my way of including examples for database-specific migrations. RSpec doesn't allow you to load specs with `load` AFAIK. 

Please correct me if I'm wrong and there is better way to do that