### PR TITLE
Sqlite INSERT INTO lines without double quotes

### DIFF
--- a/lib/hanami/model/migrator/sqlite_adapter.rb
+++ b/lib/hanami/model/migrator/sqlite_adapter.rb
@@ -110,7 +110,7 @@ module Hanami
           execute "sqlite3 #{escape(path)} .dump" do |stdout|
             begin
               contents = stdout.read.split($INPUT_RECORD_SEPARATOR)
-              contents = contents.grep(/^INSERT INTO "#{migrations_table}"/)
+              contents = contents.grep(/^INSERT INTO #{migrations_table}/)
 
               ::File.open(schema, ::File::CREAT | ::File::BINARY | ::File::WRONLY | ::File::APPEND) do |file|
                 file.write(contents.join($INPUT_RECORD_SEPARATOR))

--- a/spec/unit/hanami/model/migrator/sqlite.rb
+++ b/spec/unit/hanami/model/migrator/sqlite.rb
@@ -282,8 +282,8 @@ RSpec.shared_examples 'migrator_sqlite' do
 
         expect(actual).to include %(CREATE TABLE `schema_migrations` (`filename` varchar(255) NOT NULL PRIMARY KEY);)
         expect(actual).to include %(CREATE TABLE `reviews` (`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT, `title` varchar(255) NOT NULL, `rating` integer DEFAULT (0));)
-        expect(actual).to include %(INSERT INTO "schema_migrations" VALUES('20160831073534_create_reviews.rb');)
-        expect(actual).to include %(INSERT INTO "schema_migrations" VALUES('20160831090612_add_rating_to_reviews.rb');)
+        expect(actual).to include %(INSERT INTO schema_migrations VALUES('20160831073534_create_reviews.rb');)
+        expect(actual).to include %(INSERT INTO schema_migrations VALUES('20160831090612_add_rating_to_reviews.rb');)
       end
 
       it 'deletes all the migrations' do


### PR DESCRIPTION
After run tests with sqlite database INSERT INTO lines look like:

INSERT INTO schema_migrations ...

instead of

INSERT INTO "schema_migrations"

otherwise I am receiving this error:
<img width="1393" alt="screen shot 2018-04-05 at 21 00 12" src="https://user-images.githubusercontent.com/945115/38441637-b877d640-39e5-11e8-889f-2f384f394682.png">
