### PR TITLE
Add proper handling for json and jsonb in Postgres

### DIFF
--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -74,14 +74,17 @@ module Hanami
             #
             #  MAPPING.fetch(unwrapped.pristine, attribute)
             MAPPING.fetch(unwrapped.pristine) do
-              if defined?(ROM::SQL::Types::PG::JSONB) && unwrapped.pristine == ROM::SQL::Types::PG::JSONB
-                Schema::JSON
-              elsif defined?(ROM::SQL::Types::PG::JSON) && unwrapped.pristine == ROM::SQL::Types::PG::JSON
+              if is_json?(unwrapped.pristine)
                 Schema::JSON
               else
                 attribute
               end
             end
+          end
+
+          def self.is_json?(pristine)
+            (defined?(ROM::SQL::Types::PG::JSONB) && pristine == ROM::SQL::Types::PG::JSONB) ||
+              (defined?(ROM::SQL::Types::PG::JSON) && pristine == ROM::SQL::Types::PG::JSON)
           end
 
           # Coercer for SQL associations target

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -31,6 +31,8 @@ module Hanami
           Array    = Types::Strict::Nil | Types::Array.constructor(Coercions.method(:array))
           Hash     = Types::Strict::Nil | Types::Hash.constructor(Coercions.method(:hash))
 
+          JSON     = Types::Strict::Nil | Types::Hash.constructor(Coercions.method(:json)) | Types::Array.constructor(Coercions.method(:json))
+
           # @since 0.7.0
           # @api private
           MAPPING = {
@@ -73,7 +75,9 @@ module Hanami
             #  MAPPING.fetch(unwrapped.pristine, attribute)
             MAPPING.fetch(unwrapped.pristine) do
               if defined?(ROM::SQL::Types::PG::JSONB) && unwrapped.pristine == ROM::SQL::Types::PG::JSONB
-                Schema::Hash
+                Schema::JSON
+              elsif defined?(ROM::SQL::Types::PG::JSON) && unwrapped.pristine == ROM::SQL::Types::PG::JSON
+                Schema::JSON
               else
                 attribute
               end

--- a/lib/hanami/model/sql/types/schema/coercions.rb
+++ b/lib/hanami/model/sql/types/schema/coercions.rb
@@ -192,6 +192,12 @@ module Hanami
                 raise ArgumentError.new("invalid value for Hash(): #{arg.inspect}")
               end
             end
+
+            def self.json(arg)
+              hash(arg)
+            rescue ArgumentError
+              array(arg)
+            end
           end
           # rubocop:enable Metrics/MethodLength
         end

--- a/lib/hanami/model/sql/types/schema/coercions.rb
+++ b/lib/hanami/model/sql/types/schema/coercions.rb
@@ -193,10 +193,17 @@ module Hanami
               end
             end
 
+            # Coerces given argument to appropriate JSON type, i.e. Hash or Array
+            #
+            # @param arg the argument to coerce
+            #
+            # @return [Hash, Array] the result of the coercion
+            #
+            # @raise [ArgumentError] if the coercion fails
+            #
+            # @api private
             def self.json(arg)
-              hash(arg)
-            rescue ArgumentError
-              array(arg)
+              arg.respond_to?(:to_hash) ? hash(arg) : array(arg)
             end
           end
           # rubocop:enable Metrics/MethodLength

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -590,6 +590,29 @@ RSpec.describe 'Repository (base)' do
       #   found = repository.find('9999999')
       #   expect(found).to be_nil
       # end
+
+      describe 'JSON types' do
+        it 'writes hashes' do
+          hash = { first_name: 'John', age: 53, married: true, car: nil }
+          repository = SourceFileRepository.new
+          column_type = repository.create(metadata: hash, name: 'test', content: 'test', json_info: hash)
+          found = repository.find(column_type.id)
+
+          expect(found.metadata).to eq(hash)
+          expect(found.json_info).to eq(hash)
+        end
+
+        it 'writes arrays' do
+          array = ['abc', 1, true, nil]
+          repository = SourceFileRepository.new
+          column_type = repository.create(metadata: array, name: 'test', content: 'test', json_info: array)
+          found = repository.find(column_type.id)
+
+          expect(found.metadata).to eq(array)
+          expect(found.json_info).to eq(array)
+        end
+      end
+
       describe "when timestamps aren't enabled" do
         it 'writes the proper PG types' do
           repository = ProductRepository.new

--- a/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
+++ b/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
@@ -6,7 +6,7 @@ Hanami::Model.migration do
         column :id,         'uuid',   primary_key: true, default: Hanami::Model::Sql.function(:uuid_generate_v4)
         column :name,       String,   null: false
         column :languages,  'text[]'
-        column :metadata,   'jsonb',  null: false
+        column :metadata,   'jsonb', null: false
         column :json_info,  'json'
         column :content,    File,     null: false
         column :created_at, DateTime, null: false

--- a/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
+++ b/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
@@ -7,6 +7,7 @@ Hanami::Model.migration do
         column :name,       String,   null: false
         column :languages,  'text[]'
         column :metadata,   'jsonb',  null: false
+        column :json_info,  'json'
         column :content,    File,     null: false
         column :created_at, DateTime, null: false
         column :updated_at, DateTime, null: false


### PR DESCRIPTION
Following #418 I discovered following problems:

- For JSONB columns it is indeed assumed they are `Hash`, not `Array`
- JSON columns do not work well - they return `Sequel::Postgres::JSONHash` instead of simple `Hash`

This PR fixes those.