### PR TITLE
Depend on dry-types ~> 0.11.0

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.0'
   spec.add_runtime_dependency 'rom-sql',         '~> 1.3'
   spec.add_runtime_dependency 'rom-repository',  '~> 1.4'
-  spec.add_runtime_dependency 'dry-types',       '~> 0.11'
+  spec.add_runtime_dependency 'dry-types',       '~> 0.11.0'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
According to @flash-gordon, `rom-sql` isn't compatible with `dry-types` `0.12`, we should stay on `0.11`.