### PR TITLE
Wrap association exceptions

### DIFF
--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -62,6 +62,8 @@ module Hanami
         def add(data)
           command(:create, relation(target), use: [:timestamps])
             .call(associate(data))
+        rescue => e
+          raise Hanami::Model::Error.for(e)
         end
 
         # @since 0.7.0

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -49,10 +49,8 @@ module Hanami
         # @since 0.7.0
         # @api private
         def create(data)
-          entity.new(
-            command(:create, aggregate(target), use: [:timestamps])
-              .call(data)
-          )
+          entity.new(command(:create, aggregate(target), use: [:timestamps])
+            .call(data))
         rescue => e
           raise Hanami::Model::Error.for(e)
         end

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -53,6 +53,8 @@ module Hanami
             command(:create, aggregate(target), use: [:timestamps])
               .call(data)
           )
+        rescue => e
+          raise Hanami::Model::Error.for(e)
         end
 
         # @since 0.7.0

--- a/lib/hanami/model/associations/has_one.rb
+++ b/lib/hanami/model/associations/has_one.rb
@@ -51,10 +51,14 @@ module Hanami
           entity.new(
             command(:create, aggregate(target), use: [:timestamps]).call(data)
           )
+        rescue => e
+          raise Hanami::Model::Error.for(e)
         end
 
         def add(data)
           command(:create, relation(target), use: [:timestamps]).call(associate(data))
+        rescue => e
+          raise Hanami::Model::Error.for(e)
         end
 
         def update(data)
@@ -62,7 +66,8 @@ module Hanami
         end
 
         def remove
-          command(:delete, relation(target)).by_pk(scope.one.id).call
+          avatar = scope.one
+          command(:delete, relation(target)).by_pk(scope.one.id).call if avatar
         end
 
         def replace(data)

--- a/lib/hanami/model/associations/has_one.rb
+++ b/lib/hanami/model/associations/has_one.rb
@@ -62,7 +62,10 @@ module Hanami
         end
 
         def update(data)
-          command(:update, relation(target), use: [:timestamps]).call(associate(data))
+          command(:update, relation(target), use: [:timestamps])
+            .by_pk(
+              one.public_send(relation(target).primary_key)
+            ).call(data)
         rescue => e
           raise Hanami::Model::Error.for(e)
         end
@@ -70,8 +73,6 @@ module Hanami
         def delete
           scope.delete
         end
-
-        # compatibility with the current beta
         alias remove delete
 
         def replace(data)

--- a/lib/hanami/model/associations/has_one.rb
+++ b/lib/hanami/model/associations/has_one.rb
@@ -71,6 +71,9 @@ module Hanami
           scope.delete
         end
 
+        # compatibility with the current beta
+        alias remove delete
+
         def replace(data)
           repository.transaction do
             delete

--- a/lib/hanami/model/associations/has_one.rb
+++ b/lib/hanami/model/associations/has_one.rb
@@ -63,16 +63,17 @@ module Hanami
 
         def update(data)
           command(:update, relation(target), use: [:timestamps]).call(associate(data))
+        rescue => e
+          raise Hanami::Model::Error.for(e)
         end
 
-        def remove
-          avatar = scope.one
-          command(:delete, relation(target)).by_pk(scope.one.id).call if avatar
+        def delete
+          scope.delete
         end
 
         def replace(data)
           repository.transaction do
-            remove
+            delete
             add(data)
           end
         end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -70,7 +70,7 @@ module Hanami
         # @since x.x.x
         # @api private
         # Return the association table object. Would need an aditional query to return the entity
-        def add(*data) # Can receive an array of hashes with pks.
+        def add(*data)
           command(:create, relation(through), use: [:timestamps])
             .call(associate(data.map(&:to_h)))
         end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -74,29 +74,25 @@ module Hanami
           command(:create, relation(through), use: [:timestamps])
             .call(associate(data.map(&:to_h)))
         rescue => e
-            raise Hanami::Model::Error.for(e)
+          raise Hanami::Model::Error.for(e)
         end
 
         # @since x.x.x
         # @api private
         def delete
-          relation(through)
-            .where(source_foreign_key => subject.fetch(source_primary_key))
-            .delete
+          relation(through).where(source_foreign_key => subject.fetch(source_primary_key)).delete
         end
 
         # @since x.x.x
         # @api private
         # rubocop:disable Metrics/AbcSize
-        def remove(id)
-          repository.transaction do
-            association_record = relation(through)
-                               .where(target_foreign_key => id, source_foreign_key => subject.fetch(source_primary_key))
+        def remove(target_id)
+          association_record = relation(through)
+                               .where(target_foreign_key => target_id, source_foreign_key => subject.fetch(source_primary_key))
                                .one
-            if association_record
-              ar_id = association_record.public_send relation(through).primary_key
-              command(:delete, relation(through)).by_pk(ar_id).call
-            end
+          if association_record
+            ar_id = association_record.public_send relation(through).primary_key
+            command(:delete, relation(through)).by_pk(ar_id).call
           end
         end
         # rubocop:enable Metrics/AbcSize

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -73,19 +73,30 @@ module Hanami
         def add(*data)
           command(:create, relation(through), use: [:timestamps])
             .call(associate(data.map(&:to_h)))
+        rescue => e
+            raise Hanami::Model::Error.for(e)
         end
 
         # @since x.x.x
         # @api private
-        # disabled until I figure out a better way to do this
+        def delete
+          relation(through)
+            .where(source_foreign_key => subject.fetch(source_primary_key))
+            .delete
+        end
+
+        # @since x.x.x
+        # @api private
         # rubocop:disable Metrics/AbcSize
         def remove(id)
-          association_record = relation(through)
+          repository.transaction do
+            association_record = relation(through)
                                .where(target_foreign_key => id, source_foreign_key => subject.fetch(source_primary_key))
                                .one
-          if association_record
-            ar_id = association_record.public_send relation(through).primary_key
-            command(:delete, relation(through)).by_pk(ar_id).call
+            if association_record
+              ar_id = association_record.public_send relation(through).primary_key
+              command(:delete, relation(through)).by_pk(ar_id).call
+            end
           end
         end
         # rubocop:enable Metrics/AbcSize

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -1,27 +1,26 @@
 RSpec.describe 'Associations (has_many)' do
+  let(:author_repository) { AuthorRepository.new }
+  let(:book_repository) { BookRepository.new }
+
   it "returns nil if association wasn't preloaded" do
-    repository = AuthorRepository.new
-    author = repository.create(name: 'L')
-    found = repository.find(author.id)
+    author = author_repository.create(name: 'L')
+    found = author_repository.find(author.id)
 
     expect(found.books).to be_nil
   end
 
   it 'preloads associated records' do
-    repository = AuthorRepository.new
+    author = author_repository.create(name: 'Umberto Eco')
+    book = book_repository.create(author_id: author.id, title: 'Foucault Pendulum')
 
-    author = repository.create(name: 'Umberto Eco')
-    book = BookRepository.new.create(author_id: author.id, title: 'Foucault Pendulum')
-
-    found = repository.find_with_books(author.id)
+    found = author_repository.find_with_books(author.id)
 
     expect(found).to eq(author)
     expect(found.books).to eq([book])
   end
 
   it 'creates an object with a collection of associated objects' do
-    repository = AuthorRepository.new
-    author = repository.create_with_books(name: 'Henry Thoreau', books: [{ title: 'Walden' }])
+    author = author_repository.create_with_books(name: 'Henry Thoreau', books: [{ title: 'Walden' }])
 
     expect(author).to be_an_instance_of(Author)
     expect(author.name).to eq('Henry Thoreau')
@@ -38,10 +37,8 @@ RSpec.describe 'Associations (has_many)' do
   # ADD
   #
   it 'adds an object to the collection' do
-    repository = AuthorRepository.new
-
-    author = repository.create(name: 'Alexandre Dumas')
-    book = repository.add_book(author, title: 'The Count of Monte Cristo')
+    author = author_repository.create(name: 'Alexandre Dumas')
+    book = author_repository.add_book(author, title: 'The Count of Monte Cristo')
 
     expect(book.id).to_not be_nil
     expect(book.title).to eq('The Count of Monte Cristo')
@@ -53,29 +50,29 @@ RSpec.describe 'Associations (has_many)' do
   #
   it 'removes an object from the collection'
   # it 'removes an object from the collection' do
-  #   repository = AuthorRepository.new
+  #   author_repository = AuthorRepository.new
   #   books = BookRepository.new
 
   #   # Book under test
-  #   author = repository.create(name: 'Douglas Adams')
-  #   book = books.create(author_id: author.id, title: "The Hitchhiker's Guide to the Galaxy")
+  #   author = author_repository.create(name: 'Douglas Adams')
+  #   book = book_repository.create(author_id: author.id, title: "The Hitchhiker's Guide to the Galaxy")
 
   #   # Different book
-  #   a = repository.create(name: 'William Finnegan')
-  #   b = books.create(author_id: a.id, title: 'Barbarian Days: A Surfing Life')
+  #   a = author_repository.create(name: 'William Finnegan')
+  #   b = book_repository.create(author_id: a.id, title: 'Barbarian Days: A Surfing Life')
 
-  #   repository.remove_book(author, book.id)
+  #   author_repository.remove_book(author, book.id)
 
   #   # Check the book under test has removed foreign key
-  #   found_book = books.find(book.id)
+  #   found_book = book_repository.find(book.id)
   #   expect(found_book).to_not be_nil
   #   expect(found_book.author_id).to be_nil
 
-  #   found_author = repository.find_with_books(author.id)
-  #   expect(found_author.books.map(&:id)).to_not include(found_book.id)
+  #   found_author = author_repository.find_with_books(author.id)
+  #   expect(found_author.book_repository.map(&:id)).to_not include(found_book.id)
 
   #   # Check that the other book was left untouched
-  #   found_b = books.find(b.id)
+  #   found_b = book_repository.find(b.id)
   #   expect(found_b.author_id).to eq(a.id)
   # end
 
@@ -83,14 +80,11 @@ RSpec.describe 'Associations (has_many)' do
   # TO_A
   #
   it 'returns an array of books' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
-
-    author = repository.create(name: 'Nikolai Gogol')
-    expected = books.create(author_id: author.id, title: 'Dead Souls')
+    author = author_repository.create(name: 'Nikolai Gogol')
+    expected = book_repository.create(author_id: author.id, title: 'Dead Souls')
     expect(expected).to be_an_instance_of(Book)
 
-    actual = repository.books_for(author).to_a
+    actual = author_repository.books_for(author).to_a
     expect(actual).to eq([expected])
   end
 
@@ -98,14 +92,11 @@ RSpec.describe 'Associations (has_many)' do
   # EACH
   #
   it 'iterates through the books' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
