### PR TITLE
Fix model adapter configuration syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ class UserRepository < Hanami::Repository
 end
 
 Hanami::Model.configure do
-  adapter :sql, uri: 'postgresql://localhost/bookshelf'
+  adapter :sql, 'postgresql://localhost/bookshelf'
 end.load!
 
 repository = UserRepository.new


### PR DESCRIPTION
Documentation in README states that to configure your model adapter you have to use this syntax:

```
 adapter :sql, uri: 'postgresql://localhost/bookshelf'
```

The second argument shouldn't be a hash but a string. This string is the actual URI. If you try to use a hash it is cast to a string.