### PR TITLE
Fix for nil FKs on a belongs_to association

### DIFF
--- a/lib/hanami/model/types.rb
+++ b/lib/hanami/model/types.rb
@@ -47,6 +47,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def call(value)
+            return if value.nil?
             if valid?(value)
               coerce(value)
             else

--- a/spec/integration/hanami/model/associations/belongs_to_spec.rb
+++ b/spec/integration/hanami/model/associations/belongs_to_spec.rb
@@ -25,4 +25,11 @@ RSpec.describe 'Associations (belongs_to)' do
 
     expect(found).to eq(author)
   end
+
+  it "returns nil if there's no associated record" do
+    repository = BookRepository.new
+    book = repository.create(title: 'The no author book')
+
+    expect { repository.find_with_author(book.id) }.to_not raise_error
+  end
 end


### PR DESCRIPTION
On a `belongs_to` association there's not an obligation to have a `NOT NULL` constraint on the FK, so `nil` fks can happen.

But when we called `aggregate(:other_relation)`, an exception would be raised telling us that `nil` ins't coercible to OtherRelationEntity.

This small patch fix this by checking if nil is the value to be coerced end just returns it. So far no side effects detected. ;)