### PR TITLE
Fix timestamps for models not having updated_at column.

### DIFF
--- a/lib/hanami/model/plugins/timestamps.rb
+++ b/lib/hanami/model/plugins/timestamps.rb
@@ -24,7 +24,7 @@ module Hanami
           def initialize(relation, input)
             super
             columns     = relation.columns.sort
-            @timestamps = (columns & TIMESTAMPS).count.positive?
+            @timestamps = columns & TIMESTAMPS
           end
 
           # Processes the input
@@ -49,7 +49,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def timestamps?
-            @timestamps
+            !@timestamps.empty?
           end
         end
 
@@ -63,7 +63,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def _touch(value, now)
-            value[:updated_at] ||= now
+            value[:updated_at] ||= now if @timestamps.include?(:updated_at)
             value
           end
         end
@@ -79,7 +79,7 @@ module Hanami
           # @api private
           def _touch(value, now)
             super
-            value[:created_at] ||= now
+            value[:created_at] ||= now if @timestamps.include?(:created_at)
             value
           end
         end

--- a/lib/hanami/model/plugins/timestamps.rb
+++ b/lib/hanami/model/plugins/timestamps.rb
@@ -23,8 +23,7 @@ module Hanami
           # @api private
           def initialize(relation, input)
             super
-            columns     = relation.columns.sort
-            @timestamps = columns & TIMESTAMPS
+            @timestamps = relation.columns & TIMESTAMPS
           end
 
           # Processes the input

--- a/lib/hanami/model/plugins/timestamps.rb
+++ b/lib/hanami/model/plugins/timestamps.rb
@@ -24,7 +24,7 @@ module Hanami
           def initialize(relation, input)
             super
             columns     = relation.columns.sort
-            @timestamps = (columns & TIMESTAMPS) == TIMESTAMPS
+            @timestamps = (columns & TIMESTAMPS).count.positive?
           end
 
           # Processes the input

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -178,6 +178,14 @@ RSpec.describe 'Repository (base)' do
         expect(updated.created_at).to be_within(2).of(given_time)
         expect(updated.updated_at).to be_within(2).of(given_time)
       end
+
+      # Bug: https://github.com/hanami/model/issues/412
+      it 'can have only creation timestamp' do
+        user = UserRepository.new.create(name: 'L')
+        repository = AvatarRepository.new
+        account = repository.create(url: 'http://foo.com', user_id: user.id)
+        expect(account.created_at).to be_within(2).of(Time.now.utc)
+      end
     end
 
     # Bug: https://github.com/hanami/model/issues/237

--- a/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
+++ b/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
@@ -6,6 +6,7 @@ Hanami::Model.migration do
       foreign_key :user_id, :users, on_delete: :cascade, null: false
 
       column :url, String
+      column :created_at, DateTime
     end
   end
 end


### PR DESCRIPTION
Fix for #412 

(full disclosure: this is a quick fix, `value[:updated_at]` will still be set, but, as it's not in the schema, won't be present in the returned object)