### PR TITLE
Allow entities to be used as types in manual schema

### DIFF
--- a/lib/hanami/model/types.rb
+++ b/lib/hanami/model/types.rb
@@ -17,15 +17,67 @@ module Hanami
       # Class level interface
       #
       # @since 0.7.0
+      # rubocop:disable Naming/MethodName
       module ClassMethods
+        # Define an entity of the given type
+        #
+        # @param type [Hanami::Entity] an entity
+        #
+        # @since 1.1.0
+        #
+        # @example
+        #   require "hanami/model"
+        #
+        #   class Account < Hanami::Entity
+        #     attributes do
+        #       # ...
+        #       attribute :owner, Types::Entity(User)
+        #     end
+        #   end
+        #
+        #   account = Account.new(owner: User.new(name: "Luca"))
+        #   account.owner.class # => User
+        #   account.owner.name  # => "Luca"
+        #
+        #   account = Account.new(owner: { name: "MG" })
+        #   account.owner.class # => User
+        #   account.owner.name  # => "MG"
+        def Entity(type)
+          type = Schema::CoercibleType.new(type) unless type.is_a?(Dry::Types::Definition)
+          type
+        end
+
         # Define an array of given type
         #
+        # @param type [Object] an object
+        #
         # @since 0.7.0
-        def Collection(type) # rubocop:disable Naming/MethodName
+        #
+        # @example
+        #   require "hanami/model"
+        #
+        #   class Account < Hanami::Entity
+        #     attributes do
+        #       # ...
+        #       attribute :users, Types::Collection(User)
+        #     end
+        #   end
+        #
+        #   account = Account.new(users: [User.new(name: "Luca")])
+        #   user    = account.users.first
+        #   user.class # => User
+        #   user.name  # => "Luca"
+        #
+        #   account = Account.new(users: [{ name: "MG" }])
+        #   user    = account.users.first
+        #   user.class # => User
+        #   user.name  # => "MG"
+        def Collection(type)
           type = Schema::CoercibleType.new(type) unless type.is_a?(Dry::Types::Definition)
           Types::Array.member(type)
         end
       end
+      # rubocop:enable Naming/MethodName
 
       # Types for schema definitions
       #

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -41,6 +41,7 @@ class Account < Hanami::Entity
     attribute :id,         Types::Strict::Int
     attribute :name,       Types::String
     attribute :codes,      Types::Collection(Types::Coercible::Int)
+    attribute :owner,      Types::Entity(User)
     attribute :users,      Types::Collection(User)
     attribute :email,      Types::String.constrained(format: /@/)
     attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })

--- a/spec/unit/hanami/entity/manual_schema/base_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/base_spec.rb
@@ -18,10 +18,11 @@ RSpec.describe Hanami::Entity do
       end
 
       it 'accepts a hash' do
-        entity = described_class.new(id: 1, users: users = [User.new], name: 'Acme Inc.', codes: [1, 2, 3], email: 'account@acme-inc.test', created_at: now = DateTime.now)
+        entity = described_class.new(id: 1, owner: owner = User.new(name: "MG"), users: users = [User.new], name: 'Acme Inc.', codes: [1, 2, 3], email: 'account@acme-inc.test', created_at: now = DateTime.now)
 
         expect(entity.id).to eq(1)
         expect(entity.name).to eq('Acme Inc.')
+        expect(entity.owner).to eq(owner)
         expect(entity.users).to eq(users)
         expect(entity.codes).to eq([1, 2, 3])
         expect(entity.email).to eq('account@acme-inc.test')
@@ -52,6 +53,13 @@ RSpec.describe Hanami::Entity do
         entity = described_class.new(codes: %w[4 5 6])
 
         expect(entity.codes).to eq([4, 5, 6])
+      end
+
+      it 'coerces values for single object' do
+        entity = described_class.new(owner: owner = { name: 'L' })
+
+        expect(entity.owner).to be_a_kind_of(User)
+        expect(entity.owner.name).to eq(owner.fetch(:name))
       end
 
       it 'coerces values for array of objects' do


### PR DESCRIPTION
Introduce an enhancement for manual schema: allow entities to be used as types.

```ruby
require "hanami/model"

class Account < Hanami::Entity
  attributes do
    # ...
    attribute :owner, Types::Entity(User)
  end
end

account = Account.new(owner: User.new(name: "Luca"))
account.owner.class # => User
account.owner.name  # => "Luca"

account = Account.new(owner: { name: "MG" })
account.owner.class # => User
account.owner.name  # => "MG"
```

---

Closes #410 