-
-    author = repository.create(name: 'José Saramago')
-    expected = books.create(author_id: author.id, title: 'The Cave')
+    author = author_repository.create(name: 'José Saramago')
+    expected = book_repository.create(author_id: author.id, title: 'The Cave')
 
     actual = []
-    repository.books_for(author).each do |book|
+    author_repository.books_for(author).each do |book|
       expect(book).to be_an_instance_of(Book)
       actual << book
     end
@@ -117,14 +108,11 @@ RSpec.describe 'Associations (has_many)' do
   # MAP
   #
   it 'iterates through the books and returns an array' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
-
-    author = repository.create(name: 'José Saramago')
-    expected = books.create(author_id: author.id, title: 'The Cave')
+    author = author_repository.create(name: 'José Saramago')
+    expected = book_repository.create(author_id: author.id, title: 'The Cave')
     expect(expected).to be_an_instance_of(Book)
 
-    actual = repository.books_for(author).map { |book| book }
+    actual = author_repository.books_for(author).map { |book| book }
     expect(actual).to eq([expected])
   end
 
@@ -132,52 +120,61 @@ RSpec.describe 'Associations (has_many)' do
   # COUNT
   #
   it 'returns the count of the associated books' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
+    author = author_repository.create(name: 'Fyodor Dostoevsky')
+    book_repository.create(author_id: author.id, title: 'Crime and Punishment')
+    book_repository.create(author_id: author.id, title: 'The Brothers Karamazov')
 
-    author = repository.create(name: 'Fyodor Dostoevsky')
-    books.create(author_id: author.id, title: 'Crime and Punishment')
-    books.create(author_id: author.id, title: 'The Brothers Karamazov')
-
-    expect(repository.books_count(author)).to eq(2)
+    expect(author_repository.books_count(author)).to eq(2)
   end
 
   it 'returns the count of on sale associated books' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
+    author = author_repository.create(name: 'Steven Pinker')
+    book_repository.create(author_id: author.id, title: 'The Sense of Style', on_sale: true)
 
-    author = repository.create(name: 'Steven Pinker')
-    books.create(author_id: author.id, title: 'The Sense of Style', on_sale: true)
-
-    expect(repository.on_sales_books_count(author)).to eq(1)
+    expect(author_repository.on_sales_books_count(author)).to eq(1)
   end
 
   ##
   # DELETE
   #
   it 'deletes all the books' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
+    author = author_repository.create(name: 'Grazia Deledda')
+    book = book_repository.create(author_id: author.id, title: 'Reeds In The Wind')
 
-    author = repository.create(name: 'Grazia Deledda')
-    book = books.create(author_id: author.id, title: 'Reeds In The Wind')
+    author_repository.delete_books(author)
 
-    repository.delete_books(author)
-
-    expect(books.find(book.id)).to be_nil
+    expect(book_repository.find(book.id)).to be_nil
   end
 
   it 'deletes scoped books' do
-    repository = AuthorRepository.new
-    books = BookRepository.new
+    author = author_repository.create(name: 'Harper Lee')
+    book = book_repository.create(author_id: author.id, title: 'To Kill A Mockingbird')
+    on_sale = book_repository.create(author_id: author.id, title: 'Go Set A Watchman', on_sale: true)
 
-    author = repository.create(name: 'Harper Lee')
-    book = books.create(author_id: author.id, title: 'To Kill A Mockingbird')
-    on_sale = books.create(author_id: author.id, title: 'Go Set A Watchman', on_sale: true)
+    author_repository.delete_on_sales_books(author)
 
-    repository.delete_on_sales_books(author)
+    expect(book_repository.find(book.id)).to eq(book)
+    expect(book_repository.find(on_sale.id)).to be_nil
+  end
 
-    expect(books.find(book.id)).to eq(book)
-    expect(books.find(on_sale.id)).to be_nil
+  context 'raises a Hanami::Model::Error wrapped exception on', focus: true do
+    it '#create' do
+      expect do
+        author_repository.create_with_books(name: 'Noam Chomsky')
+      end.to raise_error Hanami::Model::Error
+    end
+
+    it '#add' do
+      author = author_repository.create(name: 'Machado de Assis')
+      expect do
+        author_repository.add_book(author, title: 'O Aliennista', on_sale: nil)
+      end.to raise_error Hanami::Model::NotNullConstraintViolationError
+    end
+
+    # This is already handled by Repository#delete if needed
+    it '#delete'
+
+    # skipped spec
+    it '#remove'
   end
 end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -167,12 +167,9 @@ RSpec.describe 'Associations (has_many)' do
     it '#add' do
       author = authors.create(name: 'Machado de Assis')
       expect do
-        authors.add_book(author, title: 'O Aliennista', on_sale: nil)
+        authors.add_book(author, title: 'O Alienista', on_sale: nil)
       end.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
-
-    # This is already handled by Repository#delete if needed
-    it '#delete'
 
     # skipped spec
     it '#remove'

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe 'Associations (has_many)' do
     expect(book_repository.find(on_sale.id)).to be_nil
   end
 
-  context 'raises a Hanami::Model::Error wrapped exception on', focus: true do
+  context 'raises a Hanami::Model::Error wrapped exception on' do
     it '#create' do
       expect do
         author_repository.create_with_books(name: 'Noam Chomsky')

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -1,26 +1,26 @@
 RSpec.describe 'Associations (has_many)' do
-  let(:author_repository) { AuthorRepository.new }
-  let(:book_repository) { BookRepository.new }
+  let(:authors) { AuthorRepository.new }
+  let(:books) { BookRepository.new }
 
   it "returns nil if association wasn't preloaded" do
-    author = author_repository.create(name: 'L')
-    found = author_repository.find(author.id)
+    author = authors.create(name: 'L')
+    found = authors.find(author.id)
 
     expect(found.books).to be_nil
   end
 
   it 'preloads associated records' do
-    author = author_repository.create(name: 'Umberto Eco')
-    book = book_repository.create(author_id: author.id, title: 'Foucault Pendulum')
+    author = authors.create(name: 'Umberto Eco')
+    book = books.create(author_id: author.id, title: 'Foucault Pendulum')
 
-    found = author_repository.find_with_books(author.id)
+    found = authors.find_with_books(author.id)
 
     expect(found).to eq(author)
     expect(found.books).to eq([book])
   end
 
   it 'creates an object with a collection of associated objects' do
-    author = author_repository.create_with_books(name: 'Henry Thoreau', books: [{ title: 'Walden' }])
+    author = authors.create_with_books(name: 'Henry Thoreau', books: [{ title: 'Walden' }])
 
     expect(author).to be_an_instance_of(Author)
     expect(author.name).to eq('Henry Thoreau')
@@ -37,8 +37,8 @@ RSpec.describe 'Associations (has_many)' do
   # ADD
   #
   it 'adds an object to the collection' do
-    author = author_repository.create(name: 'Alexandre Dumas')
-    book = author_repository.add_book(author, title: 'The Count of Monte Cristo')
+    author = authors.create(name: 'Alexandre Dumas')
+    book = authors.add_book(author, title: 'The Count of Monte Cristo')
 
     expect(book.id).to_not be_nil
     expect(book.title).to eq('The Count of Monte Cristo')
@@ -50,29 +50,29 @@ RSpec.describe 'Associations (has_many)' do
   #
   it 'removes an object from the collection'
   # it 'removes an object from the collection' do
-  #   author_repository = AuthorRepository.new
+  #   authors = AuthorRepository.new
   #   books = BookRepository.new
 
   #   # Book under test
-  #   author = author_repository.create(name: 'Douglas Adams')
-  #   book = book_repository.create(author_id: author.id, title: "The Hitchhiker's Guide to the Galaxy")
+  #   author = authors.create(name: 'Douglas Adams')
+  #   book = books.create(author_id: author.id, title: "The Hitchhiker's Guide to the Galaxy")
 
   #   # Different book
-  #   a = author_repository.create(name: 'William Finnegan')
-  #   b = book_repository.create(author_id: a.id, title: 'Barbarian Days: A Surfing Life')
+  #   a = authors.create(name: 'William Finnegan')
+  #   b = books.create(author_id: a.id, title: 'Barbarian Days: A Surfing Life')
 
-  #   author_repository.remove_book(author, book.id)
+  #   authors.remove_book(author, book.id)
 
   #   # Check the book under test has removed foreign key
-  #   found_book = book_repository.find(book.id)
+  #   found_book = books.find(book.id)
   #   expect(found_book).to_not be_nil
   #   expect(found_book.author_id).to be_nil
 
-  #   found_author = author_repository.find_with_books(author.id)
-  #   expect(found_author.book_repository.map(&:id)).to_not include(found_book.id)
+  #   found_author = authors.find_with_books(author.id)
+  #   expect(found_author.books.map(&:id)).to_not include(found_book.id)
 
   #   # Check that the other book was left untouched
-  #   found_b = book_repository.find(b.id)
+  #   found_b = books.find(b.id)
   #   expect(found_b.author_id).to eq(a.id)
   # end
 
@@ -80,11 +80,11 @@ RSpec.describe 'Associations (has_many)' do
   # TO_A
   #
   it 'returns an array of books' do
-    author = author_repository.create(name: 'Nikolai Gogol')
-    expected = book_repository.create(author_id: author.id, title: 'Dead Souls')
+    author = authors.create(name: 'Nikolai Gogol')
+    expected = books.create(author_id: author.id, title: 'Dead Souls')
     expect(expected).to be_an_instance_of(Book)
 
-    actual = author_repository.books_for(author).to_a
+    actual = authors.books_for(author).to_a
     expect(actual).to eq([expected])
   end
 
@@ -92,11 +92,11 @@ RSpec.describe 'Associations (has_many)' do
   # EACH
   #
   it 'iterates through the books' do
-    author = author_repository.create(name: 'José Saramago')
-    expected = book_repository.create(author_id: author.id, title: 'The Cave')
+    author = authors.create(name: 'José Saramago')
+    expected = books.create(author_id: author.id, title: 'The Cave')
 
     actual = []
-    author_repository.books_for(author).each do |book|
+    authors.books_for(author).each do |book|
       expect(book).to be_an_instance_of(Book)
       actual << book
     end
@@ -108,11 +108,11 @@ RSpec.describe 'Associations (has_many)' do
   # MAP
   #
   it 'iterates through the books and returns an array' do
-    author = author_repository.create(name: 'José Saramago')
-    expected = book_repository.create(author_id: author.id, title: 'The Cave')
+    author = authors.create(name: 'José Saramago')
+    expected = books.create(author_id: author.id, title: 'The Cave')
     expect(expected).to be_an_instance_of(Book)
 
-    actual = author_repository.books_for(author).map { |book| book }
+    actual = authors.books_for(author).map { |book| book }
     expect(actual).to eq([expected])
   end
 
@@ -120,54 +120,54 @@ RSpec.describe 'Associations (has_many)' do
   # COUNT
   #
   it 'returns the count of the associated books' do
