### PR TITLE
Make it compatible with dry-types 0.12.1

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.0'
   spec.add_runtime_dependency 'rom-sql',         '~> 1.3'
   spec.add_runtime_dependency 'rom-repository',  '~> 1.4'
-  spec.add_runtime_dependency 'dry-types',       '~> 0.11'
+  spec.add_runtime_dependency 'dry-types',       '~> 0.12', '>= 0.12.1'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -16,20 +16,62 @@ module Hanami
         module Schema
           require 'hanami/model/sql/types/schema/coercions'
 
-          String   = Types::Optional::Coercible::String
+          # Raise an error
+          #
+          # @since 1.0.3
+          # @api private
+          #
+          # @see https://github.com/hanami/model/pull/453
+          #
+          # TODO: remove this class in hanami-model 2.0
+          class RaiseError
+            # @since 1.0.3
+            # @api private
+            def initialize(class_name)
+              @class_name = class_name
+            end
 
-          Int      = Types::Strict::Nil | Types::Int.constructor(Coercions.method(:int))
-          Float    = Types::Strict::Nil | Types::Float.constructor(Coercions.method(:float))
-          Decimal  = Types::Strict::Nil | Types::Float.constructor(Coercions.method(:decimal))
+            # @since 1.0.3
+            # @api private
+            def try(input)
+              raise ArgumentError.new("invalid value for #{@class_name}(): #{input.inspect}")
+            end
 
-          Bool     = Types::Strict::Nil | Types::Strict::Bool
+            # @since 1.0.3
+            # @api private
+            def constrained?
+              false
+            end
+          end
 
-          Date     = Types::Strict::Nil | Types::Date.constructor(Coercions.method(:date))
-          DateTime = Types::Strict::Nil | Types::DateTime.constructor(Coercions.method(:datetime))
-          Time     = Types::Strict::Nil | Types::Time.constructor(Coercions.method(:time))
+          # Raise an error
+          #
+          # @since 1.0.3
+          # @api private
+          #
+          # @see https://github.com/hanami/model/pull/453
+          #
+          # TODO: remove this class in hanami-model 2.0
+          class RaiseTypeError < RaiseError
+            def try(input)
+              raise TypeError.new("#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
+            end
+          end
 
-          Array    = Types::Strict::Nil | Types::Array.constructor(Coercions.method(:array))
-          Hash     = Types::Strict::Nil | Types::Hash.constructor(Coercions.method(:hash))
+          String   = Types::Optional::Coercible::String | RaiseError.new("String")
+
+          Int      = Types::Strict::Nil | Types::Int.constructor(Coercions.method(:int)) | RaiseError.new("Integer")
+          Float    = Types::Strict::Nil | Types::Float.constructor(Coercions.method(:float)) | RaiseError.new("Float")
+          Decimal  = Types::Strict::Nil | Types::Decimal.constructor(Coercions.method(:decimal)) | RaiseError.new("BigDecimal")
+
+          Bool     = Types::Strict::Nil | Types::Strict::Bool | RaiseTypeError.new("Bool")
+
+          Date     = Types::Strict::Nil | Types::Date.constructor(Coercions.method(:date)) | RaiseError.new("Date")
+          DateTime = Types::Strict::Nil | Types::DateTime.constructor(Coercions.method(:datetime)) | RaiseError.new("DateTime")
+          Time     = Types::Strict::Nil | Types::Time.constructor(Coercions.method(:time)) | RaiseError.new("Time")
+
+          Array    = Types::Strict::Nil | Types::Array.constructor(Coercions.method(:array)) | RaiseError.new("Array")
+          Hash     = Types::Strict::Nil | Types::Hash.constructor(Coercions.method(:hash)) | RaiseError.new("Hash")
 
           PG_JSON  = Types::Strict::Nil | Types::Any.constructor(Coercions.method(:pg_json))
 

--- a/spec/unit/hanami/model/sql/schema/date_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/date_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Date" do
   it 'raises error for meaningless string' do
     input = 'foo'
     expect { described_class[input] }
-      .to raise_error(ArgumentError, 'invalid date')
+      .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
   end
 
   it 'raises error for symbol' do

--- a/spec/unit/hanami/model/sql/schema/date_time_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/date_time_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::DateTime" do
   it 'raises error for meaningless string' do
     input = 'foo'
     expect { described_class[input] }
-      .to raise_error(ArgumentError, 'invalid date')
+      .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
   end
 
   it 'raises error for symbol' do

--- a/spec/unit/hanami/model/sql/schema/decimal_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/decimal_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Decimal" do
   end
 
   it 'coerces object that respond to #to_d' do
+    described_class[input]
     expect(described_class[input]).to eq(input.to_d)
   end
 

--- a/spec/unit/hanami/model/sql/schema/time_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/time_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Time" do
   it 'raises error for meaningless string' do
     input = 'foo'
     expect { described_class[input] }
-      .to raise_error(ArgumentError, "no time information in #{input.inspect}")
+      .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
   end
 
   it 'raises error for symbol' do


### PR DESCRIPTION
`dry-types` `v0.12.1` introduced a breaking change: it doesn't longer let `ArgumentError` to be raised when _composite_ or _sum_ types are trying to coerce the input.

While I agree with that choice, that is a breaking change for our public API, so we had to fix it for now, and then go for an exception-less approach in 2.0.

---

Ref https://github.com/dry-rb/dry-types/commit/f535775b7c643b27a80de6690f92ec495cde93d2