### PR TITLE
Changing example in code documentation

### DIFF
--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -19,8 +19,7 @@ module Hanami
   # @example With Hanami::Entity
   #   require 'hanami/model'
   #
-  #   class Person
-  #     include Hanami::Entity
+  #   class Person < Hanami::Entity
   #   end
   #
   # If we expand the code above in **pure Ruby**, it would be:

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -19,8 +19,7 @@ module Hanami
   # @example
   #   require 'hanami/model'
   #
-  #   class Article
-  #     include Hanami::Entity
+  #   class Article < Hanami::Entity
   #   end
   #
   #   # valid


### PR DESCRIPTION
Hey,

I was reading the Entity and Repository code documentation and realized that the instance of an Entity class was wrong. In the documentation, the example guides as follows:

```ruby
2.3.4 (main)> class User
2.3.4 (main)>   include Hanami::Entity
2.3.4 (main)> end  
TypeError: wrong argument type Class (expected Module)
from (pry):2:in `include'
```

So I changed the documentation. Just it :smile:
Thanks guys.