### PR TITLE
Repository#assoc scope delegation

### DIFF
--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -104,7 +104,7 @@ module Hanami
 
         private
 
-        def method_missing(meth, args)
+        def method_missing(meth, *args)
           whitelisted_methods = %i[where order limit reverse]
           return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
           __new__(scope.public_send(meth, args))

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -96,11 +96,11 @@ module Hanami
           scope.to_a
         end
 
-        # @since 0.7.0
-        # @api private
-        def where(condition)
-          __new__(scope.where(condition))
-        end
+        # # @since 0.7.0
+        # # @api private
+        # def where(condition)
+        #   __new__(scope.where(condition))
+        # end
 
         # @since 0.7.0
         # @api private
@@ -109,6 +109,16 @@ module Hanami
         end
 
         private
+
+        def method_missing(meth, args)
+          whitelisted_methods = %i(where order limit)
+          return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
+          __new__(scope.public_send(meth, args))
+        end
+
+        def respond_to_missing?(meth, include_all)
+          scope.respond_to?(meth, include_all)
+        end
 
         # @since 0.7.0
         # @api private

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -12,7 +12,7 @@ module Hanami
         # @api private
         def self.schema_type(entity)
           type = Sql::Types::Schema::AssociationType.new(entity)
-          Types::Strict::Array.member(type)
+          Types::Strict::Array.of(type)
         end
 
         # @since 0.7.0
@@ -105,7 +105,7 @@ module Hanami
         private
 
         def method_missing(meth, args)
-          whitelisted_methods = %i(where order limit)
+          whitelisted_methods = %i[where order limit reverse]
           return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
           __new__(scope.public_send(meth, args))
         end

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -96,12 +96,6 @@ module Hanami
           scope.to_a
         end
 
-        # # @since 0.7.0
-        # # @api private
-        # def where(condition)
-        #   __new__(scope.where(condition))
-        # end
-
         # @since 0.7.0
         # @api private
         def count

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -65,15 +65,8 @@ module Hanami
           scope.count
         end
 
-<<<<<<< HEAD
-        def where(condition)
-          __new__(scope.where(condition))
-        end
-
         # Return the association table object. Would need an aditional query to return the entity
         #
-=======
->>>>>>> many-to-many respond_to :where, :limit, :order
         # @since 1.1.0
         # @api private
         def add(*data)
@@ -106,8 +99,8 @@ module Hanami
 
         private
 
-        def method_missing(meth, *args)
-          whitelisted_methods = %i[where order limit reverse]
+        def method_missing(meth, args)
+          whitelisted_methods = %i(where order limit)
           return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
           __new__(scope.public_send(meth, args))
         end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -100,7 +100,7 @@ module Hanami
         private
 
         def method_missing(meth, args)
-          whitelisted_methods = %i(where order limit)
+          whitelisted_methods = %i[where order limit]
           return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
           __new__(scope.public_send(meth, args))
         end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -12,7 +12,7 @@ module Hanami
         # @api private
         def self.schema_type(entity)
           type = Sql::Types::Schema::AssociationType.new(entity)
-          Types::Strict::Array.member(type)
+          Types::Strict::Array.of(type)
         end
 
         # @since 1.1.0
@@ -65,12 +65,15 @@ module Hanami
           scope.count
         end
 
+<<<<<<< HEAD
         def where(condition)
           __new__(scope.where(condition))
         end
 
         # Return the association table object. Would need an aditional query to return the entity
         #
+=======
+>>>>>>> many-to-many respond_to :where, :limit, :order
         # @since 1.1.0
         # @api private
         def add(*data)
@@ -102,6 +105,16 @@ module Hanami
         # rubocop:enable Metrics/AbcSize
 
         private
+
+        def method_missing(meth, args)
+          whitelisted_methods = %i(where order limit)
+          return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
+          __new__(scope.public_send(meth, args))
+        end
+
+        def respond_to_missing?(meth, include_all)
+          scope.respond_to?(meth, include_all)
+        end
 
         # @since 1.1.0
         # @api private

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -107,7 +107,7 @@ module Hanami
         private
 
         def method_missing(meth, args)
-          whitelisted_methods = %i(where order limit)
+          whitelisted_methods = %i[where order limit reverse]
           return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
           __new__(scope.public_send(meth, args))
         end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -106,7 +106,7 @@ module Hanami
 
         private
 
-        def method_missing(meth, args)
+        def method_missing(meth, *args)
           whitelisted_methods = %i[where order limit reverse]
           return super unless whitelisted_methods.member?(meth) && scope.respond_to?(meth)
           __new__(scope.public_send(meth, args))

--- a/lib/hanami/model/types.rb
+++ b/lib/hanami/model/types.rb
@@ -74,7 +74,7 @@ module Hanami
         #   user.name  # => "MG"
         def Collection(type)
           type = Schema::CoercibleType.new(type) unless type.is_a?(Dry::Types::Definition)
-          Types::Array.member(type)
+          Types::Array.of(type)
         end
       end
       # rubocop:enable Naming/MethodName

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -192,4 +192,25 @@ RSpec.describe 'Associations (has_many)' do
     # skipped spec
     it '#remove'
   end