-    author = author_repository.create(name: 'Fyodor Dostoevsky')
-    book_repository.create(author_id: author.id, title: 'Crime and Punishment')
-    book_repository.create(author_id: author.id, title: 'The Brothers Karamazov')
+    author = authors.create(name: 'Fyodor Dostoevsky')
+    books.create(author_id: author.id, title: 'Crime and Punishment')
+    books.create(author_id: author.id, title: 'The Brothers Karamazov')
 
-    expect(author_repository.books_count(author)).to eq(2)
+    expect(authors.books_count(author)).to eq(2)
   end
 
   it 'returns the count of on sale associated books' do
-    author = author_repository.create(name: 'Steven Pinker')
-    book_repository.create(author_id: author.id, title: 'The Sense of Style', on_sale: true)
+    author = authors.create(name: 'Steven Pinker')
+    books.create(author_id: author.id, title: 'The Sense of Style', on_sale: true)
 
-    expect(author_repository.on_sales_books_count(author)).to eq(1)
+    expect(authors.on_sales_books_count(author)).to eq(1)
   end
 
   ##
   # DELETE
   #
   it 'deletes all the books' do
-    author = author_repository.create(name: 'Grazia Deledda')
-    book = book_repository.create(author_id: author.id, title: 'Reeds In The Wind')
+    author = authors.create(name: 'Grazia Deledda')
+    book = books.create(author_id: author.id, title: 'Reeds In The Wind')
 
-    author_repository.delete_books(author)
+    authors.delete_books(author)
 
-    expect(book_repository.find(book.id)).to be_nil
+    expect(books.find(book.id)).to be_nil
   end
 
   it 'deletes scoped books' do
-    author = author_repository.create(name: 'Harper Lee')
-    book = book_repository.create(author_id: author.id, title: 'To Kill A Mockingbird')
-    on_sale = book_repository.create(author_id: author.id, title: 'Go Set A Watchman', on_sale: true)
+    author = authors.create(name: 'Harper Lee')
+    book = books.create(author_id: author.id, title: 'To Kill A Mockingbird')
+    on_sale = books.create(author_id: author.id, title: 'Go Set A Watchman', on_sale: true)
 
-    author_repository.delete_on_sales_books(author)
+    authors.delete_on_sales_books(author)
 
-    expect(book_repository.find(book.id)).to eq(book)
-    expect(book_repository.find(on_sale.id)).to be_nil
+    expect(books.find(book.id)).to eq(book)
+    expect(books.find(on_sale.id)).to be_nil
   end
 
   context 'raises a Hanami::Model::Error wrapped exception on' do
     it '#create' do
       expect do
-        author_repository.create_with_books(name: 'Noam Chomsky')
+        authors.create_with_books(name: 'Noam Chomsky')
       end.to raise_error Hanami::Model::Error
     end
 
     it '#add' do
-      author = author_repository.create(name: 'Machado de Assis')
+      author = authors.create(name: 'Machado de Assis')
       expect do
-        author_repository.add_book(author, title: 'O Aliennista', on_sale: nil)
+        authors.add_book(author, title: 'O Aliennista', on_sale: nil)
       end.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
 

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe 'Associations (has_one)' do
       expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
     end
   end
+
+  context '#update' do
+    it 'updates the avatar' do
+      user = users.create_with_avatar(name: 'Bakunin', avatar: { url: 'bakunin.jpg' })
+      users.update_avatar(user, url: 'http://history.com/bakunin.png')
+
+      found = users.find_with_avatar(user.id)
+
+      expect(found).to eq(user)
+      expect(found.avatar).to eq(user.avatar)
+      expect(found.avatar.url).to_not eq(user.avatar.url)
+    end
+  end
+
   context '#create' do
     it 'creates a User and an Avatar' do
       user = users.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
@@ -70,14 +84,16 @@ RSpec.describe 'Associations (has_one)' do
     end
   end
 
-  it 'replaces the associated object' do
-    user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
-    users.replace_avatar(user, url: 'http://totally-correct.com/avatar.jpg')
-    found = users.find_with_avatar(user.id)
+  context '#replace' do
+    it 'replaces the associated object' do
+      user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
+      users.replace_avatar(user, url: 'http://totally-correct.com/avatar.jpg')
+      found = users.find_with_avatar(user.id)
 
-    expect(found.avatar).to_not eq(user.avatar)
+      expect(found.avatar).to_not eq(user.avatar)
 
-    expect(avatars.by_user(user.id).size).to eq(1)
+      expect(avatars.by_user(user.id).size).to eq(1)
+    end
   end
 
   context 'raises a Hanami::Model::Error wrapped exception on' do
@@ -94,6 +110,7 @@ RSpec.describe 'Associations (has_one)' do
 
     it '#update' do
       user = users.create_with_avatar(name: 'Dan North', avatar: { url: 'bdd_creator.png' })
+
       expect do
         users.update_avatar(user, url: nil)
       end.to raise_error Hanami::Model::NotNullConstraintViolationError

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -108,12 +108,15 @@ RSpec.describe 'Associations (has_one)' do
       expect { users.add_avatar(user, url: 'new_mugshot.png') }.to raise_error Hanami::Model::UniqueConstraintViolationError
     end
 
-    it '#update' do
-      user = users.create_with_avatar(name: 'Dan North', avatar: { url: 'bdd_creator.png' })
+    # by default it seems that MySQL allows you to update a NOT NULL column to a NULL value
+    unless_platform(db: mysql) do
+      it '#update' do
+        user = users.create_with_avatar(name: 'Dan North', avatar: { url: 'bdd_creator.png' })
 
