### PR TITLE
Fix typos in spec (intance -> instance)

### DIFF
--- a/spec/unit/hanami/entity/automatic_schema_spec.rb
+++ b/spec/unit/hanami/entity/automatic_schema_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hanami::Entity do
         expect(entity.id).to eq(1)
       end
 
-      it 'freezes the intance' do
+      it 'freezes the instance' do
         entity = described_class.new
 
         expect(entity).to be_frozen

--- a/spec/unit/hanami/entity/manual_schema/base_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/base_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Hanami::Entity do
         expect(entity.id).to eq(1)
       end
 
-      it 'freezes the intance' do
+      it 'freezes the instance' do
         entity = described_class.new
 
         expect(entity).to be_frozen

--- a/spec/unit/hanami/entity/manual_schema/strict_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/strict_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hanami::Entity do
         expect(entity.name).to eq("MG")
       end
 
-      it 'freezes the intance' do
+      it 'freezes the instance' do
         entity = described_class.new(id: 1, name: "Luca")
 
         expect(entity).to be_frozen

--- a/spec/unit/hanami/entity/schemaless_spec.rb
+++ b/spec/unit/hanami/entity/schemaless_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hanami::Entity do
         expect(entity.a).to eq(1)
       end
 
-      it 'freezes the intance' do
+      it 'freezes the instance' do
         entity = described_class.new
 
         expect(entity).to be_frozen


### PR DESCRIPTION
I found and fixed some typos in spec files. (intance -> instance)
I hope this helps.