### PR TITLE
Associations to deep serialize input to `::Hash`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '1.1.0.rc1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'feature/hash-deep-serialize'
+gem 'hanami-utils', '1.1.0.rc1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '1.1.0.rc1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
+gem 'hanami-utils', '1.1.0.rc1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'feature/hash-deep-serialize'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -50,7 +50,7 @@ module Hanami
         # @api private
         def create(data)
           entity.new(command(:create, aggregate(target), use: [:timestamps])
-            .call(data))
+            .call(serialize(data)))
         rescue => e
           raise Hanami::Model::Error.for(e)
         end
@@ -59,7 +59,7 @@ module Hanami
         # @api private
         def add(data)
           command(:create, relation(target), use: [:timestamps])
-            .call(associate(data))
+            .call(associate(serialize(data)))
         rescue => e
           raise Hanami::Model::Error.for(e)
         end
@@ -201,6 +201,10 @@ module Hanami
         # @api private
         def __new__(new_scope)
           self.class.new(repository, source, target, subject, new_scope)
+        end
+
+        def serialize(data)
+          Utils::Hash.deep_serialize(data)
         end
       end
     end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -1,3 +1,5 @@
+require "hanami/utils/hash"
+
 module Hanami
   module Model
     module Associations
@@ -67,12 +69,13 @@ module Hanami
           __new__(scope.where(condition))
         end
 
+        # Return the association table object. Would need an aditional query to return the entity
+        #
         # @since 1.1.0
         # @api private
-        # Return the association table object. Would need an aditional query to return the entity
         def add(*data)
           command(:create, relation(through), use: [:timestamps])
-            .call(associate(data.map(&:to_h)))
+            .call(associate(serialize(data)))
         rescue => e
           raise Hanami::Model::Error.for(e)
         end
@@ -185,6 +188,14 @@ module Hanami
         # @api private
         def __new__(new_scope)
           self.class.new(repository, source, target, subject, new_scope)
+        end
+
+        # @since 1.1.0
+        # @api private
+        def serialize(data)
+          data.map do |d|
+            Utils::Hash.deep_serialize(d)
+          end
         end
       end
     end

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -7,7 +7,7 @@ module Hanami
       #
       # @since 0.7.0
       # @api private
-      class ManyToMany
+      class ManyToMany # rubocop:disable Metrics/ClassLength
         # @since 0.7.0
         # @api private
         def self.schema_type(entity)

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe 'Associations (has_many)' do
     expect(author.books.first.title).to eq('Walden')
   end
 
+  it 'creates associated records when it receives a collection of serializable data' do
+    author = authors.create_with_books(name: 'Sandi Metz', books: [BaseParams.new(title: 'Practical Object-Oriented Design in Ruby')])
+
+    expect(author).to be_an_instance_of(Author)
+    expect(author.name).to eq('Sandi Metz')
+    expect(author.books).to be_an_instance_of(Array)
+    expect(author.books.first).to be_an_instance_of(Book)
+    expect(author.books.first.title).to eq('Practical Object-Oriented Design in Ruby')
+  end
+
   ##############################################################################
   # OPERATIONS                                                                 #
   ##############################################################################
@@ -42,6 +52,15 @@ RSpec.describe 'Associations (has_many)' do
 
     expect(book.id).to_not be_nil
     expect(book.title).to eq('The Count of Monte Cristo')
+    expect(book.author_id).to eq(author.id)
+  end
+
+  it 'adds an object to the collection with serializable data' do
+    author = authors.create(name: 'David Foster Wallace')
+    book = authors.add_book(author, BaseParams.new(title: 'Infinite Jest'))
+
+    expect(book.id).to_not be_nil
+    expect(book.title).to eq('Infinite Jest')
     expect(book.author_id).to eq(author.id)
   end
 

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -47,24 +47,54 @@ RSpec.describe 'Associations (has_one)' do
       expect(found.avatar.id).to eq(avatar.id)
       expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
     end
+
+    it 'adds an an Avatar to an existing User when serializable data is received' do
+      user = users.create(name: 'Jean Paul-Sartre')
+      avatar = users.add_avatar(user, BaseParams.new(url: 'http://www.notarealurl.com/sartre.png'))
+      found = users.find_with_avatar(user.id)
+
+      expect(found).to eq(user)
+      expect(found.avatar.id).to eq(avatar.id)
+      expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
+    end
   end
 
   context '#update' do
     it 'updates the avatar' do
       user = users.create_with_avatar(name: 'Bakunin', avatar: { url: 'bakunin.jpg' })
-      users.update_avatar(user, url: 'http://history.com/bakunin.png')
+      users.update_avatar(user, url: url = 'http://history.com/bakunin.png')
 
       found = users.find_with_avatar(user.id)
 
       expect(found).to eq(user)
       expect(found.avatar).to eq(user.avatar)
-      expect(found.avatar.url).to_not eq(user.avatar.url)
+      expect(found.avatar.url).to eq(url)
+    end
+
+    it 'updates the avatar when serializable data is received' do
+      user = users.create_with_avatar(name: 'Bakunin', avatar: { url: 'bakunin.jpg' })
+      users.update_avatar(user, BaseParams.new(url: url = 'http://history.com/bakunin.png'))
+
+      found = users.find_with_avatar(user.id)
+
+      expect(found).to eq(user)
+      expect(found.avatar).to eq(user.avatar)
+      expect(found.avatar.url).to eq(url)
     end
   end
 
   context '#create' do
     it 'creates a User and an Avatar' do
       user = users.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
+      found = users.find_with_avatar(user.id)
+
+      expect(found.name).to eq(user.name)
+      expect(found.avatar).to eq(user.avatar)
+      expect(found.avatar.url).to eq('http://lao-tse.io/me.jpg')
+    end
+
+    it 'creates a User and an Avatar when serializable data is received' do
+      user = users.create_with_avatar(name: 'Lao Tse', avatar: BaseParams.new(url: 'http://lao-tse.io/me.jpg'))
       found = users.find_with_avatar(user.id)
 
       expect(found.name).to eq(user.name)
@@ -90,6 +120,16 @@ RSpec.describe 'Associations (has_one)' do
     it 'replaces the associated object' do
       user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
       users.replace_avatar(user, url: 'http://totally-correct.com/avatar.jpg')
+      found = users.find_with_avatar(user.id)
+
+      expect(found.avatar).to_not eq(user.avatar)
+
+      expect(avatars.by_user(user.id).size).to eq(1)
+    end
+
+    it 'replaces the associated object when serializable data is received' do
+      user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
+      users.replace_avatar(user, BaseParams.new(url: 'http://totally-correct.com/avatar.jpg'))
       found = users.find_with_avatar(user.id)
 
       expect(found.avatar).to_not eq(user.avatar)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,3 +1,11 @@
+require "ostruct"
+
+class BaseParams < OpenStruct
+  def to_hash
+    to_h
+  end
+end
+
 class User < Hanami::Entity
 end
 


### PR DESCRIPTION
Let associations to deep serialize input to `::Hash`.

---

Closes https://github.com/hanami/controller/issues/235
Ref https://github.com/hanami/utils/pull/238