### PR TITLE
Fix various small English typos in comments

### DIFF
--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -33,7 +33,7 @@ module Hanami
   #     end
   #   end
   #
-  # **Hanami::Model** ships `Hanami::Entity` for developers's convenience.
+  # **Hanami::Model** ships `Hanami::Entity` for developers' convenience.
   #
   # **Hanami::Model** depends on a narrow and well-defined interface for an
   # Entity - `#id`, `#id=`, `#initialize(attributes={})`.If your object

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -82,7 +82,7 @@ module Hanami
 
     # Disconnect from the database
     #
-    # This is useful for reboot applications in production and to ensure that
+    # This is useful for rebooting applications in production and to ensure that
     # the framework prunes stale connections.
     #
     # @since 1.0.0

--- a/lib/hanami/model/mapped_relation.rb
+++ b/lib/hanami/model/mapped_relation.rb
@@ -2,7 +2,7 @@ module Hanami
   module Model
     # Mapped proxy for ROM relations.
     #
-    # It eliminates the need of use #as for repository queries
+    # It eliminates the need to use #as for repository queries
     #
     # @since 1.0.0
     # @api private

--- a/lib/hanami/model/migrator.rb
+++ b/lib/hanami/model/migrator.rb
@@ -116,7 +116,7 @@ module Hanami
       #   # Reads all files from "db/migrations" and apply them
       #   Hanami::Model::Migrator.migrate
       #
-      #   # Migrate to a specifiy version
+      #   # Migrate to a specific version
       #   Hanami::Model::Migrator.migrate(version: "20150610133853")
       #
       # NOTE: Class level interface SHOULD be removed in Hanami 2.0
@@ -189,7 +189,7 @@ module Hanami
       #     migrations 'db/migrations'
       #   end
       #
-      #   Hanami::Model::Migrator.prepare # => creates `foo' and run migrations
+      #   Hanami::Model::Migrator.prepare # => creates `foo' and runs migrations
       #
       # @example Prepare Database (with schema dump)
       #   require 'hanami/model'

--- a/lib/hanami/model/migrator/adapter.rb
+++ b/lib/hanami/model/migrator/adapter.rb
@@ -123,10 +123,10 @@ module Hanami
         # Returns a database connection
         #
         # Given a DB connection URI we can connect to a specific database or not, we need this when creating
-        # or droping a database. Important to notice that we can't always open a _global_ DB connection,
+        # or dropping a database. Important to notice that we can't always open a _global_ DB connection,
         # because most of the times application's DB user has no rights to do so.
         #
-        # @param global [Boolean] determine whether or not a connection should specify an database.
+        # @param global [Boolean] determine whether or not a connection should specify a database.
         #
         # @since 0.5.0
         # @api private

--- a/lib/hanami/model/sql.rb
+++ b/lib/hanami/model/sql.rb
@@ -110,7 +110,7 @@ module Hanami
       #     end
       #
       #     down do
-      #       drop_table :itmes
+      #       drop_table :items
       #       execute 'DROP TYPE inventory_item'
       #     end
       #   end

--- a/lib/hanami/model/sql/entity/schema.rb
+++ b/lib/hanami/model/sql/entity/schema.rb
@@ -22,7 +22,7 @@ module Hanami
           # associations and potentially to mapping defined by the repository.
           #
           # @param registry [Hash] a registry that keeps reference between
-          #   entities klass and their underscored names
+          #   entities class and their underscored names
           # @param relation [ROM::Relation] the database relation
           # @param mapping [Hanami::Model::Mapping] the optional repository
           #   mapping
@@ -75,7 +75,7 @@ module Hanami
           # Build the schema
           #
           # @param registry [Hash] a registry that keeps reference between
-          #   entities klass and their underscored names
+          #   entities class and their underscored names
           # @param relation [ROM::Relation] the database relation
           # @param mapping [Hanami::Model::Mapping] the optional repository
           #   mapping
@@ -112,7 +112,7 @@ module Hanami
           # Merge attributes and associations
           #
           # @param registry [Hash] a registry that keeps reference between
-          #   entities klass and their underscored names
+          #   entities class and their underscored names
           # @param associations [ROM::AssociationSet] a set of associations for
           #   the current relation
           #

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -70,7 +70,7 @@ module Hanami
 
             # NOTE: In the future rom-sql should be able to always return Ruby
             # types instead of Sequel types. When that will happen we can get
-            # rid of this logic in the block and to fallback to:
+            # rid of this logic in the block and fall back to:
             #
             #  MAPPING.fetch(unwrapped.pristine, attribute)
             MAPPING.fetch(unwrapped.pristine) do

--- a/lib/hanami/model/types.rb
+++ b/lib/hanami/model/types.rb
@@ -57,7 +57,7 @@ module Hanami
           # Check if value can be coerced
           #
           # It is true if value is an instance of `object` type or if value
-          # respond to `#to_hash`.
+          # responds to `#to_hash`.
           #
           # @param value [Object] the value
           #

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -54,7 +54,7 @@ module Hanami
   #
   # All the queries and commands are private.
   # This decision forces developers to define intention revealing API, instead
-  # leak storage API details outside of a repository.
+  # of leaking storage API details outside of a repository.
   #
   # @example
   #   require 'hanami/model'
@@ -87,7 +87,7 @@ module Hanami
   #   #  * It expresses a clear intent.
   #   #
   #   #  * The caller can be easily tested in isolation.
-  #   #    It's just a matter of stub this method.
+  #   #    It's just a matter of stubbing this method.
   #   #
   #   #  * If we change the storage, the callers aren't affected.
   #
@@ -167,7 +167,7 @@ module Hanami
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
-    # Defines the ampping between a database table and an entity.
+    # Defines the mapping between a database table and an entity.
     #
     # It's also responsible to associate table columns to entity attributes.
     #
@@ -314,7 +314,7 @@ module Hanami
     module Commands
       # Create a new record
       #
-      # @return [Hanami::Entity] an new created entity
+      # @return [Hanami::Entity] a new created entity
       #
       # @raise [Hanami::Model::Error] an error in case the command fails
       #


### PR DESCRIPTION
I was reviewing the code to get a better understanding of how it all works and along the way I corrected some small English language typos I noticed in the code comments.