-      expect do
-        users.update_avatar(user, url: nil)
-      end.to raise_error Hanami::Model::NotNullConstraintViolationError
+        expect do
+          users.update_avatar(user, url: nil)
+        end.to raise_error Hanami::Model::NotNullConstraintViolationError
+      end
     end
 
     it '#replace' do

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Associations (has_one)' do
     expect(AvatarRepository.new.by_user(user.id).size).to eq(1)
   end
 
-  context 'raises a Hanami::Model::Error wrapped exception on', focus: true do
+  context 'raises a Hanami::Model::Error wrapped exception on' do
     it '#create' do
       expect do
         repository.create_with_avatar(name: 'Noam Chomsky')

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -70,4 +70,22 @@ RSpec.describe 'Associations (has_one)' do
 
     expect(AvatarRepository.new.by_user(user.id).size).to eq(1)
   end
+
+  context 'raises a Hanami::Model::Error wrapped exception on', focus: true do
+    it '#create' do
+      expect do
+        repository.create_with_avatar(name: 'Noam Chomsky')
+      end.to raise_error Hanami::Model::Error
+    end
+
+    it '#add' do
+      user = repository.create_with_avatar(name: 'Stephen Fry', avatar: { url: 'fry_mugshot.png' })
+      expect { repository.add_avatar(user, url: 'new_mugshot.png') }.to raise_error Hanami::Model::UniqueConstraintViolationError
+    end
+
+    it '#replace' do
+      user = repository.create_with_avatar(name: 'Eric Evans', avatar: { url: 'ddd_man.png' })
+      expect { repository.replace_avatar(user, url: nil) }.to raise_error Hanami::Model::NotNullConstraintViolationError
+    end
+  end
 end

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -27,25 +27,6 @@ RSpec.describe 'Associations (has_one)' do
     expect(found).to eq(avatar)
   end
 
-  it 'adds an an Avatar to an existing User' do
-    user = users.create(name: 'Jean Paul-Sartre')
-    avatar = users.add_avatar(user, url: 'http://www.notarealurl.com/sartre.png')
-    found = users.find_with_avatar(user.id)
-
-    expect(found).to eq(user)
-    expect(found.avatar.id).to eq(avatar.id)
-    expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
-  end
-
-  it 'creates a User and an Avatar' do
-    user = users.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
-    found = users.find_with_avatar(user.id)
-
-    expect(found.name).to eq(user.name)
-    expect(found.avatar).to eq(user.avatar)
-    expect(found.avatar.url).to eq('http://lao-tse.io/me.jpg')
-  end
-
   it 'returns nil if the association was preloaded but no associated object is set' do
     user       = users.create(name: 'Henry Jenkins')
     found      = users.find_with_avatar(user.id)
@@ -54,12 +35,39 @@ RSpec.describe 'Associations (has_one)' do
     expect(found.avatar).to be_nil
   end
 
-  it 'removes the Avatar' do
-    user = users.create_with_avatar(name: 'Bob Ross', avatar: { url: 'http://bobross/happy_little_avatar.jpg' })
-    users.remove_avatar(user)
-    found = users.find_with_avatar(user.id)
+  context '#add' do
+    it 'adds an an Avatar to an existing User' do
+      user = users.create(name: 'Jean Paul-Sartre')
+      avatar = users.add_avatar(user, url: 'http://www.notarealurl.com/sartre.png')
+      found = users.find_with_avatar(user.id)
 
-    expect(found.avatar).to be_nil
+      expect(found).to eq(user)
+      expect(found.avatar.id).to eq(avatar.id)
+      expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
+    end
+  end
+  context '#create' do
+    it 'creates a User and an Avatar' do
+      user = users.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
+      found = users.find_with_avatar(user.id)
+
+      expect(found.name).to eq(user.name)
+      expect(found.avatar).to eq(user.avatar)
+      expect(found.avatar.url).to eq('http://lao-tse.io/me.jpg')
+    end
+  end
+
+  context '#delete' do
+    it 'removes the Avatar' do
+      user = users.create_with_avatar(name: 'Bob Ross', avatar: { url: 'http://bobross/happy_little_avatar.jpg' })
+      other = users.create_with_avatar(name: 'Candido Portinari', avatar: { url: 'some_mugshot.jpg' })
+      users.remove_avatar(user)
+      found = users.find_with_avatar(user.id)
+      other_found = users.find_with_avatar(other.id)
+
+      expect(found.avatar).to be_nil
+      expect(other_found.avatar).to be_an Avatar
+    end
   end
 
   it 'replaces the associated object' do
@@ -82,6 +90,13 @@ RSpec.describe 'Associations (has_one)' do
     it '#add' do
       user = users.create_with_avatar(name: 'Stephen Fry', avatar: { url: 'fry_mugshot.png' })
       expect { users.add_avatar(user, url: 'new_mugshot.png') }.to raise_error Hanami::Model::UniqueConstraintViolationError
+    end
+
+    it '#update' do
+      user = users.create_with_avatar(name: 'Dan North', avatar: { url: 'bdd_creator.png' })
+      expect do
+        users.update_avatar(user, url: nil)
+      end.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
 
     it '#replace' do

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -1,35 +1,36 @@
 require 'spec_helper'
 
 RSpec.describe 'Associations (has_one)' do
-  let(:repository) { UserRepository.new }
+  let(:users) { UserRepository.new }
+  let(:avatars) { AvatarRepository.new }
 
   it "returns nil if the association wasn't preloaded" do
