### PR TITLE
Use `Hanami::Utils::Hash.deep_symbolize`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.0.0', require: false, git: 'https://github.com/hanami/utils.git', branch: '1.0.x'
+gem 'hanami-utils', '~> 1.0.0', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.0.0', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
+gem 'hanami-utils', '~> 1.0.0', require: false, git: 'https://github.com/hanami/utils.git', branch: '1.0.x'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -182,7 +182,7 @@ module Hanami
     #
     # @since 0.1.0
     def to_h
-      attributes.deep_dup.to_h
+      Utils::Hash.deep_dup(attributes)
     end
 
     # @since 0.7.0

--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -73,7 +73,7 @@ module Hanami
           if attributes.nil?
             {}
           else
-            Utils::Hash.new(attributes.dup).deep_symbolize!
+            Utils::Hash.deep_symbolize(attributes.to_hash.dup)
           end
         end
 
@@ -221,9 +221,9 @@ module Hanami
       # @since 0.7.0
       # @api private
       def call(attributes)
-        Utils::Hash.new(
+        Utils::Hash.deep_symbolize(
           schema.call(attributes)
-        ).symbolize!
+        )
       end
 
       # @since 0.7.0

--- a/lib/hanami/model/sql/entity/schema.rb
+++ b/lib/hanami/model/sql/entity/schema.rb
@@ -47,9 +47,7 @@ module Hanami
           # @since 1.0.1
           # @api private
           def call(attributes)
-            Utils::Hash.new(
-              schema.call(attributes)
-            ).deep_symbolize!
+            schema.call(attributes)
           end
 
           # @since 1.0.1

--- a/lib/hanami/model/sql/types/schema/coercions.rb
+++ b/lib/hanami/model/sql/types/schema/coercions.rb
@@ -1,4 +1,5 @@
 require 'hanami/utils/string'
+require 'hanami/utils/hash'
 
 module Hanami
   module Model
@@ -184,7 +185,9 @@ module Hanami
               when ::Hash
                 arg
               when ->(a) { a.respond_to?(:to_hash) }
-                ::Kernel.Hash(arg)
+                Utils::Hash.deep_symbolize(
+                  ::Kernel.Hash(arg)
+                )
               else
                 raise ArgumentError.new("invalid value for Hash(): #{arg.inspect}")
               end

--- a/test/entity/manual_schema_test.rb
+++ b/test/entity/manual_schema_test.rb
@@ -120,12 +120,12 @@ describe Hanami::Entity do
         )
 
         entity.visitor.must_equal(
-          'user_agent' => 'w3m/0.5.3', 'language' => { 'en' => 0.9 }
+          user_agent: 'w3m/0.5.3', language: { en: 0.9 }
         )
         entity.page_info.must_equal(
           name: 'landing page',
           scroll_depth: 0.7,
-          meta: { 'version' => '0.8.3', updated_at: 1_492_769_467_000 }
+          meta: { version: '0.8.3', updated_at: 1_492_769_467_000 }
         )
       end
     end


### PR DESCRIPTION
As effect of this change, the internal attributes of an entity are
`::Hash` and no longer `Utils::Hash`.

Cleanup for #395 