### PR TITLE
adds find_by method to repository class

### DIFF
--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -413,6 +413,21 @@ module Hanami
       raise Hanami::Model::Error.for(e)
     end
 
+    # Find by any conditions
+    #
+    # @return [Hanami::Entity,NilClass] one entity, if any
+    #
+    # @since 1.1.1
+    #
+    # @example
+    #   repository = UserRepository.new
+    #   user       = repository.create(name: 'Luca')
+    #
+    #   user       = UserRepository.new.find_by(name: 'Luca')
+    def find_by(conditions = {})
+      root.where(conditions).as(:entity).limit(1).one
+    end
+
     # Return all the records for the relation
     #
     # @return [Array<Hanami::Entity>] all the entities

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -56,6 +56,23 @@ RSpec.describe 'Repository (base)' do
     end
   end
 
+  describe '#find_by' do
+    it 'finds a record by conditions' do
+      repository = UserRepository.new
+      user = repository.create(name: 'Van Pannelo')
+      found = repository.find_by(name: user.name)
+
+      expect(found).to eq(user)
+    end
+
+    it 'returns nil for missing record' do
+      repository = UserRepository.new
+      found = repository.find_by(name: 'jjjjj')
+
+      expect(found).to be_nil
+    end
+  end
+
   describe '#all' do
     it 'returns all the records' do
       repository = UserRepository.new


### PR DESCRIPTION
I made some hanami application. and I often defined find_by method like rails's one.
so I think it will be more convenient if hanami have find_by method.
What do you think?