-    user       = repository.create(name: 'John Doe')
-    found      = repository.find(user.id)
+    user       = users.create(name: 'John Doe')
+    found      = users.find(user.id)
 
     expect(found.avatar).to be_nil
   end
 
   it 'preloads the associated record' do
-    user       = repository.create(name: 'Baruch Spinoza')
-    avatar     = AvatarRepository.new.create(user_id: user.id, url: 'http://www.notarealurl.com/avatar.png')
-    found      = repository.find_with_avatar(user.id)
+    user       = users.create(name: 'Baruch Spinoza')
+    avatar     = avatars.create(user_id: user.id, url: 'http://www.notarealurl.com/avatar.png')
+    found      = users.find_with_avatar(user.id)
     expect(found).to eq(user)
     expect(found.avatar).to eq(avatar)
   end
 
   it 'returns an Avatar' do
-    user       = repository.create(name: 'Simone de Beauvoir')
-    avatar     = AvatarRepository.new.create(user_id: user.id, url: 'http://www.notarealurl.com/simone.png')
-    found      = repository.avatar_for(user)
+    user       = users.create(name: 'Simone de Beauvoir')
+    avatar     = avatars.create(user_id: user.id, url: 'http://www.notarealurl.com/simone.png')
+    found      = users.avatar_for(user)
 
     expect(found).to eq(avatar)
   end
 
   it 'adds an an Avatar to an existing User' do
-    user = repository.create(name: 'Jean Paul-Sartre')
-    avatar = repository.add_avatar(user, url: 'http://www.notarealurl.com/sartre.png')
-    found = repository.find_with_avatar(user.id)
+    user = users.create(name: 'Jean Paul-Sartre')
+    avatar = users.add_avatar(user, url: 'http://www.notarealurl.com/sartre.png')
+    found = users.find_with_avatar(user.id)
 
     expect(found).to eq(user)
     expect(found.avatar.id).to eq(avatar.id)
@@ -37,8 +38,8 @@ RSpec.describe 'Associations (has_one)' do
   end
 
   it 'creates a User and an Avatar' do
-    user = repository.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
-    found = repository.find_with_avatar(user.id)
+    user = users.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
+    found = users.find_with_avatar(user.id)
 
     expect(found.name).to eq(user.name)
     expect(found.avatar).to eq(user.avatar)
@@ -46,46 +47,46 @@ RSpec.describe 'Associations (has_one)' do
   end
 
   it 'returns nil if the association was preloaded but no associated object is set' do
-    user       = repository.create(name: 'Henry Jenkins')
-    found      = repository.find_with_avatar(user.id)
+    user       = users.create(name: 'Henry Jenkins')
+    found      = users.find_with_avatar(user.id)
 
     expect(found).to eq(user)
     expect(found.avatar).to be_nil
   end
 
   it 'removes the Avatar' do
-    user = repository.create_with_avatar(name: 'Bob Ross', avatar: { url: 'http://bobross/happy_little_avatar.jpg' })
-    repository.remove_avatar(user)
-    found = repository.find_with_avatar(user.id)
+    user = users.create_with_avatar(name: 'Bob Ross', avatar: { url: 'http://bobross/happy_little_avatar.jpg' })
+    users.remove_avatar(user)
+    found = users.find_with_avatar(user.id)
 
     expect(found.avatar).to be_nil
   end
 
   it 'replaces the associated object' do
-    user = repository.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
-    repository.replace_avatar(user, url: 'http://totally-correct.com/avatar.jpg')
-    found = repository.find_with_avatar(user.id)
+    user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
+    users.replace_avatar(user, url: 'http://totally-correct.com/avatar.jpg')
+    found = users.find_with_avatar(user.id)
 
     expect(found.avatar).to_not eq(user.avatar)
 
-    expect(AvatarRepository.new.by_user(user.id).size).to eq(1)
+    expect(avatars.by_user(user.id).size).to eq(1)
   end
 
   context 'raises a Hanami::Model::Error wrapped exception on' do
     it '#create' do
       expect do
-        repository.create_with_avatar(name: 'Noam Chomsky')
+        users.create_with_avatar(name: 'Noam Chomsky')
       end.to raise_error Hanami::Model::Error
     end
 
     it '#add' do
-      user = repository.create_with_avatar(name: 'Stephen Fry', avatar: { url: 'fry_mugshot.png' })
-      expect { repository.add_avatar(user, url: 'new_mugshot.png') }.to raise_error Hanami::Model::UniqueConstraintViolationError
+      user = users.create_with_avatar(name: 'Stephen Fry', avatar: { url: 'fry_mugshot.png' })
+      expect { users.add_avatar(user, url: 'new_mugshot.png') }.to raise_error Hanami::Model::UniqueConstraintViolationError
     end
 
     it '#replace' do
-      user = repository.create_with_avatar(name: 'Eric Evans', avatar: { url: 'ddd_man.png' })
-      expect { repository.replace_avatar(user, url: nil) }.to raise_error Hanami::Model::NotNullConstraintViolationError
+      user = users.create_with_avatar(name: 'Eric Evans', avatar: { url: 'ddd_man.png' })
+      expect { users.replace_avatar(user, url: nil) }.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
   end
 end

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Associations (has_one)' do
+  extend PlatformHelpers
+
   let(:users) { UserRepository.new }
   let(:avatars) { AvatarRepository.new }
 
@@ -109,7 +111,7 @@ RSpec.describe 'Associations (has_one)' do
     end
 
     # by default it seems that MySQL allows you to update a NOT NULL column to a NULL value
