### PR TITLE
Allow to specify the behavior of the manual schema for an entity

### DIFF
--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -75,13 +75,14 @@ module Hanami
       # attributes via this DSL. If you don't do any setup, the entity accepts all
       # the given attributes.
       #
+      # @param type [Symbol] the type of schema to build
       # @param blk [Proc] the block that defines the attributes
       #
       # @since 0.7.0
       #
       # @see Hanami::Entity
-      def attributes(&blk)
-        self.schema = Schema.new(&blk)
+      def attributes(type = nil, &blk)
+        self.schema = Schema.new(type, &blk)
         @attributes = true
       end
 

--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -175,7 +175,7 @@ module Hanami
         # @param attributes [#to_hash] the attributes hash
         #
         # @raise [TypeError] if the process fails
-        # @raise [ArgumentError] if data is missing
+        # @raise [ArgumentError] if data is missing, or unknown keys are given
         #
         # @since 0.7.0
         # @api private
@@ -183,7 +183,7 @@ module Hanami
           schema.call(attributes)
         rescue Dry::Types::SchemaError => e
           raise TypeError.new(e.message)
-        rescue Dry::Types::MissingKeyError => e
+        rescue Dry::Types::MissingKeyError, Dry::Types::UnknownKeysError => e
           raise ArgumentError.new(e.message)
         end
 

--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -93,11 +93,22 @@ module Hanami
         #
         # @since 0.7.0
         class Dsl
+          # @since x.x.x
+          # @api private
+          TYPES = [:schema, :strict, :weak, :permissive, :strict_with_defaults, :symbolized].freeze
+
+          # @since x.x.x
+          # @api private
+          DEFAULT_TYPE = TYPES.first
+
           # @since 0.7.0
           # @api private
-          def self.build(&blk)
+          def self.build(type, &blk)
+            type ||= DEFAULT_TYPE
+            raise Hanami::Model::Error.new("Unknown schema type: `#{type.inspect}'") unless TYPES.include?(type)
+
             attributes = new(&blk).to_h
-            [attributes, Hanami::Model::Types::Coercible::Hash.schema(attributes)]
+            [attributes, Hanami::Model::Types::Coercible::Hash.__send__(type, attributes)]
           end
 
           # @since 0.7.0
@@ -152,9 +163,9 @@ module Hanami
         #
         # @since 0.7.0
         # @api private
-        def initialize(&blk)
+        def initialize(type = nil, &blk)
           raise LocalJumpError unless block_given?
-          @attributes, @schema = Dsl.build(&blk)
+          @attributes, @schema = Dsl.build(type, &blk)
           @attributes = Hash[@attributes.map { |k, _| [k, true] }]
           freeze
         end
@@ -164,6 +175,7 @@ module Hanami
         # @param attributes [#to_hash] the attributes hash
         #
         # @raise [TypeError] if the process fails
+        # @raise [ArgumentError] if data is missing
         #
         # @since 0.7.0
         # @api private
@@ -171,6 +183,8 @@ module Hanami
           schema.call(attributes)
         rescue Dry::Types::SchemaError => e
           raise TypeError.new(e.message)
+        rescue Dry::Types::MissingKeyError => e
+          raise ArgumentError.new(e.message)
         end
 
         # Check if the attribute is known
@@ -204,9 +218,9 @@ module Hanami
       #
       # @since 0.7.0
       # @api private
-      def initialize(&blk)
+      def initialize(type = nil, &blk)
         @schema = if block_given?
-                    Definition.new(&blk)
+                    Definition.new(type, &blk)
                   else
                     Schemaless.new
                   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -58,6 +58,13 @@ class PageVisit < Hanami::Entity
   end
 end
 
+class Person < Hanami::Entity
+  attributes :strict do
+    attribute :id,   Types::Strict::Int
+    attribute :name, Types::Strict::String
+  end
+end
+
 class Product < Hanami::Entity
 end
 

--- a/spec/unit/hanami/entity/manual_schema/base_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/base_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Hanami::Entity do
-  describe 'manual schema' do
+  describe 'manual schema (base)' do
     let(:described_class) { Account }
 
     let(:input) do

--- a/spec/unit/hanami/entity/manual_schema/strict_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/strict_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Hanami::Entity do
         expect { described_class.new(id: 1) }.to raise_error(ArgumentError, ":name is missing in Hash input")
       end
 
+      it "can't be instantiated with unknown data" do
+        expect { described_class.new(id: 1, name: "Luca", foo: "bar") }.to raise_error(ArgumentError, "unexpected keys [:foo] in Hash input")
+      end
+
       it "can be instantiated with full data" do
         entity = described_class.new(id: 1, name: "Luca")
 

