### PR TITLE
Enforce repository relation name as a symbol

### DIFF
--- a/lib/hanami/model/relation_name.rb
+++ b/lib/hanami/model/relation_name.rb
@@ -12,12 +12,12 @@ module Hanami
     # @api private
     class RelationName < EntityName
       # @param name [Class,String] the class or its name
-      # @return [Symbol] the relation name
+      # @return [String] the relation name
       #
       # @since 0.7.0
       # @api private
       def self.new(name)
-        Utils::String.new(super).underscore.pluralize.to_sym
+        Utils::String.new(super).underscore.pluralize
       end
     end
   end

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -282,12 +282,15 @@ module Hanami
         auto_struct true
 
         class_attribute :entity
-
         class_attribute :entity_name
-        self.entity_name = Model::EntityName.new(name)
-
         class_attribute :relation
-        self.relation = Model::RelationName.new(name)
+
+        def self.relation=(name)
+          @relation = name.to_sym
+        end
+
+        self.entity_name = Model::EntityName.new(name)
+        self.relation    = Model::RelationName.new(name)
 
         commands :create, update: :by_pk, delete: :by_pk, mapper: Model::MappedRelation.mapper_name, use: COMMAND_PLUGINS
         prepend Commands

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -106,7 +106,7 @@ module Hanami
   # @see Hanami::Entity
   # @see http://martinfowler.com/eaaCatalog/repository.html
   # @see http://en.wikipedia.org/wiki/Dependency_inversion_principle
-  class Repository < ROM::Repository::Root
+  class Repository < ROM::Repository::Root # rubocop:disable Metrics/ClassLength
     # Plugins for database commands
     #
     # @since 0.7.0

--- a/test/fixtures/database_migrations/20170517115243_create_tokens.rb
+++ b/test/fixtures/database_migrations/20170517115243_create_tokens.rb
@@ -1,0 +1,9 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :tokens
+    create_table? :tokens do
+      primary_key :id
+      column :token, String
+    end
+  end
+end

--- a/test/integration/repository/base_test.rb
+++ b/test/integration/repository/base_test.rb
@@ -44,6 +44,16 @@ describe 'Repository (base)' do
         exception.message.must_equal "Missing primary key for :labels"
       end
     end
+
+    describe 'with custom relation' do
+      it 'finds record by primary key' do
+        repository = AccessTokenRepository.new
+        access_token = repository.create(token: "123")
+        found        = repository.find(access_token.id)
+
+        found.must_equal(access_token)
+      end
+    end
   end
 
   describe '#all' do

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -13,6 +13,9 @@ end
 class Operator < Hanami::Entity
 end
 
+class AccessToken < Hanami::Entity
+end
+
 class SourceFile < Hanami::Entity
 end
 
@@ -144,6 +147,10 @@ class OperatorRepository < Hanami::Repository
     attribute :id,   from: :operator_id
     attribute :name, from: :s_name
   end
+end
+
+class AccessTokenRepository < Hanami::Repository
+  self.relation = "tokens"
 end
 
 class SourceFileRepository < Hanami::Repository


### PR DESCRIPTION
Let the following code to work:

```ruby
class AccessTokenRepository < Hanami::Repository
  self.relation = "tokens"
end
```

The documentation for `.relation=` always indicates to use `Symbol`, but in other parts of Hanami, we interchangeably accept `Symbol`/`String`. I suggest to "fix" this to avoid further confusion.

---

Fixes #399