### PR TITLE
Support for association aliasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 rvm:
   - 2.3.4
   - 2.4.2
-  - jruby-9.1.6.0
+  - jruby-9.1.9.0
   - ruby-head
   - jruby-head
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 rvm:
   - 2.3.4
   - 2.4.2
-  - jruby-9.1.9.0
+  - jruby-9.1.8.0
   - ruby-head
   - jruby-head
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 rvm:
   - 2.3.4
   - 2.4.2
-  - jruby-9.1.8.0
+  - jruby-9.1.13.0
   - ruby-head
   - jruby-head
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 rvm:
   - 2.3.4
   - 2.4.2
-  - jruby-9.1.13.0
+  - jruby-9.1.16.0
   - ruby-head
   - jruby-head
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 rvm:
   - 2.3.4
   - 2.4.2
-  - jruby-9.1.16.0
+  - jruby-9.1.6.0
   - ruby-head
   - jruby-head
 env:

--- a/lib/hanami/model/associations/belongs_to.rb
+++ b/lib/hanami/model/associations/belongs_to.rb
@@ -82,15 +82,22 @@ module Hanami
         # @since 1.1.0
         # @api private
         def association_keys
-          relation(source)
-            .associations[target]
+          association
             .__send__(:join_key_map, container.relations)
+        end
+
+        # Return the ROM::Associations for the source relation
+        #
+        # @since x.x.x
+        # @api private
+        def association
+          relation(source).associations[target]
         end
 
         # @since 1.1.0
         # @api private
         def _build_scope
-          result = relation(target)
+          result = relation(association.target.to_sym)
           result = result.where(foreign_key => subject.fetch(primary_key)) unless subject.nil?
           result.as(Model::MappedRelation.mapper_name)
         end

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -177,15 +177,23 @@ module Hanami
         # @since 0.7.0
         # @api private
         def association_keys
-          relation(source)
-            .associations[target]
+          target_association
             .__send__(:join_key_map, container.relations)
+        end
+
+
+        # Returns the targeted association for a given source
+        #
+        # @since 0.7.0
+        # @api private
+        def target_association
+          relation(source).associations[target]
         end
 
         # @since 0.7.0
         # @api private
         def _build_scope
-          result = relation(target)
+          result = relation(target_association.target.to_sym)
           result = result.where(foreign_key => subject.fetch(primary_key)) unless subject.nil?
           result.as(Model::MappedRelation.mapper_name)
         end

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -7,7 +7,7 @@ module Hanami
       #
       # @since 0.7.0
       # @api private
-      class HasMany
+      class HasMany # rubocop:disable Metrics/ClassLength
         # @since 0.7.0
         # @api private
         def self.schema_type(entity)
@@ -180,7 +180,6 @@ module Hanami
           target_association
             .__send__(:join_key_map, container.relations)
         end
-
 
         # Returns the targeted association for a given source
         #

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -158,11 +158,20 @@ module Hanami
           association_keys[1].last
         end
 
+        # Return the ROM::Associations for the source relation
+        #
+        # @since x.x.x
+        # @api private
+        def association
+          relation(source).associations[target]
+        end
+
         # @since 1.1.0
+        #
         # @api private
         # rubocop:disable Metrics/AbcSize
         def _build_scope
-          result = relation(target).qualified
+          result = relation(association.target.to_sym).qualified
           unless subject.nil?
             result = result
                      .join(through, target_foreign_key => target_primary_key)

--- a/lib/hanami/model/sql/entity/schema.rb
+++ b/lib/hanami/model/sql/entity/schema.rb
@@ -122,7 +122,7 @@ module Hanami
           # @api private
           def build_associations(registry, associations)
             associations.each_with_object({}) do |(name, association), result|
-              target       = registry.fetch(name)
+              target       = registry.fetch(association.target.to_sym)
               result[name] = Association.lookup(association).schema_type(target)
             end
           end

--- a/spec/integration/hanami/model/associations/relation_alias_spec.rb
+++ b/spec/integration/hanami/model/associations/relation_alias_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Alias (:as)  support for associations' do
 
     found = posts.feed_for(post.id)
     expect(found.author).to eq(user)
-    expect(found.comments[0].commenter).to eq(commenter)
+    expect(found.comments[0].user).to eq(commenter)
   end
 
   context '#assoc support (calling assoc by the alias)' do
@@ -47,16 +47,15 @@ RSpec.describe 'Alias (:as)  support for associations' do
       expect(found_threads).to match_array [post]
     end
 
-    # Not working yet
-    # it 'for #has_many :through' do
-    #   user = users.create(name: 'Jules Verne')
-    #   post = posts.create(title: 'World Traveling made easy', user_id: user.id)
-    #   commenter = users.create(name: 'Thomas Reid')
-    #   comment = comments.create(user_id: commenter.id, post_id: post.id)
+    it 'for #has_many :through' do
+      user = users.create(name: 'Jules Verne')
+      post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+      commenter = users.create(name: 'Thomas Reid')
+      comments.create(user_id: commenter.id, post_id: post.id)
 
-    #   commenters = posts.commenters_for(post)
+      commenters = posts.commenters_for(post)
 
-    #   expect(commenters).to match_array([commenter])
-    # end
+      expect(commenters).to match_array([commenter])
+    end
   end
 end

