### PR TITLE
Support for rom-sql 1.3 and dry-types 0.10

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.0'
-  spec.add_runtime_dependency 'rom-sql',         '~> 1.2'
+  spec.add_runtime_dependency 'rom-sql',         '~> 1.3'
   spec.add_runtime_dependency 'rom-repository',  '~> 1.3'
-  spec.add_runtime_dependency 'dry-types',       '~> 0.9'
+  spec.add_runtime_dependency 'dry-types',       '~> 0.10'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
   spec.add_development_dependency 'bundler',  '~> 1.6'

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -34,26 +34,26 @@ module Hanami
           # @since 0.7.0
           # @api private
           MAPPING = {
-            Types::String.with(meta: {})            => Schema::String,
-            Types::Int.with(meta: {})               => Schema::Int,
-            Types::Float.with(meta: {})             => Schema::Float,
-            Types::Decimal.with(meta: {})           => Schema::Decimal,
-            Types::Bool.with(meta: {})              => Schema::Bool,
-            Types::Date.with(meta: {})              => Schema::Date,
-            Types::DateTime.with(meta: {})          => Schema::DateTime,
-            Types::Time.with(meta: {})              => Schema::Time,
-            Types::Array.with(meta: {})             => Schema::Array,
-            Types::Hash.with(meta: {})              => Schema::Hash,
-            Types::String.optional.with(meta: {})   => Schema::String,
-            Types::Int.optional.with(meta: {})      => Schema::Int,
-            Types::Float.optional.with(meta: {})    => Schema::Float,
-            Types::Decimal.optional.with(meta: {})  => Schema::Decimal,
-            Types::Bool.optional.with(meta: {})     => Schema::Bool,
-            Types::Date.optional.with(meta: {})     => Schema::Date,
-            Types::DateTime.optional.with(meta: {}) => Schema::DateTime,
-            Types::Time.optional.with(meta: {})     => Schema::Time,
-            Types::Array.optional.with(meta: {})    => Schema::Array,
-            Types::Hash.optional.with(meta: {})     => Schema::Hash
+            Types::String.pristine            => Schema::String,
+            Types::Int.pristine               => Schema::Int,
+            Types::Float.pristine             => Schema::Float,
+            Types::Decimal.pristine           => Schema::Decimal,
+            Types::Bool.pristine              => Schema::Bool,
+            Types::Date.pristine              => Schema::Date,
+            Types::DateTime.pristine          => Schema::DateTime,
+            Types::Time.pristine              => Schema::Time,
+            Types::Array.pristine             => Schema::Array,
+            Types::Hash.pristine              => Schema::Hash,
+            Types::String.optional.pristine   => Schema::String,
+            Types::Int.optional.pristine      => Schema::Int,
+            Types::Float.optional.pristine    => Schema::Float,
+            Types::Decimal.optional.pristine  => Schema::Decimal,
+            Types::Bool.optional.pristine     => Schema::Bool,
+            Types::Date.optional.pristine     => Schema::Date,
+            Types::DateTime.optional.pristine => Schema::DateTime,
+            Types::Time.optional.pristine     => Schema::Time,
+            Types::Array.optional.pristine    => Schema::Array,
+            Types::Hash.optional.pristine     => Schema::Hash
           }.freeze
 
           # Convert given type into coercible
@@ -62,8 +62,11 @@ module Hanami
           # @api private
           def self.coercible(attribute)
             return attribute if attribute.constrained?
-            # TODO: figure out a better way of inferring coercions from schema types
-            MAPPING.fetch(attribute.type.with(meta: {}), attribute)
+
+            type      = attribute.type
+            unwrapped = type.optional? ? type.right : type
+
+            MAPPING.fetch(unwrapped.pristine, attribute)
           end
 
           # Coercer for SQL associations target


### PR DESCRIPTION
The recent changes introduced by `rom-sql` 1.3 and `dry-types` 0.10 led to a failure in our build. When an inferred **and** mapped schema are used together, the attributes of an entity weren't coerced.

Example:

```ruby
class Operator < Hanami::Entity
end

class OperatorRepository < Hanami::Repository
  self.relation = :t_operator

  mapping do
    attribute :id,   from: :operator_id
    attribute :name, from: :s_name
  end
end

operator = Operator.new(name: :foo)
operator.name
# => :foo
# WRONG, expected "foo"
```

---

After a long chat with @flash-gordon (thank you again, man), I decided to bump the dependencies of `rom-sql` and `dry-types` for us and to us a new API from `dry-types` to internally convert database types into DRY/Hanami types.

---

/cc @hanami/core 