-    unless_platform(db: mysql) do
+    unless_platform(db: :mysql) do
       it '#update' do
         user = users.create_with_avatar(name: 'Dan North', avatar: { url: 'bdd_creator.png' })
 

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -140,8 +140,5 @@ RSpec.describe 'Associations (has_many :through)' do
         categories.add_books(category, id: -2)
       end.to raise_error Hanami::Model::ForeignKeyConstraintViolationError
     end
-
-    it '#remove' # this is a no-op if no record is found
-    it 'delete' # same as above
   end
 end

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Associations (has_many :through)' do
   let(:ontologies) { BookOntologyRepository.new }
 
   ### ENTITIES
-  let(:book) { books.create(title: 'Ontology: Encyclopedia of Database Systems', on_sale: false) }
+  let(:book) { books.create(title: 'Ontology: Encyclopedia of Database Systems') }
   let(:category) { categories.create(name: 'information science') }
 
   it "returns nil if association wasn't preloaded" do
@@ -57,6 +57,35 @@ RSpec.describe 'Associations (has_many :through)' do
     end
   end
 
+  context '#delete' do
+    it 'removes all association information' do
+      books.add_category(book, category)
+      categorized = books.find_with_categories(book.id)
+      books.clear_categories(book)
+      found = books.find_with_categories(book.id)
+
+      expect(categorized.categories).to be_an Array
+      expect(categorized.categories).to match_array([category])
+      expect(found.categories).to be_empty
+      expect(found).to eq(categorized)
+    end
+
+    it 'does not touch other books' do
+      other_book = books.create(title: 'Do not meddle with')
+      books.add_category(other_book, category)
+      books.add_category(book, category)
+
+      books.clear_categories(book)
+      found = books.find_with_categories(book.id)
+      other_found = books.find_with_categories(other_book.id)
+
+      expect(found).to eq(book)
+      expect(other_book).to eq(other_found)
+      expect(other_found.categories).to eq([category])
+      expect(found.categories).to be_empty
+    end
+  end
+
   context '#remove' do
     it 'removes the desired association' do
       to_remove = books.create(title: 'The Life of a Stoic')
@@ -103,5 +132,16 @@ RSpec.describe 'Associations (has_many :through)' do
 
       expect(categories.books_count(category)).to eq(2)
     end
+  end
+
+  context 'raises a Hanami::Model::Error wrapped exception on' do
+    it '#add' do
+      expect do
+        categories.add_books(category, id: -2)
+      end.to raise_error Hanami::Model::ForeignKeyConstraintViolationError
+    end
+
+    it '#remove' # this is a no-op if no record is found
+    it 'delete' # same as above
   end
 end

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe 'Repository (base)' do
         engine(:jruby).db(:mysql) { 'Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)' }
       end
 
-      expect { AvatarRepository.new.create(user_id: 999_999_999) }.to raise_error do |error|
+      expect { AvatarRepository.new.create(user_id: 999_999_999, url: 'url') }.to raise_error do |error|
         expect(error).to be_a(expected_error)
         expect(error.message).to include(message)
       end
@@ -459,7 +459,7 @@ RSpec.describe 'Repository (base)' do
 
       user = UserRepository.new.create(name: 'L')
       repository = AvatarRepository.new
-      avatar = repository.create(user_id: user.id)
+      avatar = repository.create(user_id: user.id, url: 'a valid url')
 
       expect { repository.update(avatar.id, user_id: 999_999_999) }.to raise_error do |error|
         expect(error).to be_a(expected_error)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -86,7 +86,7 @@ class UserRepository < Hanami::Repository
   end
 
   def find_with_avatar(id)
-    aggregate(:avatar).where(id: id).as(User).one
+    aggregate(:avatar).where(id: id).map_to(User).one
   end
 
   def create_with_avatar(data)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -94,11 +94,15 @@ class UserRepository < Hanami::Repository
   end
 
   def remove_avatar(user)
-    assoc(:avatar, user).remove
+    assoc(:avatar, user).delete
   end
 
   def add_avatar(user, data)
     assoc(:avatar, user).add(data)
+  end
+
+  def update_avatar(user, data)
+    assoc(:avatar, user).update(data)
   end
 
   def replace_avatar(user, data)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -228,6 +228,10 @@ class BookRepository < Hanami::Repository
     assoc(:categories, book).add(category)
   end
 
+  def clear_categories(book)
+    assoc(:categories, book).delete
+  end
+
   def categories_for(book)
     assoc(:categories, book).to_a
   end

--- a/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
+++ b/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
@@ -3,9 +3,9 @@ Hanami::Model.migration do
     drop_table?   :avatars
     create_table? :avatars do
       primary_key :id
-      foreign_key :user_id, :users, on_delete: :cascade, null: false
+      foreign_key :user_id, :users, on_delete: :cascade, null: false, unique: true
 
-      column :url, String
+      column :url, String, null: false
       column :created_at, DateTime
     end
   end


### PR DESCRIPTION
All the association code did not handle exceptions at all. The result was that we were receiving `ROM::SQL` exceptions instead of `Hanami::Model` ones.

This resulted in a very confused developer (myself) and some frustration, which leads us to this PR.

In all operations that might raise an exception, I added a `rescue` clause that wraps the error on a `Hanami::Model::Error`.

As, for the first time, I was working with the full association code, I made some changes to keep them consistent with each other.

Where the API changed I left an alias to the method old name just in case (and besides, it makes sense).