--- a/spec/integration/hanami/model/associations/relation_alias_spec.rb
+++ b/spec/integration/hanami/model/associations/relation_alias_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe 'Alias (:as)  support for associations' do
+  let(:users) { UserRepository.new }
+  let(:posts) { PostRepository.new }
+  let(:comments) { CommentRepository.new }
+
+  it 'the attribute is named after the association' do
+    user = users.create(name: 'Jules Verne')
+    post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+
+    post_found = posts.find_with_author(post.id)
+    expect(post_found.author).to eq(user)
+
+    user_found = users.find_with_threads(user.id)
+    expect(user_found.threads).to match_array([post])
+  end
+
+  it 'it works with nested aggregates' do
+    user = users.create(name: 'Jules Verne')
+    post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+    commenter = users.create(name: 'Thomas Reid')
+    comments.create(user_id: commenter.id, post_id: post.id)
+
+    found = posts.feed_for(post.id)
+    expect(found.author).to eq(user)
+    expect(found.comments[0].commenter).to eq(commenter)
+  end
+
+  context '#assoc support (calling assoc by the alias)' do
+    it 'for #belongs_to' do
+      user = users.create(name: 'Jules Verne')
+      post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+      commenter = users.create(name: 'Thomas Reid')
+      comment = comments.create(user_id: commenter.id, post_id: post.id)
+
+      found_author = posts.author_for(post)
+      expect(found_author).to eq(user)
+
+      found_commenter = comments.commenter_for(comment)
+      expect(found_commenter).to eq(commenter)
+    end
+
+    it 'for #has_many' do
+      user = users.create(name: 'Jules Verne')
+      post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+
+      found_threads = users.threads_for(user)
+      expect(found_threads).to match_array [post]
+    end
+
+    # Not working yet
+    # it 'for #has_many :through' do
+    #   user = users.create(name: 'Jules Verne')
+    #   post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+    #   commenter = users.create(name: 'Thomas Reid')
+    #   comment = comments.create(user_id: commenter.id, post_id: post.id)
+
+    #   commenters = posts.commenters_for(post)
+
+    #   expect(commenters).to match_array([commenter])
+    # end
+  end
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -100,7 +100,7 @@ class PostRepository < Hanami::Repository
   end
 
   def feed_for(id)
-    aggregate(:author, comments: :commenter).where(id: id).map_to(Post).one
+    aggregate(:author, comments: :user).where(id: id).map_to(Post).one
   end
 
   def author_for(post)
@@ -111,11 +111,11 @@ end
 class CommentRepository < Hanami::Repository
   associations do
     belongs_to :post
-    belongs_to :users, as: :commenter
+    belongs_to :user
   end
 
   def commenter_for(comment)
-    assoc(:commenter, comment).one
+    assoc(:user, comment).one
   end
 end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -25,7 +25,10 @@ end
 class SourceFile < Hanami::Entity
 end
 
-class Avatar < Hanami::Entity
+class Post < Hanami::Entity
+end
+
+class Comment < Hanami::Entity
 end
 
 class Warehouse < Hanami::Entity
@@ -77,6 +80,45 @@ end
 class Label < Hanami::Entity
 end
 
+class PostRepository < Hanami::Repository
+  associations do
+    belongs_to :user, as: :author
+    has_many :comments
+    has_many :users, through: :comments, as: :commenters
+  end
+
+  def find_with_commenters(id)
+    aggregate(:commenters).where(id: id).map_to(Post).to_a
+  end
+
+  def commenters_for(post)
+    assoc(:commenters, post).to_a
+  end
+
+  def find_with_author(id)
+    aggregate(:author).where(id: id).map_to(Post).one
+  end
+
+  def feed_for(id)
+    aggregate(:author, comments: :commenter).where(id: id).map_to(Post).one
+  end
+
+  def author_for(post)
+    assoc(:author, post).one
+  end
+end
+
+class CommentRepository < Hanami::Repository
+  associations do
+    belongs_to :post
+    belongs_to :users, as: :commenter
+  end
+
+  def commenter_for(comment)
+    assoc(:commenter, comment).one
+  end
+end
+
 class AvatarRepository < Hanami::Repository
   associations do
     belongs_to :user
@@ -90,6 +132,16 @@ end
 class UserRepository < Hanami::Repository
   associations do
     has_one :avatar
+    has_many :posts, as: :threads
+    has_many :comments
+  end
+
+  def find_with_threads(id)
+    aggregate(:threads).where(id: id).map_to(User).one
+  end
+
+  def threads_for(user)
+    assoc(:threads, user).to_a
   end
 
   def find_with_avatar(id)

--- a/spec/support/fixtures/database_migrations/20171002201227_create_posts_and_comments.rb
+++ b/spec/support/fixtures/database_migrations/20171002201227_create_posts_and_comments.rb
@@ -1,0 +1,17 @@
+Hanami::Model.migration do
+  change do
+    drop_table?   :posts
+    create_table? :posts do
+      primary_key :id
+      column :title, String
+      foreign_key :user_id, :users, on_delete: :cascade, null: false
+    end
+    drop_table? :comments
+    create_table? :comments do
+      primary_key :id
+
+      foreign_key :user_id, :users, on_delete: :cascade, null: false
+      foreign_key :post_id, :posts, on_delete: :cascade, null: false
+    end
+  end
+end


### PR DESCRIPTION
This small patch adds alias support for hanami associations

```
class UserRepository < Hanami::Repository
  associations do
    has_many :posts
  end
end

class PostRepository < Hanami::Repository
  associations do
    belongs_to :user, as: :author
  end

  def latest_10_posts
    aggregates(:author).reverse(:created_at).limit(10).map_to(Post).to_a
  end
end 

#=> [Post(title: 'Awesomeness in a Jar`, author: User(name: 'InternetPerson'))] 
```
