### PR TITLE
handles special characters

### DIFF
--- a/lib/hanami/model/sql/consoles/postgresql.rb
+++ b/lib/hanami/model/sql/consoles/postgresql.rb
@@ -59,7 +59,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def configure_password
-            ENV[PASSWORD] = @uri.password unless @uri.password.nil?
+            ENV[PASSWORD] = URI.decode(@uri.password) unless @uri.password.nil?
           end
         end
       end

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples "sql_console_postgresql" do
 
       it 'sets the PGPASSWORD environment variable decoding special characters' do
         console.connection_string
-        expect(ENV['PGPASSWORD']).to eq('WRONG')
+        expect(ENV['PGPASSWORD']).to eq('p@ss')
         ENV.delete('PGPASSWORD')
       end
     end

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -15,5 +15,16 @@ RSpec.shared_examples "sql_console_postgresql" do
       expect(ENV['PGPASSWORD']).to eq('password')
       ENV.delete('PGPASSWORD')
     end
+
+    context 'when the password contains percent encoded characters' do
+      let(:uri) { URI.parse('postgres://username:p%40ss@localhost:1234/foo_development') }
+
+      it 'sets the PGPASSWORD environment variable decoding special characters' do
+        console.connection_string
+        expect(ENV['PGPASSWORD']).to eq('WRONG')
+        ENV.delete('PGPASSWORD')
+      end
+    end
+
   end
 end

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -25,6 +25,5 @@ RSpec.shared_examples "sql_console_postgresql" do
         ENV.delete('PGPASSWORD')
       end
     end
-
   end
 end


### PR DESCRIPTION
The ENV variable `PGPASSWORD` needs a string that is not percent-encoded, even though the official documentation states otherwise:

https://www.postgresql.org/docs/current/static/libpq-envars.html

> PGPASSWORD behaves the same as the password connection parameter.

https://www.postgresql.org/docs/current/static/libpq-connect.html

> Percent-encoding may be used to include symbols with special meaning in any of the URI parts.

Fixes https://github.com/hanami/hanami/issues/804