### PR TITLE
Overwriting the `Repository#command` method

### DIFF
--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -49,7 +49,7 @@ module Hanami
         # @since 0.7.0
         # @api private
         def create(data)
-          entity.new(command(:create, aggregate(target), use: [:timestamps])
+          entity.new(command(:create, aggregate(target), mapper: nil, use: [:timestamps])
             .call(serialize(data)))
         rescue => e
           raise Hanami::Model::Error.for(e)
@@ -113,7 +113,7 @@ module Hanami
         # @since 0.7.0
         # @api private
         def command(target, relation, options = {})
-          repository.command(target, relation, options)
+          repository.command(target => relation, **options)
         end
 
         # @since 0.7.0

--- a/lib/hanami/model/associations/has_one.rb
+++ b/lib/hanami/model/associations/has_one.rb
@@ -51,20 +51,20 @@ module Hanami
 
         def create(data)
           entity.new(
-            command(:create, aggregate(target), use: [:timestamps]).call(serialize(data))
+            command(:create, aggregate(target), mapper: nil).call(serialize(data))
           )
         rescue => e
           raise Hanami::Model::Error.for(e)
         end
 
         def add(data)
-          command(:create, relation(target), use: [:timestamps]).call(associate(serialize(data)))
+          command(:create, relation(target), mapper: nil).call(associate(serialize(data)))
         rescue => e
           raise Hanami::Model::Error.for(e)
         end
 
         def update(data)
-          command(:update, relation(target), use: [:timestamps])
+          command(:update, relation(target), mapper: nil)
             .by_pk(
               one.public_send(relation(target).primary_key)
             ).call(serialize(data))

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -132,6 +132,13 @@ module Hanami
       Hanami::Model.container
     end
 
+    def command(*args, **opts, &block)
+      opts[:use] = COMMAND_PLUGINS | Array(opts[:use])
+      opts[:mapper] = opts.fetch(:mapper, Model::MappedRelation.mapper_name)
+
+      super(*args, **opts, &block)
+    end
+
     # Define a database relation, which describes how data is fetched from the
     # database.
     #

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -132,6 +132,26 @@ module Hanami
       Hanami::Model.container
     end
 
+    # Define a new ROM::Command while preserving the defaults used by Hanami itself.
+    #
+    # It allows the user to define a new command to, for example,
+    # create many records at the same time and still get entities back.
+    #
+    # The first argument is the command and relation it will operate on.
+    #
+    # @return [ROM::Command] the created command
+    #
+    # @example
+    #   In this example, calling the create_many method with and array of data,
+    #   would result in the creation of records and return an Array of Task entities.
+    #
+    #   class TaskRepository < Hanami::Repository
+    #     def create_many(data)
+    #       command(create: :tasks, result: :many).call(data)
+    #     end
+    #   end
+    #
+    # @since x.x.x
     def command(*args, **opts, &block)
       opts[:use] = COMMAND_PLUGINS | Array(opts[:use])
       opts[:mapper] = opts.fetch(:mapper, Model::MappedRelation.mapper_name)

--- a/spec/integration/hanami/model/repository/command_spec.rb
+++ b/spec/integration/hanami/model/repository/command_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe 'Customized commands' do
+  subject(:authors) { AuthorRepository.new }
+
+  let(:data) do
+    [{name: 'Arthur C. Clarke'}, {name: 'Phillip K. Dick'}]
+  end
+
+  context 'the mapper' do
+    it 'is enabled by default' do
+      result = authors.create_many(data)
+      expect(result).to be_an Array
+      expect(result).to all(be_an(Author))
+    end
+
+    it 'can be explictly turned off' do
+      result = authors.create_many(data, opts: { mapper: nil })
+      expect(result).to all(be_an(ROM::Struct))
+    end
+  end
+
+  context 'timestamps' do
+    it 'are enabled by default' do
+      result = authors.create_many(data)
+      expect(result.first.created_at).to be_within(2).of(Time.now.utc)
+    end
+  end
+end

--- a/spec/integration/hanami/model/repository/command_spec.rb
+++ b/spec/integration/hanami/model/repository/command_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Customized commands' do
   subject(:authors) { AuthorRepository.new }
 
   let(:data) do
-    [{name: 'Arthur C. Clarke'}, {name: 'Phillip K. Dick'}]
+    [{ name: 'Arthur C. Clarke' }, { name: 'Phillip K. Dick' }]
   end
 
   context 'the mapper' do

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -210,6 +210,10 @@ class AuthorRepository < Hanami::Repository
     has_many :books
   end
 
+  def create_many(data, opts: {})
+    command(create: :authors, result: :many, **opts).call(data)
+  end
+
   def create_with_books(data)
     assoc(:books).create(data)
   end


### PR DESCRIPTION
This PR eases end user pain when defining new commands.

Before she had to pass a bunch of options that she had no idea even where there or waht the Hanami defaults are, so we take care of that.

```ruby
class UserRepository < Hanami::Repository
  def create_many(bunch_of_data)
    command(create: :users, result: :many).call(bunch_of_data)
  end

  def ye_old_way_of_creating_many(bundle_of_data)
    command(create: :users, 
      mapper: :entity, 
      result: :many, use: [:schema, :mapping, :timestamps]).call(bundle_of_data)
  end
end
``` 

Closes hanami/hanami#856