### PR TITLE
Do not override class-level input in commands (fixes #404)

### DIFF
--- a/lib/hanami/model/plugins/mapping.rb
+++ b/lib/hanami/model/plugins/mapping.rb
@@ -37,8 +37,8 @@ module Hanami
           # @since 0.7.0
           # @api private
           def build(relation, options = {})
-            input(InputWithMapping.new(relation, input))
-            super(relation, options.merge(input: input))
+            wrapped_input = InputWithMapping.new(relation, options.fetch(:input) { input })
+            super(relation, options.merge(input: wrapped_input))
           end
         end
 

--- a/lib/hanami/model/plugins/schema.rb
+++ b/lib/hanami/model/plugins/schema.rb
@@ -37,8 +37,8 @@ module Hanami
           # @since 0.7.0
           # @api private
           def build(relation, options = {})
-            input(InputWithSchema.new(relation, input))
-            super(relation, options.merge(input: input))
+            wrapped_input = InputWithSchema.new(relation, options.fetch(:input) { input })
+            super(relation, options.merge(input: wrapped_input))
           end
         end
 

--- a/lib/hanami/model/plugins/timestamps.rb
+++ b/lib/hanami/model/plugins/timestamps.rb
@@ -100,8 +100,8 @@ module Hanami
                        InputWithUpdateTimestamp
                      end
 
-            input(plugin.new(relation, input))
-            super(relation, options.merge(input: input))
+            wrapped_input = plugin.new(relation, options.fetch(:input) { input })
+            super(relation, options.merge(input: wrapped_input))
           end
         end
 


### PR DESCRIPTION
The previous version modified class-level state on each command call. This led to a big performance impact and ended up with a StackOverfow exception. The new code still builds inputs on every request but this can be optimized in future.