### PR TITLE
Improve connection string postgresql

### DIFF
--- a/lib/hanami/model/sql/consoles/postgresql.rb
+++ b/lib/hanami/model/sql/consoles/postgresql.rb
@@ -36,7 +36,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def host
-            " -h #{@uri.host}"
+            " -h #{query['host'] || @uri.host}"
           end
 
           # @since 0.7.0
@@ -48,19 +48,31 @@ module Hanami
           # @since 0.7.0
           # @api private
           def port
-            " -p #{@uri.port}" unless @uri.port.nil?
+            port = query['port'] || @uri.port
+            " -p #{port}" if port
           end
 
           # @since 0.7.0
           # @api private
           def username
-            " -U #{@uri.user}" unless @uri.user.nil?
+            username = query['user'] || @uri.user
+            " -U #{username}" if username
           end
 
           # @since 0.7.0
           # @api private
           def configure_password
-            ENV[PASSWORD] = CGI.unescape(@uri.password) unless @uri.password.nil?
+            password = query['password'] || @uri.password
+            ENV[PASSWORD] = CGI.unescape(query['password'] || @uri.password) if password
+          end
+
+          # @since x.x.x
+          # @api private
+          def query
+            return {} if @uri.query.nil? || @uri.query.empty?
+
+            parsed_query = @uri.query.split("&").map { |a| a.split("=") }
+            @query ||= Hash[parsed_query]
           end
         end
       end

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -25,5 +25,19 @@ RSpec.shared_examples "sql_console_postgresql" do
         ENV.delete('PGPASSWORD')
       end
     end
+
+    context 'when components of the  hierarchical part of the URI can also be given as parameters' do
+      let(:uri) { URI.parse('postgres:///foo_development?user=username&password=password&host=localhost&port=1234') }
+
+      it 'returns a connection string' do
+        expect(console.connection_string).to eq('psql -h localhost -d foo_development -p 1234 -U username')
+      end
+
+      it 'sets the PGPASSWORD environment variable' do
+        console.connection_string
+        expect(ENV['PGPASSWORD']).to eq('password')
+        ENV.delete('PGPASSWORD')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR implements https://github.com/hanami/hanami/issues/805

Check this link: https://www.postgresql.org/docs/9.6/static/libpq-connect.html#AEN45575

Tested in a fresh application with a connection string like the following:
```
posgresql:///foo_development?host=localhost&port=1234&user=username&password=password
```

cc @olistik 