### PR TITLE
Set minimal rom-sql version

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_runtime_dependency 'hanami-utils',    '~> 1.0'
-  spec.add_runtime_dependency 'rom-sql',         '~> 1.3'
+  spec.add_runtime_dependency 'rom-sql',         '~> 1.3', '>= 1.3.5'
   spec.add_runtime_dependency 'rom-repository',  '~> 1.4'
   spec.add_runtime_dependency 'dry-types',       '~> 0.11.0'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -86,11 +86,9 @@ module Hanami
           # @api private
           def self.pg_json_pristines
             @pg_json_pristines ||= ::Hash.new do |hash, type|
-              if defined?(ROM::SQL::Types::PG)
-                hash[type] = ROM::SQL::Types::PG.const_get(type).pristine
-              else
-                hash[type] = nil
-              end
+              hash[type] = if defined?(ROM::SQL::Types::PG)
+                             ROM::SQL::Types::PG.const_get(type).pristine
+                           end
             end
           end
 

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -82,11 +82,23 @@ module Hanami
             end
           end
 
+          # @since 1.1.0
+          # @api private
+          def self.pg_json_pristines
+            @pg_json_pristines ||= ::Hash.new do |hash, type|
+              if defined?(ROM::SQL::Types::PG)
+                hash[type] = ROM::SQL::Types::PG.const_get(type).pristine
+              else
+                hash[type] = nil
+              end
+            end
+          end
+
           # @since 1.0.2
           # @api private
           def self.pg_json?(pristine)
-            (defined?(ROM::SQL::Types::PG::JSONB) && pristine == ROM::SQL::Types::PG::JSONB) ||
-              (defined?(ROM::SQL::Types::PG::JSON) && pristine == ROM::SQL::Types::PG::JSON)
+            pristine == pg_json_pristines['JSONB'] ||
+              pristine == pg_json_pristines['JSON']
           end
 
           private_class_method :pg_json?


### PR DESCRIPTION
I made `rom-sql` 1.x compatible with `dry-types` 0.11 in https://github.com/rom-rb/rom-sql/pull/250. Dependency for `dry-types` is already set in master (https://github.com/hanami/model/pull/454), here I set the rom-sql's version and run CI check, once it's green I'll push 1.3.5 to rubygems.