### PR TITLE
Raise meaningful error for unknown database adapter

### DIFF
--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -47,6 +47,9 @@ module Hanami
 
       # NOTE: This must be changed when we want to support several adapters at the time
       #
+      # @raise [Hanami::Model::UnknownDatabaseAdapterError] if `url` is blank,
+      #   or it uses an unknown adapter.
+      #
       # @since 0.7.0
       # @api private
       def connection
@@ -54,6 +57,9 @@ module Hanami
       end
 
       # NOTE: This must be changed when we want to support several adapters at the time
+      #
+      # @raise [Hanami::Model::UnknownDatabaseAdapterError] if `url` is blank,
+      #   or it uses an unknown adapter.
       #
       # @since 0.7.0
       # @api private
@@ -122,12 +128,21 @@ module Hanami
         gateway.use_logger(@logger = value)
       end
 
+      # @raise [Hanami::Model::UnknownDatabaseAdapterError] if `url` is blank,
+      #   or it uses an unknown adapter.
+      #
       # @since 1.0.0
       # @api private
       def rom
         @rom ||= ROM::Configuration.new(@backend, @url, infer_relations: false)
+      rescue => e
+        raise UnknownDatabaseAdapterError.new(@url) if e.message =~ /adapters/
+        raise e
       end
 
+      # @raise [Hanami::Model::UnknownDatabaseAdapterError] if `url` is blank,
+      #   or it uses an unknown adapter.
+      #
       # @since 1.0.0
       # @api private
       def load!(repositories, &blk) # rubocop:disable Metrics/AbcSize

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -118,5 +118,14 @@ module Hanami
     # @since 1.2.0
     class UnknownAttributeError < Error
     end
+
+    # Unknown database adapter error
+    #
+    # @since 1.2.1
+    class UnknownDatabaseAdapterError < Error
+      def initialize(url)
+        super("Unknown database adapter for URL: #{url.inspect}. Please check your database configuration (hint: ENV['DATABASE_URL']).")
+      end
+    end
   end
 end

--- a/spec/unit/hanami/model/configuration_spec.rb
+++ b/spec/unit/hanami/model/configuration_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Hanami::Model::Configuration do
       expect(connection).to be_a_kind_of(Sequel::Database)
       expect(connection.url).to eq(url)
     end
+
+    context 'with blank url' do
+      let(:url) { nil }
+
+      it 'raises error' do
+        expect { subject.connection }.to raise_error(Hanami::Model::UnknownDatabaseAdapterError, "Unknown database adapter for URL: #{url.inspect}. Please check your database configuration (hint: ENV['DATABASE_URL']).")
+      end
+    end
   end
 
   describe '#gateway' do
@@ -49,6 +57,14 @@ RSpec.describe Hanami::Model::Configuration do
 
       expect(gateway).to be_a_kind_of(ROM::Gateway)
       expect(gateway.connection).to eq(subject.connection)
+    end
+
+    context 'with blank url' do
+      let(:url) { nil }
+
+      it 'raises error' do
+        expect { subject.connection }.to raise_error(Hanami::Model::UnknownDatabaseAdapterError, "Unknown database adapter for URL: #{url.inspect}. Please check your database configuration (hint: ENV['DATABASE_URL']).")
+      end
     end
   end
 


### PR DESCRIPTION
Raise a meaningful error message when trying to use an unknown database adapter via misconfigured connection URL.

#### Before

```shell
$ bundle exec hanami console
LoadError: cannot load such file -- sequel/adapters/
```

#### After

```shell
$ bundle exec hanami console
Unknown database adapter for URL: "". Please check your database configuration (hint: ENV['DATABASE_URL']).
```

---

This fixes the root problem of https://github.com/hanami/hanami/pull/868