--- a/spec/unit/hanami/entity/manual_schema/strict_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/strict_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Hanami::Entity do
+  describe 'manual schema (strict)' do
+    let(:described_class) { Person }
+
+    let(:input) do
+      Class.new do
+        def to_hash
+          Hash[id: 2, name: "MG"]
+        end
+      end.new
+    end
+
+    describe '#initialize' do
+      it "can't be instantiated without attributes" do
+        expect { described_class.new }.to raise_error(ArgumentError, ":id is missing in Hash input")
+      end
+
+      it "can't be instantiated with empty hash" do
+        expect { described_class.new({}) }.to raise_error(ArgumentError, ":id is missing in Hash input")
+      end
+
+      it "can't be instantiated with partial data" do
+        expect { described_class.new(id: 1) }.to raise_error(ArgumentError, ":name is missing in Hash input")
+      end
+
+      it "can be instantiated with full data" do
+        entity = described_class.new(id: 1, name: "Luca")
+
+        expect(entity.id).to   eq(1)
+        expect(entity.name).to eq("Luca")
+      end
+
+      it 'accepts object that implements #to_hash' do
+        entity = described_class.new(input)
+
+        expect(entity.id).to   eq(2)
+        expect(entity.name).to eq("MG")
+      end
+
+      it 'freezes the intance' do
+        entity = described_class.new(id: 1, name: "Luca")
+
+        expect(entity).to be_frozen
+      end
+
+      it "fails if values aren't of the expected type" do
+        expect { described_class.new(id: "1", name: "Luca") }.to raise_error(TypeError, %("1" (String) has invalid type for :id violates constraints (type?(Integer, "1") failed)))
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/entity/manual_schema/types_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/types_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Hanami::Entity do
+  describe 'manual schema (types)' do
+    [nil, :schema, :strict, :weak, :permissive, :strict_with_defaults, :symbolized].each do |type|
+      it "allows to build schema with #{type.inspect}" do
+        Class.new(described_class) do
+          attributes(type) {}
+        end
+      end
+    end
+
+    it "raises error for unknown type" do
+      expect do
+        Class.new(described_class) do
+          attributes(:unknown) {}
+        end
+      end.to raise_error(Hanami::Model::Error, "Unknown schema type: `:unknown'")
+    end
+  end
+end


### PR DESCRIPTION
This is a proposal to allow developers to specify the behavior of manual schema for entities.

## Existent behavior

```ruby
class Person < Hanami::Entity
  attributes do
    attribute :id, Types::Int
    attribute :name, Types::String
  end
end

Person.new
=> #<Person:0x007ff859e34118 @attributes={}>

Person.new(id: 1)
# => #<Person:0x007ff85acbcfc8 @attributes={:id=>1}>

Person.new(id: "1")
# => #<Person:0x007ff85a04d558 @attributes={:id=>"1"}>

Person.new(id: 1, name: "Luca")
# => #<Person:0x007ff85ab20200 @attributes={:id=>1, :name=>"Luca"}>

Person.new(id: 1, name: "Luca", foo: "bar")
# => #<Person:0x007ff859e44ea0 @attributes={:id=>1, :name=>"Luca"}>

Person.new(foo: "bar")
# => #<Person:0x007ff859e4d1e0 @attributes={}>
```

## Additional behavior

```ruby
class Person < Hanami::Entity
  attributes :strict do
    attribute :id, Types::Strict::Int
    attribute :name, Types::Strict::String
  end
end

Person.new
# => ArgumentError: :id is missing in Hash input

Person.new(id: 1)
# => ArgumentError: :name is missing in Hash input

Person.new(id: 1, name: "Luca")
# => #<Person:0x007f8476816c88 @attributes={:id=>1, :name=>"Luca"}>

Person.new(id: 1, name: "Luca", foo: "bar")
# => ArgumentError: unexpected keys [:foo] in Hash input

Person.new(foo: "bar")
# => ArgumentError: unexpected keys [:foo] in Hash input

Person.new(id: "1", name: "Luca")
# => TypeError: "1" (String) has invalid type for :id violates constraints (type?(Integer, "1") failed)
```

⚠️ **Please note that we are NOT replacing the existing behavior, we're adding additional ones, the one above is just an example.** ⚠️ 

## Allowed types

  * omitted (defaults to `:schema`, which is the **existing behavior**)
  * `:schema`
  * `:strict`
  * `:weak`
  * `:permissive`
  * `:strict_with_defaults`
  * `:symbolized`

Read more at: http://dry-rb.org/gems/dry-types/hash-schemas/

---

Closes #411