+
+  context 'delegates scope manipulation to #scope' do
+    let(:author) { authors.create_with_books(name: 'Luis de Camões', books: [{title: 'Os Lusíadas'}]) }
+    let(:book_assoc) { authors.books_for(id: author.id) }
+
+    it 'responds to #where' do
+      expect(book_assoc).to respond_to :where
+      expect { book_assoc.where(title: 'Os Lusíadas') }.to_not raise_error
+      expect(book_assoc.where(title: 'Os Lusíadas').to_a.size).to eq(1)
+    end
+
+    it 'reponds to #limit' do
+      expect(book_assoc).to respond_to :limit
+      expect { book_assoc.limit(5) }.to_not raise_error
+    end
+
+    it 'responds to #order' do
+      expect(book_assoc).to respond_to :order
+      expect{ book_assoc.order(:title) }.to_not raise_error
+    end
+  end
 end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -212,5 +212,13 @@ RSpec.describe 'Associations (has_many)' do
       expect(book_assoc).to respond_to :order
       expect { book_assoc.order(:title) }.to_not raise_error
     end
+
+    it 'allows chaining of the methods' do
+      author = authors.create_with_books(name: 'Machado de Assis', books: [{title: 'Dom Casmurro'}, {title: 'O Alienista'}])
+      authors.add_book(author, {title: 'Memórias Póstumas de Brás Cubas'})
+      found = authors.last_books_published_for(author)
+
+      expect(found.map(&:title)).to match(['Memórias Póstumas de Brás Cubas', 'O Alienista'])
+    end
   end
 end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe 'Associations (has_many)' do
   end
 
   context 'delegates scope manipulation to #scope' do
-    let(:author) { authors.create_with_books(name: 'Luis de Camões', books: [{title: 'Os Lusíadas'}]) }
+    let(:author) { authors.create_with_books(name: 'Luis de Camões', books: [{ title: 'Os Lusíadas' }]) }
     let(:book_assoc) { authors.books_for(id: author.id) }
 
     it 'responds to #where' do
@@ -210,7 +210,7 @@ RSpec.describe 'Associations (has_many)' do
 
     it 'responds to #order' do
       expect(book_assoc).to respond_to :order
-      expect{ book_assoc.order(:title) }.to_not raise_error
+      expect { book_assoc.order(:title) }.to_not raise_error
     end
   end
 end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -214,8 +214,8 @@ RSpec.describe 'Associations (has_many)' do
     end
 
     it 'allows chaining of the methods' do
-      author = authors.create_with_books(name: 'Machado de Assis', books: [{title: 'Dom Casmurro'}, {title: 'O Alienista'}])
-      authors.add_book(author, {title: 'Memórias Póstumas de Brás Cubas'})
+      author = authors.create_with_books(name: 'Machado de Assis', books: [{ title: 'Dom Casmurro' }, { title: 'O Alienista' }])
+      authors.add_book(author, title: 'Memórias Póstumas de Brás Cubas')
       found = authors.last_books_published_for(author)
 
       expect(found.map(&:title)).to match(['Memórias Póstumas de Brás Cubas', 'O Alienista'])

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Associations (has_many :through)' do
   it 'returns an array of Categories' do
     ontologies.create(book_id: book.id, category_id: category.id)
 
-    found = books.categories_for(book)
+    found = books.categories_for(book).to_a
     expect(found).to eq([category])
   end
 
@@ -139,6 +139,26 @@ RSpec.describe 'Associations (has_many :through)' do
       expect do
         categories.add_books(category, id: -2)
       end.to raise_error Hanami::Model::ForeignKeyConstraintViolationError
+    end
+  end
+
+  context 'delegates scope manipulation to #scope' do
+    let(:category_assoc) { books.categories_for(book) }
+
+    it 'responds to #where' do
+      expect(category_assoc).to respond_to :where
+      expect { category_assoc.where(name: 'nonexistant') }.to_not raise_error
+      expect(category_assoc.where(name: 'nonexistant').to_a.size).to eq(0)
+    end
+
+    it 'reponds to #limit' do
+      expect(category_assoc).to respond_to :limit
+      expect { category_assoc.limit(5) }.to_not raise_error
+    end
+
+    it 'responds to #order' do
+      expect(category_assoc).to respond_to :order
+      expect{ category_assoc.order(:name) }.to_not raise_error
     end
   end
 end

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Associations (has_many :through)' do
 
     it 'responds to #order' do
       expect(category_assoc).to respond_to :order
-      expect{ category_assoc.order(:name) }.to_not raise_error
+      expect { category_assoc.order(:name) }.to_not raise_error
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -250,6 +250,10 @@ class AuthorRepository < Hanami::Repository
     assoc(:books, author).where(on_sale: true).count
   end
 
+  def last_books_published_for(author)
+    assoc(:books, author).reverse(:created_at).limit(2).to_a
+  end
+
   def find_book(author, id)
     book_for(author, id).one
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -317,7 +317,7 @@ class BookRepository < Hanami::Repository
   end
 
   def categories_for(book)
-    assoc(:categories, book).to_a
+    assoc(:categories, book)
   end
 
   def find_with_categories(id)


### PR DESCRIPTION
Both `has_many` and `many_to_many` associations had this glaring issue where you could not filter any results of said association.

Let's say:
```
class AuthorRepository < Hanami::Repository
  associations do
    has_many :books
  end

  # works
  def books_for(author)
    assoc(:books, author)
  end

 # works
  def books_titled(author, title)
    assoc(:books, author).where(title: title)
  end 

  # did not work
  def last_books_published_for(author)
   assoc(:books, author).order(:published_at).reverse.limit(5)
  end
end
```
This PR fixes this by delegating a few methods back at `#scope` and returning a new association object.