### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ A persistence layer for Hanami
 
 ## v1.0.4 - 2017-10-14
 ### Fixed
-- [Nikita Shilnikov] Keep the dependency on `dry-sql` at `~> 1.3`, which is compatible with `dry-types` `~> 0.11.0`
+- [Nikita Shilnikov] Keep the dependency on `rom-sql` at `~> 1.3`, which is compatible with `dry-types` `~> 0.11.0`
 - [Nikita Shilnikov] Ensure to write Postgres JSON (`PGJSON`) type for nested associated records
 - [Nikita Shilnikov] Ensure `Repository#select` to work with `Hanami::Model::MappedRelation`
 


### PR DESCRIPTION
I was surprised to find out about a `dry-sql` gem :stuck_out_tongue: