### PR TITLE
[Hanami Issue 921] Support for Ruby version 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 # Please keep AllCops, Bundler, Style, Metrics groups and then order cops
 # alphabetically
 inherit_from:
-  - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop.yml
+  - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop-unstable.yml
 Lint/RescueWithoutErrorClass:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.3.6
   - 2.4.2
   - 2.5.0
-  - jruby-9.1.13.0
+  - jruby-9.2.0.0
   - ruby-head
   - jruby-head
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
+gem 'hanami-utils', '2.0.0.alpha1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'unstable'
 
 platforms :ruby do
   gem 'sqlite3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,27 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 gemspec
 
-unless ENV['TRAVIS']
-  gem 'byebug', require: false, platforms: :mri
-  gem 'yard',   require: false
+unless ENV["TRAVIS"]
+  gem "byebug", require: false, platforms: :mri
+  gem "yard",   require: false
 end
 
-gem 'hanami-utils', '2.0.0.alpha1', require: false, git: 'https://github.com/hanami/utils.git', branch: 'unstable'
+gem "hanami-utils", "2.0.0.alpha1", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
 
 platforms :ruby do
-  gem 'sqlite3', require: false
-  gem 'pg',      require: false
-  gem 'mysql2',  require: false
+  gem "sqlite3", require: false
+  gem "pg",      require: false
+  gem "mysql2",  require: false
 end
 
 platforms :jruby do
-  gem 'jdbc-sqlite3',  require: false
-  gem 'jdbc-postgres', require: false
-  gem 'jdbc-mysql',    require: false
+  gem "jdbc-sqlite3",  require: false
+  gem "jdbc-postgres", require: false
+  gem "jdbc-mysql",    require: false
 end
 
-gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
-gem 'simplecov', require: false
-gem 'codecov',   require: false
+gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git"
+gem "simplecov", require: false
+gem "codecov",   require: false

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Like all the other Hanami components, it can be used as a standalone framework o
 
 ## Rubies
 
-__Hanami::Model__ supports Ruby (MRI) 2.4+ and JRuby 9.1.5.0+
+__Hanami::Model__ supports Ruby (MRI) 2.4+ and JRuby 9.2.0.0
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Like all the other Hanami components, it can be used as a standalone framework o
 
 ## Rubies
 
-__Hanami::Model__ supports Ruby (MRI) 2.3+ and JRuby 9.1.5.0+
+__Hanami::Model__ supports Ruby (MRI) 2.4+ and JRuby 9.1.5.0+
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,18 @@
-require 'rake'
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+# frozen_string_literal: true
+
+require "rake"
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 namespace :spec do
   RSpec::Core::RakeTask.new(:all) do |task|
-    task.pattern = FileList['spec/**/*_spec.rb']
+    task.pattern = FileList["spec/**/*_spec.rb"]
   end
 
   task :coverage do
-    ENV['COVERAGE'] = 'true'
-    Rake::Task['spec:all'].invoke
+    ENV["COVERAGE"] = "true"
+    Rake::Task["spec:all"].invoke
   end
 end
 
-task default: 'spec:all'
+task default: "spec:all"

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency "hanami-utils",    "~> 2.0.alpha"
   spec.add_runtime_dependency "rom",             "~> 3.3", ">= 3.3.3"

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -1,31 +1,33 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'hanami/model/version'
+require "hanami/model/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'hanami-model'
+  spec.name          = "hanami-model"
   spec.version       = Hanami::Model::VERSION
-  spec.authors       = ['Luca Guidi']
-  spec.email         = ['me@lucaguidi.com']
-  spec.summary       = 'A persistence layer for Hanami'
-  spec.description   = 'A persistence framework with entities and repositories'
-  spec.homepage      = 'http://hanamirb.org'
-  spec.license       = 'MIT'
+  spec.authors       = ["Luca Guidi"]
+  spec.email         = ["me@lucaguidi.com"]
+  spec.summary       = "A persistence layer for Hanami"
+  spec.description   = "A persistence framework with entities and repositories"
+  spec.homepage      = "http://hanamirb.org"
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z -- lib/* CHANGELOG.md EXAMPLE.md LICENSE.md README.md hanami-model.gemspec`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency 'hanami-utils',    '2.0.0.alpha1'
-  spec.add_runtime_dependency 'rom',             '~> 3.3', '>= 3.3.3'
-  spec.add_runtime_dependency 'rom-sql',         '~> 1.3', '>= 1.3.5'
-  spec.add_runtime_dependency 'rom-repository',  '~> 1.4'
-  spec.add_runtime_dependency 'dry-types',       '~> 0.11.0'
-  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_runtime_dependency "hanami-utils",    "2.0.0.alpha1"
+  spec.add_runtime_dependency "rom",             "~> 3.3", ">= 3.3.3"
+  spec.add_runtime_dependency "rom-sql",         "~> 1.3", ">= 1.3.5"
+  spec.add_runtime_dependency "rom-repository",  "~> 1.4"
+  spec.add_runtime_dependency "dry-types",       "~> 0.11.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
 
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake',  '~> 12'
-  spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake",  "~> 12"
+  spec.add_development_dependency "rspec", "~> 3.7"
 end

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_runtime_dependency 'hanami-utils',    '~> 1.1'
+  spec.add_runtime_dependency 'hanami-utils',    '2.0.0.alpha1'
   spec.add_runtime_dependency 'rom',             '~> 3.3', '>= 3.3.3'
   spec.add_runtime_dependency 'rom-sql',         '~> 1.3', '>= 1.3.5'
   spec.add_runtime_dependency 'rom-repository',  '~> 1.4'

--- a/lib/hanami-model.rb
+++ b/lib/hanami-model.rb
@@ -1,1 +1,0 @@
-require 'hanami/model' # rubocop:disable Naming/FileName

--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -1,4 +1,6 @@
-require 'hanami/model/types'
+# frozen_string_literal: true
+
+require "hanami/model/types"
 
 module Hanami
   # An object that is defined by its identity.
@@ -50,7 +52,7 @@ module Hanami
   #
   # @see Hanami::Repository
   class Entity
-    require 'hanami/entity/schema'
+    require "hanami/entity/schema"
 
     # Syntactic shortcut to reference types in custom schema DSL
     #

--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -1,5 +1,7 @@
-require 'hanami/model/types'
-require 'hanami/utils/hash'
+# frozen_string_literal: true
+
+require "hanami/model/types"
+require "hanami/utils/hash"
 
 module Hanami
   class Entity

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -1,7 +1,9 @@
-require 'rom'
-require 'concurrent'
-require 'hanami/entity'
-require 'hanami/repository'
+# frozen_string_literal: true
+
+require "rom"
+require "concurrent"
+require "hanami/entity"
+require "hanami/repository"
 
 # Hanami
 #
@@ -11,12 +13,12 @@ module Hanami
   #
   # @since 0.1.0
   module Model
-    require 'hanami/model/version'
-    require 'hanami/model/error'
-    require 'hanami/model/configuration'
-    require 'hanami/model/configurator'
-    require 'hanami/model/mapping'
-    require 'hanami/model/plugins'
+    require "hanami/model/version"
+    require "hanami/model/error"
+    require "hanami/model/configuration"
+    require "hanami/model/configurator"
+    require "hanami/model/mapping"
+    require "hanami/model/plugins"
 
     # @api private
     # @since 0.7.0
@@ -70,7 +72,7 @@ module Hanami
     # @since 0.7.0
     # @api private
     def self.container
-      raise 'Not loaded' unless loaded?
+      raise "Not loaded" unless loaded?
       @container
     end
 

--- a/lib/hanami/model/association.rb
+++ b/lib/hanami/model/association.rb
@@ -1,8 +1,10 @@
-require 'rom-sql'
-require 'hanami/model/associations/belongs_to'
-require 'hanami/model/associations/has_many'
-require 'hanami/model/associations/has_one'
-require 'hanami/model/associations/many_to_many'
+# frozen_string_literal: true
+
+require "rom-sql"
+require "hanami/model/associations/belongs_to"
+require "hanami/model/associations/has_many"
+require "hanami/model/associations/has_one"
+require "hanami/model/associations/many_to_many"
 
 module Hanami
   module Model

--- a/lib/hanami/model/associations/belongs_to.rb
+++ b/lib/hanami/model/associations/belongs_to.rb
@@ -1,4 +1,6 @@
-require 'hanami/model/types'
+# frozen_string_literal: true
+
+require "hanami/model/types"
 
 module Hanami
   module Model

--- a/lib/hanami/model/associations/dsl.rb
+++ b/lib/hanami/model/associations/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     module Associations

--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -1,4 +1,6 @@
-require 'hanami/model/types'
+# frozen_string_literal: true
+
+require "hanami/model/types"
 
 module Hanami
   module Model

--- a/lib/hanami/model/associations/has_one.rb
+++ b/lib/hanami/model/associations/has_one.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "hanami/utils/hash"
 
 module Hanami

--- a/lib/hanami/model/associations/many_to_many.rb
+++ b/lib/hanami/model/associations/many_to_many.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "hanami/utils/hash"
 
 module Hanami

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -1,4 +1,6 @@
-require 'rom/configuration'
+# frozen_string_literal: true
+
+require "rom/configuration"
 
 module Hanami
   module Model

--- a/lib/hanami/model/configurator.rb
+++ b/lib/hanami/model/configurator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     # Configuration DSL
@@ -42,7 +44,7 @@ module Hanami
       # @since 1.0.0
       # @api private
       def migrations_logger(stream = $stdout)
-        require 'hanami/model/migrator/logger'
+        require "hanami/model/migrator/logger"
         @migrations_logger ||= Hanami::Model::Migrator::Logger.new(stream)
       end
 
@@ -76,10 +78,10 @@ module Hanami
       # @since 1.0.0
       # @api private
       def logger(stream, options = {})
-        require 'hanami/logger'
+        require "hanami/logger"
 
         opts = options.merge(stream: stream)
-        @_logger = Hanami::Logger.new('hanami.model', opts)
+        @_logger = Hanami::Logger.new("hanami.model", opts)
       end
 
       # @since 1.0.0

--- a/lib/hanami/model/entity_name.rb
+++ b/lib/hanami/model/entity_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     # Conventional name for entities.
@@ -18,7 +20,7 @@ module Hanami
       # @since 0.7.0
       # @api private
       def initialize(name)
-        @name = name.sub(SUFFIX, '')
+        @name = name.sub(SUFFIX, "")
       end
 
       # @since 0.7.0

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -1,4 +1,6 @@
-require 'concurrent'
+# frozen_string_literal: true
+
+require "concurrent"
 
 module Hanami
   module Model
@@ -41,7 +43,7 @@ module Hanami
     class InvalidCommandError < Error
       # @since 0.5.0
       # @api private
-      def initialize(message = 'Invalid command')
+      def initialize(message = "Invalid command")
         super
       end
     end
@@ -52,7 +54,7 @@ module Hanami
     class ConstraintViolationError < Error
       # @since 0.7.0
       # @api private
-      def initialize(message = 'Constraint has been violated')
+      def initialize(message = "Constraint has been violated")
         super
       end
     end
@@ -63,7 +65,7 @@ module Hanami
     class UniqueConstraintViolationError < ConstraintViolationError
       # @since 0.6.1
       # @api private
-      def initialize(message = 'Unique constraint has been violated')
+      def initialize(message = "Unique constraint has been violated")
         super
       end
     end
@@ -74,7 +76,7 @@ module Hanami
     class ForeignKeyConstraintViolationError < ConstraintViolationError
       # @since 0.6.1
       # @api private
-      def initialize(message = 'Foreign key constraint has been violated')
+      def initialize(message = "Foreign key constraint has been violated")
         super
       end
     end
@@ -85,7 +87,7 @@ module Hanami
     class NotNullConstraintViolationError < ConstraintViolationError
       # @since 0.6.1
       # @api private
-      def initialize(message = 'NOT NULL constraint has been violated')
+      def initialize(message = "NOT NULL constraint has been violated")
         super
       end
     end
@@ -96,7 +98,7 @@ module Hanami
     class CheckConstraintViolationError < ConstraintViolationError
       # @since 0.6.1
       # @api private
-      def initialize(message = 'Check constraint has been violated')
+      def initialize(message = "Check constraint has been violated")
         super
       end
     end

--- a/lib/hanami/model/mapped_relation.rb
+++ b/lib/hanami/model/mapped_relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     # Mapped proxy for ROM relations.

--- a/lib/hanami/model/mapping.rb
+++ b/lib/hanami/model/mapping.rb
@@ -1,4 +1,6 @@
-require 'transproc/all'
+# frozen_string_literal: true
+
+require "transproc/all"
 
 module Hanami
   module Model

--- a/lib/hanami/model/migration.rb
+++ b/lib/hanami/model/migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     # Database migration

--- a/lib/hanami/model/migrator.rb
+++ b/lib/hanami/model/migrator.rb
@@ -1,5 +1,7 @@
-require 'sequel'
-require 'sequel/extensions/migration'
+# frozen_string_literal: true
+
+require "sequel"
+require "sequel/extensions/migration"
 
 module Hanami
   module Model
@@ -13,8 +15,8 @@ module Hanami
     #
     # @since 0.4.0
     class Migrator
-      require 'hanami/model/migrator/connection'
-      require 'hanami/model/migrator/adapter'
+      require "hanami/model/migrator/connection"
+      require "hanami/model/migrator/adapter"
 
       # Create database defined by current configuration.
       #

--- a/lib/hanami/model/migrator/adapter.rb
+++ b/lib/hanami/model/migrator/adapter.rb
@@ -1,6 +1,8 @@
-require 'uri'
-require 'shellwords'
-require 'open3'
+# frozen_string_literal: true
+
+require "uri"
+require "shellwords"
+require "open3"
 
 module Hanami
   module Model
@@ -31,13 +33,13 @@ module Hanami
 
           case connection.database_type
           when :sqlite
-            require 'hanami/model/migrator/sqlite_adapter'
+            require "hanami/model/migrator/sqlite_adapter"
             SQLiteAdapter
           when :postgres
-            require 'hanami/model/migrator/postgres_adapter'
+            require "hanami/model/migrator/postgres_adapter"
             PostgresAdapter
           when :mysql
-            require 'hanami/model/migrator/mysql_adapter'
+            require "hanami/model/migrator/mysql_adapter"
             MySQLAdapter
           else
             self

--- a/lib/hanami/model/migrator/connection.rb
+++ b/lib/hanami/model/migrator/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     class Migrator
@@ -34,7 +36,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def host
-          @host ||= parsed_uri.host || parsed_opt('host')
+          @host ||= parsed_uri.host || parsed_opt("host")
         end
 
         # Returns DB connection port
@@ -44,7 +46,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def port
-          @port ||= parsed_uri.port || parsed_opt('port').to_i.nonzero?
+          @port ||= parsed_uri.port || parsed_opt("port").to_i.nonzero?
         end
 
         # Returns DB name from conenction
@@ -83,7 +85,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def user
-          @user ||= parsed_opt('user') || parsed_uri.user
+          @user ||= parsed_opt("user") || parsed_uri.user
         end
 
         # Returns user from DB connection
@@ -93,7 +95,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def password
-          @password ||= parsed_opt('password') || parsed_uri.password
+          @password ||= parsed_opt("password") || parsed_uri.password
         end
 
         # Returns DB connection URI directly from adapter
@@ -109,7 +111,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def global_uri
-          uri.sub(parsed_uri.select(:path).first, '')
+          uri.sub(parsed_uri.select(:path).first, "")
         end
 
         # Returns a boolean telling if a DB connection is from JDBC or not
@@ -117,7 +119,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def jdbc?
-          !uri.scan('jdbc:').empty?
+          !uri.scan("jdbc:").empty?
         end
 
         # Returns database connection URI instance without JDBC namespace
@@ -125,7 +127,7 @@ module Hanami
         # @since 0.5.0
         # @api private
         def parsed_uri
-          @uri ||= URI.parse(uri.sub('jdbc:', ''))
+          @uri ||= URI.parse(uri.sub("jdbc:", ""))
         end
 
         # @api private

--- a/lib/hanami/model/migrator/logger.rb
+++ b/lib/hanami/model/migrator/logger.rb
@@ -1,4 +1,6 @@
-require 'hanami/logger'
+# frozen_string_literal: true
+
+require "hanami/logger"
 
 module Hanami
   module Model

--- a/lib/hanami/model/migrator/mysql_adapter.rb
+++ b/lib/hanami/model/migrator/mysql_adapter.rb
@@ -23,7 +23,7 @@ module Hanami
         def create
           new_connection(global: true).run %(CREATE DATABASE `#{database}`;)
         rescue Sequel::DatabaseError => e
-          message = if e.message.match?(/database exists/)
+          message = if e.message.match(/database exists/) # rubocop:disable Performance/RedundantMatch
                       DB_CREATION_ERROR
                     else
                       e.message
@@ -37,7 +37,7 @@ module Hanami
         def drop
           new_connection(global: true).run %(DROP DATABASE `#{database}`;)
         rescue Sequel::DatabaseError => e
-          message = if e.message.match?(/doesn\'t exist/)
+          message = if e.message.match(/doesn\'t exist/) # rubocop:disable Performance/RedundantMatch
                       "Cannot find database: #{database}"
                     else
                       e.message

--- a/lib/hanami/model/migrator/mysql_adapter.rb
+++ b/lib/hanami/model/migrator/mysql_adapter.rb
@@ -23,7 +23,7 @@ module Hanami
         def create
           new_connection(global: true).run %(CREATE DATABASE `#{database}`;)
         rescue Sequel::DatabaseError => e
-          message = if e.message.match(/database exists/) # rubocop:disable Performance/RedundantMatch
+          message = if e.message.match?(/database exists/)
                       DB_CREATION_ERROR
                     else
                       e.message
@@ -37,7 +37,7 @@ module Hanami
         def drop
           new_connection(global: true).run %(DROP DATABASE `#{database}`;)
         rescue Sequel::DatabaseError => e
-          message = if e.message.match(/doesn\'t exist/) # rubocop:disable Performance/RedundantMatch
+          message = if e.message.match?(/doesn\'t exist/)
                       "Cannot find database: #{database}"
                     else
                       e.message

--- a/lib/hanami/model/migrator/mysql_adapter.rb
+++ b/lib/hanami/model/migrator/mysql_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     class Migrator
@@ -8,20 +10,20 @@ module Hanami
       class MySQLAdapter < Adapter
         # @since 0.7.0
         # @api private
-        PASSWORD = 'MYSQL_PWD'.freeze
+        PASSWORD = "MYSQL_PWD"
 
         # @since 1.0.0
         # @api private
-        DB_CREATION_ERROR = 'Database creation failed. If the database exists, ' \
-                            'then its console may be open. See this issue for more details: ' \
-                            'https://github.com/hanami/model/issues/250'.freeze
+        DB_CREATION_ERROR = "Database creation failed. If the database exists, " \
+                            "then its console may be open. See this issue for more details: " \
+                            "https://github.com/hanami/model/issues/250"
 
         # @since 0.4.0
         # @api private
         def create
           new_connection(global: true).run %(CREATE DATABASE `#{database}`;)
         rescue Sequel::DatabaseError => e
-          message = if e.message.match(/database exists/) # rubocop:disable Performance/RedundantMatch
+          message = if e.message.match?(/database exists/)
                       DB_CREATION_ERROR
                     else
                       e.message
@@ -35,7 +37,7 @@ module Hanami
         def drop
           new_connection(global: true).run %(DROP DATABASE `#{database}`;)
         rescue Sequel::DatabaseError => e
-          message = if e.message.match(/doesn\'t exist/) # rubocop:disable Performance/RedundantMatch
+          message = if e.message.match?(/doesn\'t exist/)
                       "Cannot find database: #{database}"
                     else
                       e.message

--- a/lib/hanami/model/migrator/postgres_adapter.rb
+++ b/lib/hanami/model/migrator/postgres_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     class Migrator
@@ -8,32 +10,32 @@ module Hanami
       class PostgresAdapter < Adapter
         # @since 0.4.0
         # @api private
-        HOST     = 'PGHOST'.freeze
+        HOST     = "PGHOST"
 
         # @since 0.4.0
         # @api private
-        PORT     = 'PGPORT'.freeze
+        PORT     = "PGPORT"
 
         # @since 0.4.0
         # @api private
-        USER     = 'PGUSER'.freeze
+        USER     = "PGUSER"
 
         # @since 0.4.0
         # @api private
-        PASSWORD = 'PGPASSWORD'.freeze
+        PASSWORD = "PGPASSWORD"
 
         # @since 1.0.0
         # @api private
-        DB_CREATION_ERROR = 'createdb: database creation failed. If the database exists, ' \
-                            'then its console may be open. See this issue for more details: ' \
-                            'https://github.com/hanami/model/issues/250'.freeze
+        DB_CREATION_ERROR = "createdb: database creation failed. If the database exists, " \
+                            "then its console may be open. See this issue for more details: " \
+                            "https://github.com/hanami/model/issues/250"
 
         # @since 0.4.0
         # @api private
         def create
           set_environment_variables
 
-          call_db_command('createdb')
+          call_db_command("createdb")
         end
 
         # @since 0.4.0
@@ -41,7 +43,7 @@ module Hanami
         def drop
           set_environment_variables
 
-          call_db_command('dropdb')
+          call_db_command("dropdb")
         end
 
         # @since 0.4.0
@@ -85,14 +87,14 @@ module Hanami
         # @since 0.4.0
         # @api private
         def dump_migrations_data
-          error = ->(err) { raise MigrationError.new(err) unless err =~ /no matching tables/i }
+          error = ->(err) { raise MigrationError.new(err) unless err.match?(/no matching tables/i) }
           execute "pg_dump -t #{migrations_table} #{database} >> #{escape(schema)}", error: error
         end
 
         # @since 0.5.1
         # @api private
         def call_db_command(command)
-          require 'open3'
+          require "open3"
 
           begin
             Open3.popen3(command, database) do |_stdin, _stdout, stderr, wait_thr|

--- a/lib/hanami/model/migrator/postgres_adapter.rb
+++ b/lib/hanami/model/migrator/postgres_adapter.rb
@@ -87,7 +87,7 @@ module Hanami
         # @since 0.4.0
         # @api private
         def dump_migrations_data
-          error = ->(err) { raise MigrationError.new(err) unless err.match?(/no matching tables/i) }
+          error = ->(err) { raise MigrationError.new(err) unless err =~ /no matching tables/i }
           execute "pg_dump -t #{migrations_table} #{database} >> #{escape(schema)}", error: error
         end
 

--- a/lib/hanami/model/migrator/sqlite_adapter.rb
+++ b/lib/hanami/model/migrator/sqlite_adapter.rb
@@ -1,6 +1,8 @@
-require 'pathname'
-require 'hanami/utils'
-require 'English'
+# frozen_string_literal: true
+
+require "pathname"
+require "hanami/utils"
+require "English"
 
 module Hanami
   module Model
@@ -71,7 +73,7 @@ module Hanami
         # @api private
         def path
           root.join(
-            @connection.uri.sub(/\A(jdbc:sqlite:\/\/|sqlite:\/\/)/, '')
+            @connection.uri.sub(/\A(jdbc:sqlite:\/\/|sqlite:\/\/)/, "")
           )
         end
 

--- a/lib/hanami/model/plugins.rb
+++ b/lib/hanami/model/plugins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     # Plugins to extend read/write operations from/to the database
@@ -17,9 +19,9 @@ module Hanami
         end
       end
 
-      require 'hanami/model/plugins/mapping'
-      require 'hanami/model/plugins/schema'
-      require 'hanami/model/plugins/timestamps'
+      require "hanami/model/plugins/mapping"
+      require "hanami/model/plugins/schema"
+      require "hanami/model/plugins/timestamps"
     end
   end
 end

--- a/lib/hanami/model/plugins/mapping.rb
+++ b/lib/hanami/model/plugins/mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     module Plugins

--- a/lib/hanami/model/plugins/schema.rb
+++ b/lib/hanami/model/plugins/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     module Plugins

--- a/lib/hanami/model/plugins/timestamps.rb
+++ b/lib/hanami/model/plugins/timestamps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     module Plugins

--- a/lib/hanami/model/relation_name.rb
+++ b/lib/hanami/model/relation_name.rb
@@ -1,5 +1,7 @@
-require_relative 'entity_name'
-require 'hanami/utils/string'
+# frozen_string_literal: true
+
+require_relative "entity_name"
+require "hanami/utils/string"
 
 module Hanami
   module Model

--- a/lib/hanami/model/sql.rb
+++ b/lib/hanami/model/sql.rb
@@ -1,12 +1,14 @@
-require 'rom-sql'
-require 'hanami/utils'
+# frozen_string_literal: true
+
+require "rom-sql"
+require "hanami/utils"
 
 module Hanami
   # Hanami::Model migrations
   module Model
-    require 'hanami/model/error'
-    require 'hanami/model/association'
-    require 'hanami/model/migration'
+    require "hanami/model/error"
+    require "hanami/model/association"
+    require "hanami/model/migration"
 
     # Define a migration
     #
@@ -53,8 +55,8 @@ module Hanami
     #
     # @since 0.7.0
     module Sql
-      require 'hanami/model/sql/types'
-      require 'hanami/model/sql/entity/schema'
+      require "hanami/model/sql/types"
+      require "hanami/model/sql/entity/schema"
 
       # Returns a SQL fragment that references a database function by the given name
       # This is useful for database migrations

--- a/lib/hanami/model/sql/console.rb
+++ b/lib/hanami/model/sql/console.rb
@@ -1,4 +1,6 @@
-require 'uri'
+# frozen_string_literal: true
+
+require "uri"
 
 module Hanami
   module Model
@@ -26,14 +28,14 @@ module Hanami
         # @api private
         def console # rubocop:disable Metrics/MethodLength
           case @uri.scheme
-          when 'sqlite'
-            require 'hanami/model/sql/consoles/sqlite'
+          when "sqlite"
+            require "hanami/model/sql/consoles/sqlite"
             Sql::Consoles::Sqlite.new(@uri)
-          when 'postgres', 'postgresql'
-            require 'hanami/model/sql/consoles/postgresql'
+          when "postgres", "postgresql"
+            require "hanami/model/sql/consoles/postgresql"
             Sql::Consoles::Postgresql.new(@uri)
-          when 'mysql', 'mysql2'
-            require 'hanami/model/sql/consoles/mysql'
+          when "mysql", "mysql2"
+            require "hanami/model/sql/consoles/mysql"
             Sql::Consoles::Mysql.new(@uri)
           end
         end

--- a/lib/hanami/model/sql/consoles/abstract.rb
+++ b/lib/hanami/model/sql/consoles/abstract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     module Sql
@@ -18,7 +20,7 @@ module Hanami
           # @since 0.7.0
           # @api private
           def database_name
-            @uri.path.sub(/^\//, '')
+            @uri.path.sub(/^\//, "")
           end
 
           # @since 0.7.0

--- a/lib/hanami/model/sql/consoles/mysql.rb
+++ b/lib/hanami/model/sql/consoles/mysql.rb
@@ -1,4 +1,6 @@
-require_relative 'abstract'
+# frozen_string_literal: true
+
+require_relative "abstract"
 
 module Hanami
   module Model
@@ -11,7 +13,7 @@ module Hanami
         class Mysql < Abstract
           # @since 0.7.0
           # @api private
-          COMMAND = 'mysql'.freeze
+          COMMAND = "mysql"
 
           # @since 0.7.0
           # @api private

--- a/lib/hanami/model/sql/consoles/postgresql.rb
+++ b/lib/hanami/model/sql/consoles/postgresql.rb
@@ -1,5 +1,7 @@
-require_relative 'abstract'
-require 'cgi'
+# frozen_string_literal: true
+
+require_relative "abstract"
+require "cgi"
 
 module Hanami
   module Model
@@ -12,11 +14,11 @@ module Hanami
         class Postgresql < Abstract
           # @since 0.7.0
           # @api private
-          COMMAND = 'psql'.freeze
+          COMMAND = "psql"
 
           # @since 0.7.0
           # @api private
-          PASSWORD = 'PGPASSWORD'.freeze
+          PASSWORD = "PGPASSWORD"
 
           # @since 0.7.0
           # @api private
@@ -48,22 +50,22 @@ module Hanami
           # @since 0.7.0
           # @api private
           def port
-            port = query['port'] || @uri.port
+            port = query["port"] || @uri.port
             " -p #{port}" if port
           end
 
           # @since 0.7.0
           # @api private
           def username
-            username = query['user'] || @uri.user
+            username = query["user"] || @uri.user
             " -U #{username}" if username
           end
 
           # @since 0.7.0
           # @api private
           def configure_password
-            password = query['password'] || @uri.password
-            ENV[PASSWORD] = CGI.unescape(query['password'] || @uri.password) if password
+            password = query["password"] || @uri.password
+            ENV[PASSWORD] = CGI.unescape(query["password"] || @uri.password) if password
           end
 
           # @since 1.1.0

--- a/lib/hanami/model/sql/consoles/sqlite.rb
+++ b/lib/hanami/model/sql/consoles/sqlite.rb
@@ -1,5 +1,7 @@
-require_relative 'abstract'
-require 'shellwords'
+# frozen_string_literal: true
+
+require_relative "abstract"
+require "shellwords"
 
 module Hanami
   module Model
@@ -12,12 +14,12 @@ module Hanami
         class Sqlite < Abstract
           # @since 0.7.0
           # @api private
-          COMMAND = 'sqlite3'.freeze
+          COMMAND = "sqlite3"
 
           # @since 0.7.0
           # @api private
           def connection_string
-            concat(command, ' ', host, database)
+            concat(command, " ", host, database)
           end
 
           private

--- a/lib/hanami/model/sql/entity/schema.rb
+++ b/lib/hanami/model/sql/entity/schema.rb
@@ -1,6 +1,8 @@
-require 'hanami/entity/schema'
-require 'hanami/model/types'
-require 'hanami/model/association'
+# frozen_string_literal: true
+
+require "hanami/entity/schema"
+require "hanami/model/types"
+require "hanami/model/association"
 
 module Hanami
   module Model

--- a/lib/hanami/model/sql/types.rb
+++ b/lib/hanami/model/sql/types.rb
@@ -1,5 +1,7 @@
-require 'hanami/model/types'
-require 'rom/types'
+# frozen_string_literal: true
+
+require "hanami/model/types"
+require "rom/types"
 
 module Hanami
   module Model
@@ -14,7 +16,7 @@ module Hanami
         #
         # @since 0.7.0
         module Schema
-          require 'hanami/model/sql/types/schema/coercions'
+          require "hanami/model/sql/types/schema/coercions"
 
           String   = Types::Optional::Coercible::String
 
@@ -95,8 +97,8 @@ module Hanami
           # @since 1.0.2
           # @api private
           def self.pg_json?(pristine)
-            pristine == pg_json_pristines['JSONB'.freeze] ||
-              pristine == pg_json_pristines['JSON'.freeze]
+            pristine == pg_json_pristines["JSONB"] ||
+              pristine == pg_json_pristines["JSON"]
           end
 
           private_class_method :pg_json?

--- a/lib/hanami/model/sql/types/schema/coercions.rb
+++ b/lib/hanami/model/sql/types/schema/coercions.rb
@@ -1,5 +1,7 @@
-require 'hanami/utils/string'
-require 'hanami/utils/hash'
+# frozen_string_literal: true
+
+require "hanami/utils/string"
+require "hanami/utils/hash"
 
 module Hanami
   module Model

--- a/lib/hanami/model/types.rb
+++ b/lib/hanami/model/types.rb
@@ -1,4 +1,6 @@
-require 'rom/types'
+# frozen_string_literal: true
+
+require "rom/types"
 
 module Hanami
   module Model

--- a/lib/hanami/model/version.rb
+++ b/lib/hanami/model/version.rb
@@ -5,6 +5,6 @@ module Hanami
     # Defines the version
     #
     # @since 0.1.0
-    VERSION = "1.1.0"
+    VERSION = "2.0.0.alpha1"
   end
 end

--- a/lib/hanami/model/version.rb
+++ b/lib/hanami/model/version.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Hanami
   module Model
     # Defines the version
     #
     # @since 0.1.0
-    VERSION = '1.1.0'.freeze
+    VERSION = "1.1.0"
   end
 end

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -1,12 +1,14 @@
-require 'rom-repository'
-require 'hanami/model/entity_name'
-require 'hanami/model/relation_name'
-require 'hanami/model/mapped_relation'
-require 'hanami/model/associations/dsl'
-require 'hanami/model/association'
-require 'hanami/utils/class'
-require 'hanami/utils/class_attribute'
-require 'hanami/utils/io'
+# frozen_string_literal: true
+
+require "rom-repository"
+require "hanami/model/entity_name"
+require "hanami/model/relation_name"
+require "hanami/model/mapped_relation"
+require "hanami/model/associations/dsl"
+require "hanami/model/association"
+require "hanami/utils/class"
+require "hanami/utils/class_attribute"
+require "hanami/utils/io"
 
 module Hanami
   # Mediates between the entities and the persistence layer, by offering an API

--- a/spec/integration/hanami/model/associations/belongs_to_spec.rb
+++ b/spec/integration/hanami/model/associations/belongs_to_spec.rb
@@ -1,25 +1,27 @@
-RSpec.describe 'Associations (belongs_to)' do
+# frozen_string_literal: true
+
+RSpec.describe "Associations (belongs_to)" do
   it "returns nil if association wasn't preloaded" do
     repository = BookRepository.new
-    book       = repository.create(name: 'L')
+    book       = repository.create(name: "L")
     found      = repository.find(book.id)
 
     expect(found.author).to be(nil)
   end
 
-  it 'preloads the associated record' do
+  it "preloads the associated record" do
     repository = BookRepository.new
-    author = AuthorRepository.new.create(name: 'Michel Foucault')
-    book   = repository.create(author_id: author.id, title: 'Surveiller et punir')
+    author = AuthorRepository.new.create(name: "Michel Foucault")
+    book   = repository.create(author_id: author.id, title: "Surveiller et punir")
     found = repository.find_with_author(book.id)
 
     expect(found).to eq(book)
     expect(found.author).to eq(author)
   end
 
-  it 'returns an author' do
+  it "returns an author" do
     repository = BookRepository.new
-    author = AuthorRepository.new.create(name: 'Maurice Leblanc')
+    author = AuthorRepository.new.create(name: "Maurice Leblanc")
     book   = repository.create(author_id: author.id, title: "L'Aguille Creuse")
     found = repository.author_for(book)
 
@@ -28,7 +30,7 @@ RSpec.describe 'Associations (belongs_to)' do
 
   it "returns nil if there's no associated record" do
     repository = BookRepository.new
-    book = repository.create(title: 'The no author book')
+    book = repository.create(title: "The no author book")
 
     expect { repository.find_with_author(book.id) }.to_not raise_error
   end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -1,17 +1,19 @@
-RSpec.describe 'Associations (has_many)' do
+# frozen_string_literal: true
+
+RSpec.describe "Associations (has_many)" do
   let(:authors) { AuthorRepository.new }
   let(:books) { BookRepository.new }
 
   it "returns nil if association wasn't preloaded" do
-    author = authors.create(name: 'L')
+    author = authors.create(name: "L")
     found = authors.find(author.id)
 
     expect(found.books).to be_nil
   end
 
-  it 'preloads associated records' do
-    author = authors.create(name: 'Umberto Eco')
-    book = books.create(author_id: author.id, title: 'Foucault Pendulum')
+  it "preloads associated records" do
+    author = authors.create(name: "Umberto Eco")
+    book = books.create(author_id: author.id, title: "Foucault Pendulum")
 
     found = authors.find_with_books(author.id)
 
@@ -19,24 +21,24 @@ RSpec.describe 'Associations (has_many)' do
     expect(found.books).to eq([book])
   end
 
-  it 'creates an object with a collection of associated objects' do
-    author = authors.create_with_books(name: 'Henry Thoreau', books: [{ title: 'Walden' }])
+  it "creates an object with a collection of associated objects" do
+    author = authors.create_with_books(name: "Henry Thoreau", books: [{ title: "Walden" }])
 
     expect(author).to be_an_instance_of(Author)
-    expect(author.name).to eq('Henry Thoreau')
+    expect(author.name).to eq("Henry Thoreau")
     expect(author.books).to be_an_instance_of(Array)
     expect(author.books.first).to be_an_instance_of(Book)
-    expect(author.books.first.title).to eq('Walden')
+    expect(author.books.first.title).to eq("Walden")
   end
 
-  it 'creates associated records when it receives a collection of serializable data' do
-    author = authors.create_with_books(name: 'Sandi Metz', books: [BaseParams.new(title: 'Practical Object-Oriented Design in Ruby')])
+  it "creates associated records when it receives a collection of serializable data" do
+    author = authors.create_with_books(name: "Sandi Metz", books: [BaseParams.new(title: "Practical Object-Oriented Design in Ruby")])
 
     expect(author).to be_an_instance_of(Author)
-    expect(author.name).to eq('Sandi Metz')
+    expect(author.name).to eq("Sandi Metz")
     expect(author.books).to be_an_instance_of(Array)
     expect(author.books.first).to be_an_instance_of(Book)
-    expect(author.books.first.title).to eq('Practical Object-Oriented Design in Ruby')
+    expect(author.books.first.title).to eq("Practical Object-Oriented Design in Ruby")
   end
 
   ##############################################################################
@@ -46,38 +48,38 @@ RSpec.describe 'Associations (has_many)' do
   ##
   # ADD
   #
-  it 'adds an object to the collection' do
-    author = authors.create(name: 'Alexandre Dumas')
-    book = authors.add_book(author, title: 'The Count of Monte Cristo')
+  it "adds an object to the collection" do
+    author = authors.create(name: "Alexandre Dumas")
+    book = authors.add_book(author, title: "The Count of Monte Cristo")
 
     expect(book.id).to_not be_nil
-    expect(book.title).to eq('The Count of Monte Cristo')
+    expect(book.title).to eq("The Count of Monte Cristo")
     expect(book.author_id).to eq(author.id)
   end
 
-  it 'adds an object to the collection with serializable data' do
-    author = authors.create(name: 'David Foster Wallace')
-    book = authors.add_book(author, BaseParams.new(title: 'Infinite Jest'))
+  it "adds an object to the collection with serializable data" do
+    author = authors.create(name: "David Foster Wallace")
+    book = authors.add_book(author, BaseParams.new(title: "Infinite Jest"))
 
     expect(book.id).to_not be_nil
-    expect(book.title).to eq('Infinite Jest')
+    expect(book.title).to eq("Infinite Jest")
     expect(book.author_id).to eq(author.id)
   end
 
   ##
   # REMOVE
   #
-  it 'removes an object from the collection' do
+  it "removes an object from the collection" do
     authors = AuthorRepository.new
     books = BookRepository.new
 
     # Book under test
-    author = authors.create(name: 'Douglas Adams')
+    author = authors.create(name: "Douglas Adams")
     book = books.create(author_id: author.id, title: "The Hitchhiker's Guide to the Galaxy")
 
     # Different book
-    a = authors.create(name: 'William Finnegan')
-    b = books.create(author_id: a.id, title: 'Barbarian Days: A Surfing Life')
+    a = authors.create(name: "William Finnegan")
+    b = books.create(author_id: a.id, title: "Barbarian Days: A Surfing Life")
 
     authors.remove_book(author, book.id)
 
@@ -97,9 +99,9 @@ RSpec.describe 'Associations (has_many)' do
   ##
   # TO_A
   #
-  it 'returns an array of books' do
-    author = authors.create(name: 'Nikolai Gogol')
-    expected = books.create(author_id: author.id, title: 'Dead Souls')
+  it "returns an array of books" do
+    author = authors.create(name: "Nikolai Gogol")
+    expected = books.create(author_id: author.id, title: "Dead Souls")
     expect(expected).to be_an_instance_of(Book)
 
     actual = authors.books_for(author).to_a
@@ -109,9 +111,9 @@ RSpec.describe 'Associations (has_many)' do
   ##
   # EACH
   #
-  it 'iterates through the books' do
-    author = authors.create(name: 'José Saramago')
-    expected = books.create(author_id: author.id, title: 'The Cave')
+  it "iterates through the books" do
+    author = authors.create(name: "José Saramago")
+    expected = books.create(author_id: author.id, title: "The Cave")
 
     actual = []
     authors.books_for(author).each do |book|
@@ -125,9 +127,9 @@ RSpec.describe 'Associations (has_many)' do
   ##
   # MAP
   #
-  it 'iterates through the books and returns an array' do
-    author = authors.create(name: 'José Saramago')
-    expected = books.create(author_id: author.id, title: 'The Cave')
+  it "iterates through the books and returns an array" do
+    author = authors.create(name: "José Saramago")
+    expected = books.create(author_id: author.id, title: "The Cave")
     expect(expected).to be_an_instance_of(Book)
 
     actual = authors.books_for(author).map { |book| book }
@@ -137,17 +139,17 @@ RSpec.describe 'Associations (has_many)' do
   ##
   # COUNT
   #
-  it 'returns the count of the associated books' do
-    author = authors.create(name: 'Fyodor Dostoevsky')
-    books.create(author_id: author.id, title: 'Crime and Punishment')
-    books.create(author_id: author.id, title: 'The Brothers Karamazov')
+  it "returns the count of the associated books" do
+    author = authors.create(name: "Fyodor Dostoevsky")
+    books.create(author_id: author.id, title: "Crime and Punishment")
+    books.create(author_id: author.id, title: "The Brothers Karamazov")
 
     expect(authors.books_count(author)).to eq(2)
   end
 
-  it 'returns the count of on sale associated books' do
-    author = authors.create(name: 'Steven Pinker')
-    books.create(author_id: author.id, title: 'The Sense of Style', on_sale: true)
+  it "returns the count of on sale associated books" do
+    author = authors.create(name: "Steven Pinker")
+    books.create(author_id: author.id, title: "The Sense of Style", on_sale: true)
 
     expect(authors.on_sales_books_count(author)).to eq(1)
   end
@@ -155,19 +157,19 @@ RSpec.describe 'Associations (has_many)' do
   ##
   # DELETE
   #
-  it 'deletes all the books' do
-    author = authors.create(name: 'Grazia Deledda')
-    book = books.create(author_id: author.id, title: 'Reeds In The Wind')
+  it "deletes all the books" do
+    author = authors.create(name: "Grazia Deledda")
+    book = books.create(author_id: author.id, title: "Reeds In The Wind")
 
     authors.delete_books(author)
 
     expect(books.find(book.id)).to be_nil
   end
 
-  it 'deletes scoped books' do
-    author = authors.create(name: 'Harper Lee')
-    book = books.create(author_id: author.id, title: 'To Kill A Mockingbird')
-    on_sale = books.create(author_id: author.id, title: 'Go Set A Watchman', on_sale: true)
+  it "deletes scoped books" do
+    author = authors.create(name: "Harper Lee")
+    book = books.create(author_id: author.id, title: "To Kill A Mockingbird")
+    on_sale = books.create(author_id: author.id, title: "Go Set A Watchman", on_sale: true)
 
     authors.delete_on_sales_books(author)
 
@@ -175,21 +177,21 @@ RSpec.describe 'Associations (has_many)' do
     expect(books.find(on_sale.id)).to be_nil
   end
 
-  context 'raises a Hanami::Model::Error wrapped exception on' do
-    it '#create' do
+  context "raises a Hanami::Model::Error wrapped exception on" do
+    it "#create" do
       expect do
-        authors.create_with_books(name: 'Noam Chomsky')
+        authors.create_with_books(name: "Noam Chomsky")
       end.to raise_error Hanami::Model::Error
     end
 
-    it '#add' do
-      author = authors.create(name: 'Machado de Assis')
+    it "#add" do
+      author = authors.create(name: "Machado de Assis")
       expect do
-        authors.add_book(author, title: 'O Alienista', on_sale: nil)
+        authors.add_book(author, title: "O Alienista", on_sale: nil)
       end.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
 
     # skipped spec
-    it '#remove'
+    it "#remove"
   end
 end

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -1,68 +1,70 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
-RSpec.describe 'Associations (has_one)' do
+require "spec_helper"
+
+RSpec.describe "Associations (has_one)" do
   extend PlatformHelpers
 
   let(:users) { UserRepository.new }
   let(:avatars) { AvatarRepository.new }
 
   it "returns nil if the association wasn't preloaded" do
-    user       = users.create(name: 'John Doe')
+    user       = users.create(name: "John Doe")
     found      = users.find(user.id)
 
     expect(found.avatar).to be_nil
   end
 
-  it 'preloads the associated record' do
-    user       = users.create(name: 'Baruch Spinoza')
-    avatar     = avatars.create(user_id: user.id, url: 'http://www.notarealurl.com/avatar.png')
+  it "preloads the associated record" do
+    user       = users.create(name: "Baruch Spinoza")
+    avatar     = avatars.create(user_id: user.id, url: "http://www.notarealurl.com/avatar.png")
     found      = users.find_with_avatar(user.id)
     expect(found).to eq(user)
     expect(found.avatar).to eq(avatar)
   end
 
-  it 'returns an Avatar' do
-    user       = users.create(name: 'Simone de Beauvoir')
-    avatar     = avatars.create(user_id: user.id, url: 'http://www.notarealurl.com/simone.png')
+  it "returns an Avatar" do
+    user       = users.create(name: "Simone de Beauvoir")
+    avatar     = avatars.create(user_id: user.id, url: "http://www.notarealurl.com/simone.png")
     found      = users.avatar_for(user)
 
     expect(found).to eq(avatar)
   end
 
-  it 'returns nil if the association was preloaded but no associated object is set' do
-    user       = users.create(name: 'Henry Jenkins')
+  it "returns nil if the association was preloaded but no associated object is set" do
+    user       = users.create(name: "Henry Jenkins")
     found      = users.find_with_avatar(user.id)
 
     expect(found).to eq(user)
     expect(found.avatar).to be_nil
   end
 
-  context '#add' do
-    it 'adds an an Avatar to an existing User' do
-      user = users.create(name: 'Jean Paul-Sartre')
-      avatar = users.add_avatar(user, url: 'http://www.notarealurl.com/sartre.png')
+  context "#add" do
+    it "adds an an Avatar to an existing User" do
+      user = users.create(name: "Jean Paul-Sartre")
+      avatar = users.add_avatar(user, url: "http://www.notarealurl.com/sartre.png")
       found = users.find_with_avatar(user.id)
 
       expect(found).to eq(user)
       expect(found.avatar.id).to eq(avatar.id)
-      expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
+      expect(found.avatar.url).to eq("http://www.notarealurl.com/sartre.png")
     end
 
-    it 'adds an an Avatar to an existing User when serializable data is received' do
-      user = users.create(name: 'Jean Paul-Sartre')
-      avatar = users.add_avatar(user, BaseParams.new(url: 'http://www.notarealurl.com/sartre.png'))
+    it "adds an an Avatar to an existing User when serializable data is received" do
+      user = users.create(name: "Jean Paul-Sartre")
+      avatar = users.add_avatar(user, BaseParams.new(url: "http://www.notarealurl.com/sartre.png"))
       found = users.find_with_avatar(user.id)
 
       expect(found).to eq(user)
       expect(found.avatar.id).to eq(avatar.id)
-      expect(found.avatar.url).to eq('http://www.notarealurl.com/sartre.png')
+      expect(found.avatar.url).to eq("http://www.notarealurl.com/sartre.png")
     end
   end
 
-  context '#update' do
-    it 'updates the avatar' do
-      user = users.create_with_avatar(name: 'Bakunin', avatar: { url: 'bakunin.jpg' })
-      users.update_avatar(user, url: url = 'http://history.com/bakunin.png')
+  context "#update" do
+    it "updates the avatar" do
+      user = users.create_with_avatar(name: "Bakunin", avatar: { url: "bakunin.jpg" })
+      users.update_avatar(user, url: url = "http://history.com/bakunin.png")
 
       found = users.find_with_avatar(user.id)
 
@@ -71,9 +73,9 @@ RSpec.describe 'Associations (has_one)' do
       expect(found.avatar.url).to eq(url)
     end
 
-    it 'updates the avatar when serializable data is received' do
-      user = users.create_with_avatar(name: 'Bakunin', avatar: { url: 'bakunin.jpg' })
-      users.update_avatar(user, BaseParams.new(url: url = 'http://history.com/bakunin.png'))
+    it "updates the avatar when serializable data is received" do
+      user = users.create_with_avatar(name: "Bakunin", avatar: { url: "bakunin.jpg" })
+      users.update_avatar(user, BaseParams.new(url: url = "http://history.com/bakunin.png"))
 
       found = users.find_with_avatar(user.id)
 
@@ -83,30 +85,30 @@ RSpec.describe 'Associations (has_one)' do
     end
   end
 
-  context '#create' do
-    it 'creates a User and an Avatar' do
-      user = users.create_with_avatar(name: 'Lao Tse', avatar: { url: 'http://lao-tse.io/me.jpg' })
+  context "#create" do
+    it "creates a User and an Avatar" do
+      user = users.create_with_avatar(name: "Lao Tse", avatar: { url: "http://lao-tse.io/me.jpg" })
       found = users.find_with_avatar(user.id)
 
       expect(found.name).to eq(user.name)
       expect(found.avatar).to eq(user.avatar)
-      expect(found.avatar.url).to eq('http://lao-tse.io/me.jpg')
+      expect(found.avatar.url).to eq("http://lao-tse.io/me.jpg")
     end
 
-    it 'creates a User and an Avatar when serializable data is received' do
-      user = users.create_with_avatar(name: 'Lao Tse', avatar: BaseParams.new(url: 'http://lao-tse.io/me.jpg'))
+    it "creates a User and an Avatar when serializable data is received" do
+      user = users.create_with_avatar(name: "Lao Tse", avatar: BaseParams.new(url: "http://lao-tse.io/me.jpg"))
       found = users.find_with_avatar(user.id)
 
       expect(found.name).to eq(user.name)
       expect(found.avatar).to eq(user.avatar)
-      expect(found.avatar.url).to eq('http://lao-tse.io/me.jpg')
+      expect(found.avatar.url).to eq("http://lao-tse.io/me.jpg")
     end
   end
 
-  context '#delete' do
-    it 'removes the Avatar' do
-      user = users.create_with_avatar(name: 'Bob Ross', avatar: { url: 'http://bobross/happy_little_avatar.jpg' })
-      other = users.create_with_avatar(name: 'Candido Portinari', avatar: { url: 'some_mugshot.jpg' })
+  context "#delete" do
+    it "removes the Avatar" do
+      user = users.create_with_avatar(name: "Bob Ross", avatar: { url: "http://bobross/happy_little_avatar.jpg" })
+      other = users.create_with_avatar(name: "Candido Portinari", avatar: { url: "some_mugshot.jpg" })
       users.remove_avatar(user)
       found = users.find_with_avatar(user.id)
       other_found = users.find_with_avatar(other.id)
@@ -116,10 +118,10 @@ RSpec.describe 'Associations (has_one)' do
     end
   end
 
-  context '#replace' do
-    it 'replaces the associated object' do
-      user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
-      users.replace_avatar(user, url: 'http://totally-correct.com/avatar.jpg')
+  context "#replace" do
+    it "replaces the associated object" do
+      user = users.create_with_avatar(name: "Frank Herbert", avatar: { url: "http://not-real.com/avatar.jpg" })
+      users.replace_avatar(user, url: "http://totally-correct.com/avatar.jpg")
       found = users.find_with_avatar(user.id)
 
       expect(found.avatar).to_not eq(user.avatar)
@@ -127,9 +129,9 @@ RSpec.describe 'Associations (has_one)' do
       expect(avatars.by_user(user.id).size).to eq(1)
     end
 
-    it 'replaces the associated object when serializable data is received' do
-      user = users.create_with_avatar(name: 'Frank Herbert', avatar: { url: 'http://not-real.com/avatar.jpg' })
-      users.replace_avatar(user, BaseParams.new(url: 'http://totally-correct.com/avatar.jpg'))
+    it "replaces the associated object when serializable data is received" do
+      user = users.create_with_avatar(name: "Frank Herbert", avatar: { url: "http://not-real.com/avatar.jpg" })
+      users.replace_avatar(user, BaseParams.new(url: "http://totally-correct.com/avatar.jpg"))
       found = users.find_with_avatar(user.id)
 
       expect(found.avatar).to_not eq(user.avatar)
@@ -138,22 +140,22 @@ RSpec.describe 'Associations (has_one)' do
     end
   end
 
-  context 'raises a Hanami::Model::Error wrapped exception on' do
-    it '#create' do
+  context "raises a Hanami::Model::Error wrapped exception on" do
+    it "#create" do
       expect do
-        users.create_with_avatar(name: 'Noam Chomsky')
+        users.create_with_avatar(name: "Noam Chomsky")
       end.to raise_error Hanami::Model::Error
     end
 
-    it '#add' do
-      user = users.create_with_avatar(name: 'Stephen Fry', avatar: { url: 'fry_mugshot.png' })
-      expect { users.add_avatar(user, url: 'new_mugshot.png') }.to raise_error Hanami::Model::UniqueConstraintViolationError
+    it "#add" do
+      user = users.create_with_avatar(name: "Stephen Fry", avatar: { url: "fry_mugshot.png" })
+      expect { users.add_avatar(user, url: "new_mugshot.png") }.to raise_error Hanami::Model::UniqueConstraintViolationError
     end
 
     # by default it seems that MySQL allows you to update a NOT NULL column to a NULL value
     unless_platform(db: :mysql) do
-      it '#update' do
-        user = users.create_with_avatar(name: 'Dan North', avatar: { url: 'bdd_creator.png' })
+      it "#update" do
+        user = users.create_with_avatar(name: "Dan North", avatar: { url: "bdd_creator.png" })
 
         expect do
           users.update_avatar(user, url: nil)
@@ -161,8 +163,8 @@ RSpec.describe 'Associations (has_one)' do
       end
     end
 
-    it '#replace' do
-      user = users.create_with_avatar(name: 'Eric Evans', avatar: { url: 'ddd_man.png' })
+    it "#replace" do
+      user = users.create_with_avatar(name: "Eric Evans", avatar: { url: "ddd_man.png" })
       expect { users.replace_avatar(user, url: nil) }.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
   end

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -1,19 +1,21 @@
-RSpec.describe 'Associations (has_many :through)' do
+# frozen_string_literal: true
+
+RSpec.describe "Associations (has_many :through)" do
   #### REPOS
   let(:books) { BookRepository.new }
   let(:categories) { CategoryRepository.new }
   let(:ontologies) { BookOntologyRepository.new }
 
   ### ENTITIES
-  let(:book) { books.create(title: 'Ontology: Encyclopedia of Database Systems') }
-  let(:category) { categories.create(name: 'information science') }
+  let(:book) { books.create(title: "Ontology: Encyclopedia of Database Systems") }
+  let(:category) { categories.create(name: "information science") }
 
   it "returns nil if association wasn't preloaded" do
     found = books.find(book.id)
     expect(found.categories).to be(nil)
   end
 
-  it 'preloads the associated record' do
+  it "preloads the associated record" do
     ontologies.create(book_id: book.id, category_id: category.id)
     found = books.find_with_categories(book.id)
 
@@ -21,22 +23,22 @@ RSpec.describe 'Associations (has_many :through)' do
     expect(found.categories).to eq([category])
   end
 
-  it 'returns an array of Categories' do
+  it "returns an array of Categories" do
     ontologies.create(book_id: book.id, category_id: category.id)
 
     found = books.categories_for(book)
     expect(found).to eq([category])
   end
 
-  it 'returns the count of on sale associated books' do
-    on_sale = books.create(title: 'The Sense of Style', on_sale: true)
+  it "returns the count of on sale associated books" do
+    on_sale = books.create(title: "The Sense of Style", on_sale: true)
     ontologies.create(book_id: on_sale.id, category_id: category.id)
 
     expect(categories.on_sales_books_count(category)).to eq(1)
   end
 
-  context '#add' do
-    it 'adds an object to the collection' do
+  context "#add" do
+    it "adds an object to the collection" do
       books.add_category(book, category)
 
       found_book = books.find_with_categories(book.id)
@@ -48,8 +50,8 @@ RSpec.describe 'Associations (has_many :through)' do
       expect(found_category.books).to eq([book])
     end
 
-    it 'associates a collection of records' do
-      other_book = books.create(title: 'Ontological Engineering')
+    it "associates a collection of records" do
+      other_book = books.create(title: "Ontological Engineering")
       categories.add_books(category, book, other_book)
       found = categories.find_with_books(category.id)
 
@@ -57,8 +59,8 @@ RSpec.describe 'Associations (has_many :through)' do
     end
   end
 
-  context '#delete' do
-    it 'removes all association information' do
+  context "#delete" do
+    it "removes all association information" do
       books.add_category(book, category)
       categorized = books.find_with_categories(book.id)
       books.clear_categories(book)
@@ -70,8 +72,8 @@ RSpec.describe 'Associations (has_many :through)' do
       expect(found).to eq(categorized)
     end
 
-    it 'does not touch other books' do
-      other_book = books.create(title: 'Do not meddle with')
+    it "does not touch other books" do
+      other_book = books.create(title: "Do not meddle with")
       books.add_category(other_book, category)
       books.add_category(book, category)
 
@@ -86,9 +88,9 @@ RSpec.describe 'Associations (has_many :through)' do
     end
   end
 
-  context '#remove' do
-    it 'removes the desired association' do
-      to_remove = books.create(title: 'The Life of a Stoic')
+  context "#remove" do
+    it "removes the desired association" do
+      to_remove = books.create(title: "The Life of a Stoic")
       books.add_category(to_remove, category)
 
       categories.remove_book(category, to_remove.id)
@@ -98,15 +100,15 @@ RSpec.describe 'Associations (has_many :through)' do
     end
   end
 
-  context 'collection methods' do
-    it 'returns an array of books' do
+  context "collection methods" do
+    it "returns an array of books" do
       ontologies.create(book_id: book.id, category_id: category.id)
 
       actual = categories.books_for(category).to_a
       expect(actual).to eq([book])
     end
 
-    it 'iterates through the categories' do
+    it "iterates through the categories" do
       ontologies.create(book_id: book.id, category_id: category.id)
       actual = []
 
@@ -118,15 +120,15 @@ RSpec.describe 'Associations (has_many :through)' do
       expect(actual).to eq([book])
     end
 
-    it 'iterates through the books and returns an array' do
+    it "iterates through the books and returns an array" do
       ontologies.create(book_id: book.id, category_id: category.id)
 
       actual = categories.books_for(category).map(&:id)
       expect(actual).to eq([book.id])
     end
 
-    it 'returns the count of the associated books' do
-      other_book = books.create(title: 'Practical Ontologies for Information Professionals')
+    it "returns the count of the associated books" do
+      other_book = books.create(title: "Practical Ontologies for Information Professionals")
       ontologies.create(book_id: book.id, category_id: category.id)
       ontologies.create(book_id: other_book.id, category_id: category.id)
 
@@ -134,8 +136,8 @@ RSpec.describe 'Associations (has_many :through)' do
     end
   end
 
-  context 'raises a Hanami::Model::Error wrapped exception on' do
-    it '#add' do
+  context "raises a Hanami::Model::Error wrapped exception on" do
+    it "#add" do
       expect do
         categories.add_books(category, id: -2)
       end.to raise_error Hanami::Model::ForeignKeyConstraintViolationError

--- a/spec/integration/hanami/model/associations/relation_alias_spec.rb
+++ b/spec/integration/hanami/model/associations/relation_alias_spec.rb
@@ -1,11 +1,13 @@
-RSpec.describe 'Alias (:as)  support for associations' do
+# frozen_string_literal: true
+
+RSpec.describe "Alias (:as)  support for associations" do
   let(:users) { UserRepository.new }
   let(:posts) { PostRepository.new }
   let(:comments) { CommentRepository.new }
 
-  it 'the attribute is named after the association' do
-    user = users.create(name: 'Jules Verne')
-    post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+  it "the attribute is named after the association" do
+    user = users.create(name: "Jules Verne")
+    post = posts.create(title: "World Traveling made easy", user_id: user.id)
 
     post_found = posts.find_with_author(post.id)
     expect(post_found.author).to eq(user)
@@ -14,10 +16,10 @@ RSpec.describe 'Alias (:as)  support for associations' do
     expect(user_found.threads).to match_array([post])
   end
 
-  it 'it works with nested aggregates' do
-    user = users.create(name: 'Jules Verne')
-    post = posts.create(title: 'World Traveling made easy', user_id: user.id)
-    commenter = users.create(name: 'Thomas Reid')
+  it "it works with nested aggregates" do
+    user = users.create(name: "Jules Verne")
+    post = posts.create(title: "World Traveling made easy", user_id: user.id)
+    commenter = users.create(name: "Thomas Reid")
     comments.create(user_id: commenter.id, post_id: post.id)
 
     found = posts.feed_for(post.id)
@@ -25,11 +27,11 @@ RSpec.describe 'Alias (:as)  support for associations' do
     expect(found.comments[0].user).to eq(commenter)
   end
 
-  context '#assoc support (calling assoc by the alias)' do
-    it 'for #belongs_to' do
-      user = users.create(name: 'Jules Verne')
-      post = posts.create(title: 'World Traveling made easy', user_id: user.id)
-      commenter = users.create(name: 'Thomas Reid')
+  context "#assoc support (calling assoc by the alias)" do
+    it "for #belongs_to" do
+      user = users.create(name: "Jules Verne")
+      post = posts.create(title: "World Traveling made easy", user_id: user.id)
+      commenter = users.create(name: "Thomas Reid")
       comment = comments.create(user_id: commenter.id, post_id: post.id)
 
       found_author = posts.author_for(post)
@@ -39,18 +41,18 @@ RSpec.describe 'Alias (:as)  support for associations' do
       expect(found_commenter).to eq(commenter)
     end
 
-    it 'for #has_many' do
-      user = users.create(name: 'Jules Verne')
-      post = posts.create(title: 'World Traveling made easy', user_id: user.id)
+    it "for #has_many" do
+      user = users.create(name: "Jules Verne")
+      post = posts.create(title: "World Traveling made easy", user_id: user.id)
 
       found_threads = users.threads_for(user)
       expect(found_threads).to match_array [post]
     end
 
-    it 'for #has_many :through' do
-      user = users.create(name: 'Jules Verne')
-      post = posts.create(title: 'World Traveling made easy', user_id: user.id)
-      commenter = users.create(name: 'Thomas Reid')
+    it "for #has_many :through" do
+      user = users.create(name: "Jules Verne")
+      post = posts.create(title: "World Traveling made easy", user_id: user.id)
+      commenter = users.create(name: "Thomas Reid")
       comments.create(user_id: commenter.id, post_id: post.id)
 
       commenters = posts.commenters_for(post)

--- a/spec/integration/hanami/model/migration/mysql.rb
+++ b/spec/integration/hanami/model/migration/mysql.rb
@@ -1,13 +1,15 @@
-RSpec.shared_examples 'migration_integration_mysql' do
+# frozen_string_literal: true
+
+RSpec.shared_examples "migration_integration_mysql" do
   before do
     @schema = Pathname.new("#{__dir__}/../../../../../tmp/schema.sql").expand_path
-    @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])
+    @connection = Sequel.connect(ENV["HANAMI_DATABASE_URL"])
 
     Hanami::Model::Migrator::Adapter.for(Hanami::Model.configuration).dump
   end
 
-  describe 'columns' do
-    it 'defines column types' do
+  describe "columns" do
+    it "defines column types" do
       table = @connection.schema(:column_types)
 
       name, options = table[0]
@@ -16,7 +18,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[1]
@@ -25,7 +27,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[2]
@@ -34,7 +36,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[3]
@@ -43,7 +45,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:db_type)).to eq("varchar(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[4]
@@ -52,7 +54,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(3)')
+      expect(options.fetch(:db_type)).to eq("varchar(3)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[5]
@@ -61,7 +63,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(50)')
+      expect(options.fetch(:db_type)).to eq("varchar(50)")
       expect(options.fetch(:max_length)).to eq(50)
       expect(options.fetch(:primary_key)).to eq(false)
 
@@ -71,7 +73,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('char(255)')
+      expect(options.fetch(:db_type)).to eq("char(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[7]
@@ -80,7 +82,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('char(64)')
+      expect(options.fetch(:db_type)).to eq("char(64)")
       expect(options.fetch(:max_length)).to eq(64)
       expect(options.fetch(:primary_key)).to eq(false)
 
@@ -90,7 +92,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[9]
@@ -99,7 +101,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:blob)
-      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:db_type)).to eq("blob")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[10]
@@ -108,7 +110,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:blob)
-      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:db_type)).to eq("blob")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[11]
@@ -117,7 +119,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[12]
@@ -126,7 +128,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('bigint(20)')
+      expect(options.fetch(:db_type)).to eq("bigint(20)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[13]
@@ -135,7 +137,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:float)
-      expect(options.fetch(:db_type)).to eq('double')
+      expect(options.fetch(:db_type)).to eq("double")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[14]
@@ -144,7 +146,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:db_type)).to eq("decimal(10,0)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[15]
@@ -153,7 +155,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:db_type)).to eq("decimal(10,0)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[16]
@@ -162,7 +164,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('decimal(10,2)')
+      expect(options.fetch(:db_type)).to eq("decimal(10,2)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[17]
@@ -171,7 +173,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:db_type)).to eq("decimal(10,0)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[18]
@@ -180,7 +182,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:date)
-      expect(options.fetch(:db_type)).to eq('date')
+      expect(options.fetch(:db_type)).to eq("date")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[19]
@@ -189,7 +191,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:datetime)
-      expect(options.fetch(:db_type)).to eq('datetime')
+      expect(options.fetch(:db_type)).to eq("datetime")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[20]
@@ -198,7 +200,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:datetime)
-      expect(options.fetch(:db_type)).to eq('datetime')
+      expect(options.fetch(:db_type)).to eq("datetime")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[21]
@@ -207,7 +209,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:time)
-      expect(options.fetch(:db_type)).to eq('time')
+      expect(options.fetch(:db_type)).to eq("time")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[22]
@@ -216,7 +218,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:db_type)).to eq("tinyint(1)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[23]
@@ -225,105 +227,105 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:db_type)).to eq("tinyint(1)")
       expect(options.fetch(:primary_key)).to eq(false)
     end
 
-    it 'defines column defaults' do
+    it "defines column defaults" do
       table = @connection.schema(:default_values)
 
       name, options = table[0]
       expect(name).to eq(:a)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('23')
+      expect(options.fetch(:default)).to eq("23")
       expect(options.fetch(:ruby_default)).to eq(23)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[1]
       expect(name).to eq(:b)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('Hanami')
-      expect(options.fetch(:ruby_default)).to eq('Hanami')
+      expect(options.fetch(:default)).to eq("Hanami")
+      expect(options.fetch(:ruby_default)).to eq("Hanami")
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:db_type)).to eq("varchar(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[2]
       expect(name).to eq(:c)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('-1')
+      expect(options.fetch(:default)).to eq("-1")
       expect(options.fetch(:ruby_default)).to eq(-1)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[3]
       expect(name).to eq(:d)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:default)).to eq("0")
       expect(options.fetch(:ruby_default)).to eq(0)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('bigint(20)')
+      expect(options.fetch(:db_type)).to eq("bigint(20)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[4]
       expect(name).to eq(:e)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('3.14')
+      expect(options.fetch(:default)).to eq("3.14")
       expect(options.fetch(:ruby_default)).to eq(3.14)
       expect(options.fetch(:type)).to eq(:float)
-      expect(options.fetch(:db_type)).to eq('double')
+      expect(options.fetch(:db_type)).to eq("double")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[5]
       expect(name).to eq(:f)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('1')
+      expect(options.fetch(:default)).to eq("1")
       expect(options.fetch(:ruby_default)).to eq(1.0)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:db_type)).to eq("decimal(10,0)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[6]
       expect(name).to eq(:g)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('943943')
+      expect(options.fetch(:default)).to eq("943943")
       expect(options.fetch(:ruby_default)).to eq(943_943)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('decimal(10,0)')
+      expect(options.fetch(:db_type)).to eq("decimal(10,0)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[10]
       expect(name).to eq(:k)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('1')
+      expect(options.fetch(:default)).to eq("1")
       expect(options.fetch(:ruby_default)).to eq(true)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:db_type)).to eq("tinyint(1)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[11]
       expect(name).to eq(:l)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:default)).to eq("0")
       expect(options.fetch(:ruby_default)).to eq(false)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('tinyint(1)')
+      expect(options.fetch(:db_type)).to eq("tinyint(1)")
       expect(options.fetch(:primary_key)).to eq(false)
     end
 
-    it 'defines null constraint' do
+    it "defines null constraint" do
       table = @connection.schema(:null_constraints)
 
       name, options = table[0]
@@ -342,7 +344,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(true)
     end
 
-    it 'defines column index' do
+    it "defines column index" do
       indexes = @connection.indexes(:column_indexes)
 
       expect(indexes.fetch(:column_indexes_a_index, nil)).to be_nil
@@ -353,7 +355,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(index[:columns]).to eq([:c])
     end
 
-    it 'defines index via #index' do
+    it "defines index via #index" do
       indexes = @connection.indexes(:column_indexes)
 
       index = indexes.fetch(:column_indexes_d_index)
@@ -369,7 +371,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(index[:columns]).to eq(%i[lat lng])
     end
 
-    it 'defines primary key (via #primary_key :id)' do
+    it "defines primary key (via #primary_key :id)" do
       table = @connection.schema(:primary_keys_1)
 
       name, options = table[0]
@@ -378,12 +380,12 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(true)
     end
 
-    it 'defines composite primary key (via #primary_key [:column1, :column2])' do
+    it "defines composite primary key (via #primary_key [:column1, :column2])" do
       table = @connection.schema(:primary_keys_3)
 
       name, options = table[0]
@@ -392,14 +394,14 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
 
       expected = Platform.match do
-        os(:linux) { '0' }
+        os(:linux) { "0" }
         os(:macos) { nil }
       end
 
       expect(options.fetch(:default)).to eq(expected)
 
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
 
@@ -409,19 +411,19 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
 
       expected = Platform.match do
-        os(:linux) { '0' }
+        os(:linux) { "0" }
         os(:macos) { nil }
       end
 
       expect(options.fetch(:default)).to eq(expected)
 
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
     end
 
-    it 'defines primary key (via #column primary_key: true)' do
+    it "defines primary key (via #column primary_key: true)" do
       table = @connection.schema(:primary_keys_2)
 
       name, options = table[0]
@@ -430,12 +432,12 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:db_type)).to eq("varchar(255)")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
     end
 
-    it 'defines foreign key (via #foreign_key)' do
+    it "defines foreign key (via #foreign_key)" do
       table = @connection.schema(:albums)
 
       name, options = table[1]
@@ -444,7 +446,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('int(11)')
+      expect(options.fetch(:db_type)).to eq("int(11)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       foreign_key = @connection.foreign_key_list(:albums).first
@@ -455,7 +457,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       # expect(foreign_key.fetch(:on_delete)).to eq(:cascade)
     end
 
-    it 'defines column constraint and check'
+    it "defines column constraint and check"
     # it 'defines column constraint and check' do
     #   expect(@schema.read).to include %(CREATE TABLE `table_constraints` (`age` integer, `role` varchar(255), CONSTRAINT `age_constraint` CHECK (`age` > 18), CHECK (role IN("contributor", "manager", "owner")));)
     # end

--- a/spec/integration/hanami/model/migration/postgresql.rb
+++ b/spec/integration/hanami/model/migration/postgresql.rb
@@ -1,13 +1,15 @@
-RSpec.shared_examples 'migration_integration_postgresql' do
+# frozen_string_literal: true
+
+RSpec.shared_examples "migration_integration_postgresql" do
   before do
     @schema = Pathname.new("#{__dir__}/../../../../../tmp/schema.sql").expand_path
-    @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])
+    @connection = Sequel.connect(ENV["HANAMI_DATABASE_URL"])
 
     Hanami::Model::Migrator::Adapter.for(Hanami::Model.configuration).dump
   end
 
-  describe 'columns' do
-    it 'defines column types' do
+  describe "columns" do
+    it "defines column types" do
       table = @connection.schema(:column_types)
 
       name, options = table[0]
@@ -16,7 +18,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[1]
@@ -25,7 +27,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[2]
@@ -34,7 +36,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[3]
@@ -43,7 +45,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[4]
@@ -52,7 +54,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[5]
@@ -61,7 +63,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character varying(1)')
+      expect(options.fetch(:db_type)).to eq("character varying(1)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[6]
@@ -70,7 +72,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character varying(2)')
+      expect(options.fetch(:db_type)).to eq("character varying(2)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[7]
@@ -79,7 +81,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character(3)')
+      expect(options.fetch(:db_type)).to eq("character(3)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[8]
@@ -88,7 +90,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character(4)')
+      expect(options.fetch(:db_type)).to eq("character(4)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[9]
@@ -97,7 +99,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character varying(50)')
+      expect(options.fetch(:db_type)).to eq("character varying(50)")
       expect(options.fetch(:max_length)).to eq(50)
       expect(options.fetch(:primary_key)).to eq(false)
 
@@ -107,7 +109,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character(255)')
+      expect(options.fetch(:db_type)).to eq("character(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[11]
@@ -116,7 +118,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('character(64)')
+      expect(options.fetch(:db_type)).to eq("character(64)")
       expect(options.fetch(:max_length)).to eq(64)
       expect(options.fetch(:primary_key)).to eq(false)
 
@@ -126,7 +128,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[13]
@@ -135,7 +137,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:blob)
-      expect(options.fetch(:db_type)).to eq('bytea')
+      expect(options.fetch(:db_type)).to eq("bytea")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[14]
@@ -144,7 +146,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:blob)
-      expect(options.fetch(:db_type)).to eq('bytea')
+      expect(options.fetch(:db_type)).to eq("bytea")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[15]
@@ -153,7 +155,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[16]
@@ -162,7 +164,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:db_type)).to eq("bigint")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[17]
@@ -171,7 +173,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:float)
-      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:db_type)).to eq("double precision")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[18]
@@ -180,7 +182,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[19]
@@ -189,7 +191,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric(10,0)')
+      expect(options.fetch(:db_type)).to eq("numeric(10,0)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[20]
@@ -198,7 +200,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric(10,2)')
+      expect(options.fetch(:db_type)).to eq("numeric(10,2)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[21]
@@ -207,7 +209,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[22]
@@ -216,7 +218,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:date)
-      expect(options.fetch(:db_type)).to eq('date')
+      expect(options.fetch(:db_type)).to eq("date")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[23]
@@ -225,7 +227,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:datetime)
-      expect(options.fetch(:db_type)).to eq('timestamp without time zone')
+      expect(options.fetch(:db_type)).to eq("timestamp without time zone")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[24]
@@ -234,7 +236,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:datetime)
-      expect(options.fetch(:db_type)).to eq('timestamp without time zone')
+      expect(options.fetch(:db_type)).to eq("timestamp without time zone")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[25]
@@ -243,7 +245,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:time)
-      expect(options.fetch(:db_type)).to eq('time without time zone')
+      expect(options.fetch(:db_type)).to eq("time without time zone")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[26]
@@ -252,7 +254,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[27]
@@ -261,7 +263,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[28]
@@ -270,7 +272,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer[]')
+      expect(options.fetch(:db_type)).to eq("integer[]")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[29]
@@ -279,7 +281,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer[]')
+      expect(options.fetch(:db_type)).to eq("integer[]")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[30]
@@ -288,7 +290,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text[]')
+      expect(options.fetch(:db_type)).to eq("text[]")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[31]
@@ -297,7 +299,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:money)
-      expect(options.fetch(:db_type)).to eq('money')
+      expect(options.fetch(:db_type)).to eq("money")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[32]
@@ -306,7 +308,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:mood)
-      expect(options.fetch(:db_type)).to eq('mood')
+      expect(options.fetch(:db_type)).to eq("mood")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[33]
@@ -315,7 +317,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:point)
-      expect(options.fetch(:db_type)).to eq('point')
+      expect(options.fetch(:db_type)).to eq("point")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[34]
@@ -324,7 +326,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:line)
-      expect(options.fetch(:db_type)).to eq('line')
+      expect(options.fetch(:db_type)).to eq("line")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[35]
@@ -333,7 +335,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq("'<(15,15),1>'::circle")
       # expect(options.fetch(:type)).to eq(:circle)
-      expect(options.fetch(:db_type)).to eq('circle')
+      expect(options.fetch(:db_type)).to eq("circle")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[36]
@@ -342,16 +344,16 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq("'192.168.0.0/24'::cidr")
       # expect(options.fetch(:type)).to eq(:cidr)
-      expect(options.fetch(:db_type)).to eq('cidr')
+      expect(options.fetch(:db_type)).to eq("cidr")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[37]
       expect(name).to eq(:uuid1)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('uuid_generate_v4()')
+      expect(options.fetch(:default)).to eq("uuid_generate_v4()")
       # expect(options.fetch(:type)).to eq(:uuid)
-      expect(options.fetch(:db_type)).to eq('uuid')
+      expect(options.fetch(:db_type)).to eq("uuid")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[38]
@@ -360,7 +362,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:xml)
-      expect(options.fetch(:db_type)).to eq('xml')
+      expect(options.fetch(:db_type)).to eq("xml")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[39]
@@ -369,7 +371,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:json)
-      expect(options.fetch(:db_type)).to eq('json')
+      expect(options.fetch(:db_type)).to eq("json")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[40]
@@ -378,7 +380,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:jsonb)
-      expect(options.fetch(:db_type)).to eq('jsonb')
+      expect(options.fetch(:db_type)).to eq("jsonb")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[41]
@@ -387,21 +389,21 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq("ROW('fuzzy dice'::text, 42, 1.99)")
       # expect(options.fetch(:type)).to eq(:inventory_item)
-      expect(options.fetch(:db_type)).to eq('inventory_item')
+      expect(options.fetch(:db_type)).to eq("inventory_item")
       expect(options.fetch(:primary_key)).to eq(false)
     end
 
-    it 'defines column defaults' do
+    it "defines column defaults" do
       table = @connection.schema(:default_values)
 
       name, options = table[0]
       expect(name).to eq(:a)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('23')
+      expect(options.fetch(:default)).to eq("23")
       expect(options.fetch(:ruby_default)).to eq(23)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[1]
@@ -409,9 +411,9 @@ RSpec.shared_examples 'migration_integration_postgresql' do
 
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq("'Hanami'::text")
-      expect(options.fetch(:ruby_default)).to eq('Hanami')
+      expect(options.fetch(:ruby_default)).to eq("Hanami")
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[2]
@@ -420,7 +422,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
 
       expected = Platform.match do
-        os(:linux) { '(-1)' }
+        os(:linux) { "(-1)" }
         os(:macos) { "'-1'::integer" }
       end
 
@@ -428,71 +430,71 @@ RSpec.shared_examples 'migration_integration_postgresql' do
 
       # expect(options.fetch(:ruby_default)).to eq(-1)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[3]
       expect(name).to eq(:d)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:default)).to eq("0")
       expect(options.fetch(:ruby_default)).to eq(0)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:db_type)).to eq("bigint")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[4]
       expect(name).to eq(:e)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('3.14')
+      expect(options.fetch(:default)).to eq("3.14")
       expect(options.fetch(:ruby_default)).to eq(3.14)
       expect(options.fetch(:type)).to eq(:float)
-      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:db_type)).to eq("double precision")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[5]
       expect(name).to eq(:f)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('1.0')
+      expect(options.fetch(:default)).to eq("1.0")
       expect(options.fetch(:ruby_default)).to eq(1.0)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[6]
       expect(name).to eq(:g)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('943943')
+      expect(options.fetch(:default)).to eq("943943")
       expect(options.fetch(:ruby_default)).to eq(943_943)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[10]
       expect(name).to eq(:k)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('true')
+      expect(options.fetch(:default)).to eq("true")
       expect(options.fetch(:ruby_default)).to eq(true)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[11]
       expect(name).to eq(:l)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('false')
+      expect(options.fetch(:default)).to eq("false")
       expect(options.fetch(:ruby_default)).to eq(false)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
     end
 
-    it 'defines null constraint' do
+    it "defines null constraint" do
       table = @connection.schema(:null_constraints)
 
       name, options = table[0]
@@ -511,7 +513,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
     end
 
-    it 'defines column index' do
+    it "defines column index" do
       indexes = @connection.indexes(:column_indexes)
 
       expect(indexes.fetch(:column_indexes_a_index, nil)).to be_nil
@@ -522,7 +524,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(index[:columns]).to eq([:c])
     end
 
-    it 'defines index via #index' do
+    it "defines index via #index" do
       indexes = @connection.indexes(:column_indexes)
 
       index = indexes.fetch(:column_indexes_d_index)
@@ -538,7 +540,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(index[:columns]).to eq(%i[lat lng])
     end
 
-    it 'defines primary key (via #primary_key :id)' do
+    it "defines primary key (via #primary_key :id)" do
       table = @connection.schema(:primary_keys_1)
 
       name, options = table[0]
@@ -547,12 +549,12 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq("nextval('primary_keys_1_id_seq'::regclass)")
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(true)
     end
 
-    it 'defines composite primary key (via #primary_key [:column1, :column2])' do
+    it "defines composite primary key (via #primary_key [:column1, :column2])" do
       table = @connection.schema(:primary_keys_3)
 
       name, options = table[0]
@@ -561,7 +563,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
 
@@ -571,12 +573,12 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
     end
 
-    it 'defines primary key (via #column primary_key: true)' do
+    it "defines primary key (via #column primary_key: true)" do
       table = @connection.schema(:primary_keys_2)
 
       name, options = table[0]
@@ -585,12 +587,12 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
     end
 
-    it 'defines foreign key (via #foreign_key)' do
+    it "defines foreign key (via #foreign_key)" do
       table = @connection.schema(:albums)
 
       name, options = table[1]
@@ -599,7 +601,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       foreign_key = @connection.foreign_key_list(:albums).first
@@ -611,7 +613,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
     end
 
     unless Platform.ci?
-      it 'defines column constraint and check' do
+      it "defines column constraint and check" do
         actual = @schema.read
 
         expect(actual).to include %(CONSTRAINT age_constraint CHECK ((age > 18)))

--- a/spec/integration/hanami/model/migration/sqlite.rb
+++ b/spec/integration/hanami/model/migration/sqlite.rb
@@ -1,13 +1,15 @@
-RSpec.shared_examples 'migration_integration_sqlite' do
+# frozen_string_literal: true
+
+RSpec.shared_examples "migration_integration_sqlite" do
   before do
     @schema = Pathname.new("#{__dir__}/../../../../../tmp/schema.sql").expand_path
-    @connection = Sequel.connect(ENV['HANAMI_DATABASE_URL'])
+    @connection = Sequel.connect(ENV["HANAMI_DATABASE_URL"])
 
     Hanami::Model::Migrator::Adapter.for(Hanami::Model.configuration).dump
   end
 
-  describe 'columns' do
-    it 'defines column types' do
+  describe "columns" do
+    it "defines column types" do
       table = @connection.schema(:column_types)
 
       name, options = table[0]
@@ -16,7 +18,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[1]
@@ -25,7 +27,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[2]
@@ -34,7 +36,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[3]
@@ -43,7 +45,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:db_type)).to eq("varchar(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[4]
@@ -52,7 +54,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('string')
+      expect(options.fetch(:db_type)).to eq("string")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[5]
@@ -61,7 +63,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('string')
+      expect(options.fetch(:db_type)).to eq("string")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[6]
@@ -70,7 +72,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(3)')
+      expect(options.fetch(:db_type)).to eq("varchar(3)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[7]
@@ -79,7 +81,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(50)')
+      expect(options.fetch(:db_type)).to eq("varchar(50)")
       expect(options.fetch(:max_length)).to eq(50)
       expect(options.fetch(:primary_key)).to eq(false)
 
@@ -89,7 +91,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('char(255)')
+      expect(options.fetch(:db_type)).to eq("char(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[9]
@@ -98,7 +100,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('char(64)')
+      expect(options.fetch(:db_type)).to eq("char(64)")
       expect(options.fetch(:max_length)).to eq(64)
       expect(options.fetch(:primary_key)).to eq(false)
 
@@ -108,7 +110,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('text')
+      expect(options.fetch(:db_type)).to eq("text")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[11]
@@ -117,7 +119,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:blob)
-      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:db_type)).to eq("blob")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[12]
@@ -126,7 +128,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:blob)
-      expect(options.fetch(:db_type)).to eq('blob')
+      expect(options.fetch(:db_type)).to eq("blob")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[13]
@@ -135,7 +137,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[14]
@@ -144,7 +146,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:db_type)).to eq("bigint")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[15]
@@ -153,7 +155,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:float)
-      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:db_type)).to eq("double precision")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[16]
@@ -162,7 +164,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[17]
@@ -171,7 +173,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       # expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric(10)')
+      expect(options.fetch(:db_type)).to eq("numeric(10)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[18]
@@ -180,7 +182,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric(10, 2)')
+      expect(options.fetch(:db_type)).to eq("numeric(10, 2)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[19]
@@ -189,7 +191,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[20]
@@ -198,7 +200,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:date)
-      expect(options.fetch(:db_type)).to eq('date')
+      expect(options.fetch(:db_type)).to eq("date")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[21]
@@ -207,7 +209,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:datetime)
-      expect(options.fetch(:db_type)).to eq('timestamp')
+      expect(options.fetch(:db_type)).to eq("timestamp")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[22]
@@ -216,7 +218,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:datetime)
-      expect(options.fetch(:db_type)).to eq('timestamp')
+      expect(options.fetch(:db_type)).to eq("timestamp")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[23]
@@ -225,7 +227,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:time)
-      expect(options.fetch(:db_type)).to eq('time')
+      expect(options.fetch(:db_type)).to eq("time")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[24]
@@ -234,7 +236,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[25]
@@ -243,21 +245,21 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
     end
 
-    it 'defines column defaults' do
+    it "defines column defaults" do
       table = @connection.schema(:default_values)
 
       name, options = table[0]
       expect(name).to eq(:a)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('23')
+      expect(options.fetch(:default)).to eq("23")
       expect(options.fetch(:ruby_default)).to eq(23)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[1]
@@ -265,83 +267,83 @@ RSpec.shared_examples 'migration_integration_sqlite' do
 
       expect(options.fetch(:allow_null)).to eq(true)
       expect(options.fetch(:default)).to eq("'Hanami'")
-      expect(options.fetch(:ruby_default)).to eq('Hanami')
+      expect(options.fetch(:ruby_default)).to eq("Hanami")
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:db_type)).to eq("varchar(255)")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[2]
       expect(name).to eq(:c)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('-1')
+      expect(options.fetch(:default)).to eq("-1")
       expect(options.fetch(:ruby_default)).to eq(-1)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[3]
       expect(name).to eq(:d)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:default)).to eq("0")
       expect(options.fetch(:ruby_default)).to eq(0)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('bigint')
+      expect(options.fetch(:db_type)).to eq("bigint")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[4]
       expect(name).to eq(:e)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('3.14')
+      expect(options.fetch(:default)).to eq("3.14")
       expect(options.fetch(:ruby_default)).to eq(3.14)
       expect(options.fetch(:type)).to eq(:float)
-      expect(options.fetch(:db_type)).to eq('double precision')
+      expect(options.fetch(:db_type)).to eq("double precision")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[5]
       expect(name).to eq(:f)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('1.0')
+      expect(options.fetch(:default)).to eq("1.0")
       expect(options.fetch(:ruby_default)).to eq(1.0)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[6]
       expect(name).to eq(:g)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('943943')
+      expect(options.fetch(:default)).to eq("943943")
       expect(options.fetch(:ruby_default)).to eq(943_943)
       expect(options.fetch(:type)).to eq(:decimal)
-      expect(options.fetch(:db_type)).to eq('numeric')
+      expect(options.fetch(:db_type)).to eq("numeric")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[10]
       expect(name).to eq(:k)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('1')
+      expect(options.fetch(:default)).to eq("1")
       expect(options.fetch(:ruby_default)).to eq(true)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
 
       name, options = table[11]
       expect(name).to eq(:l)
 
       expect(options.fetch(:allow_null)).to eq(true)
-      expect(options.fetch(:default)).to eq('0')
+      expect(options.fetch(:default)).to eq("0")
       expect(options.fetch(:ruby_default)).to eq(false)
       expect(options.fetch(:type)).to eq(:boolean)
-      expect(options.fetch(:db_type)).to eq('boolean')
+      expect(options.fetch(:db_type)).to eq("boolean")
       expect(options.fetch(:primary_key)).to eq(false)
     end
 
-    it 'defines null constraint' do
+    it "defines null constraint" do
       table = @connection.schema(:null_constraints)
 
       name, options = table[0]
@@ -360,7 +362,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(true)
     end
 
-    it 'defines column index' do
+    it "defines column index" do
       indexes = @connection.indexes(:column_indexes)
 
       expect(indexes.fetch(:column_indexes_a_index, nil)).to be_nil
@@ -371,7 +373,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(index[:columns]).to eq([:c])
     end
 
-    it 'defines index via #index' do
+    it "defines index via #index" do
       indexes = @connection.indexes(:column_indexes)
 
       index = indexes.fetch(:column_indexes_d_index)
@@ -387,7 +389,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(index[:columns]).to eq(%i[lat lng])
     end
 
-    it 'defines primary key (via #primary_key :id)' do
+    it "defines primary key (via #primary_key :id)" do
       table = @connection.schema(:primary_keys_1)
 
       name, options = table[0]
@@ -396,12 +398,12 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(true)
     end
 
-    it 'defines composite primary key (via #primary_key [:column1, :column2])' do
+    it "defines composite primary key (via #primary_key [:column1, :column2])" do
       table = @connection.schema(:primary_keys_3)
 
       name, options = table[0]
@@ -410,7 +412,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
 
@@ -420,12 +422,12 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
     end
 
-    it 'defines primary key (via #column primary_key: true)' do
+    it "defines primary key (via #column primary_key: true)" do
       table = @connection.schema(:primary_keys_2)
 
       name, options = table[0]
@@ -434,12 +436,12 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:string)
-      expect(options.fetch(:db_type)).to eq('varchar(255)')
+      expect(options.fetch(:db_type)).to eq("varchar(255)")
       expect(options.fetch(:primary_key)).to eq(true)
       expect(options.fetch(:auto_increment)).to eq(false)
     end
 
-    it 'defines foreign key (via #foreign_key)' do
+    it "defines foreign key (via #foreign_key)" do
       table = @connection.schema(:albums)
 
       name, options = table[1]
@@ -448,7 +450,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(options.fetch(:allow_null)).to eq(false)
       expect(options.fetch(:default)).to eq(nil)
       expect(options.fetch(:type)).to eq(:integer)
-      expect(options.fetch(:db_type)).to eq('integer')
+      expect(options.fetch(:db_type)).to eq("integer")
       expect(options.fetch(:primary_key)).to eq(false)
 
       foreign_key = @connection.foreign_key_list(:albums).first
@@ -459,7 +461,7 @@ RSpec.shared_examples 'migration_integration_sqlite' do
       expect(foreign_key.fetch(:on_delete)).to eq(:cascade)
     end
 
-    it 'defines column constraint and check' do
+    it "defines column constraint and check" do
       expect(@schema.read).to include %(CREATE TABLE `table_constraints` (`age` integer, `role` varchar(255), CONSTRAINT `age_constraint` CHECK (`age` > 18), CHECK (role IN("contributor", "manager", "owner")));)
     end
   end

--- a/spec/integration/hanami/model/migration_spec.rb
+++ b/spec/integration/hanami/model/migration_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require_relative "./migration/#{Database.engine}.rb"
 
-RSpec.describe 'Hanami::Model.migration' do
+RSpec.describe "Hanami::Model.migration" do
   include_examples "migration_integration_#{Database.engine}"
 end

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -1,34 +1,36 @@
-require 'securerandom'
+# frozen_string_literal: true
 
-RSpec.describe 'Repository (base)' do
+require "securerandom"
+
+RSpec.describe "Repository (base)" do
   extend PlatformHelpers
 
-  describe '#find' do
-    it 'finds record by primary key' do
+  describe "#find" do
+    it "finds record by primary key" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
+      user = repository.create(name: "L")
       found = repository.find(user.id)
 
       expect(found).to eq(user)
     end
 
-    it 'returns nil when nil is given' do
+    it "returns nil when nil is given" do
       repository = UserRepository.new
-      repository.create(name: 'L')
+      repository.create(name: "L")
       found = repository.find(nil)
 
       expect(found).to be_nil
     end
 
-    it 'returns nil for missing record' do
+    it "returns nil for missing record" do
       repository = UserRepository.new
-      found = repository.find('9999999')
+      found = repository.find("9999999")
 
       expect(found).to be_nil
     end
 
     # See https://github.com/hanami/model/issues/374
-    describe 'with non-autoincrement primary key' do
+    describe "with non-autoincrement primary key" do
       before do
         repository.clear
       end
@@ -36,7 +38,7 @@ RSpec.describe 'Repository (base)' do
       let(:repository) { LabelRepository.new }
       let(:id)         { 1 }
 
-      it 'raises error' do
+      it "raises error" do
         repository.create(id: id)
 
         expect { repository.find(id) }
@@ -45,8 +47,8 @@ RSpec.describe 'Repository (base)' do
     end
 
     # See https://github.com/hanami/model/issues/399
-    describe 'with custom relation' do
-      it 'finds record by primary key' do
+    describe "with custom relation" do
+      it "finds record by primary key" do
         repository = AccessTokenRepository.new
         access_token = repository.create(token: "123")
         found        = repository.find(access_token.id)
@@ -56,55 +58,55 @@ RSpec.describe 'Repository (base)' do
     end
   end
 
-  describe '#all' do
-    it 'returns all the records' do
+  describe "#all" do
+    it "returns all the records" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
+      user = repository.create(name: "L")
 
       expect(repository.all).to be_an_instance_of(Array)
       expect(repository.all).to include(user)
     end
   end
 
-  describe '#first' do
-    it 'returns first record from table' do
+  describe "#first" do
+    it "returns first record from table" do
       repository = UserRepository.new
       repository.clear
 
-      user = repository.create(name: 'James Hetfield')
-      repository.create(name: 'Tom')
+      user = repository.create(name: "James Hetfield")
+      repository.create(name: "Tom")
 
       expect(repository.first).to eq(user)
     end
   end
 
-  describe '#last' do
-    it 'returns last record from table' do
+  describe "#last" do
+    it "returns last record from table" do
       repository = UserRepository.new
       repository.clear
 
-      repository.create(name: 'Tom')
-      user = repository.create(name: 'Ella Fitzgerald')
+      repository.create(name: "Tom")
+      user = repository.create(name: "Ella Fitzgerald")
 
       expect(repository.last).to eq(user)
     end
   end
 
-  describe '#clear' do
-    it 'clears all the records' do
+  describe "#clear" do
+    it "clears all the records" do
       repository = UserRepository.new
-      repository.create(name: 'L')
+      repository.create(name: "L")
 
       repository.clear
       expect(repository.all).to be_empty
     end
   end
 
-  describe 'relation' do
-    describe 'read' do
-      it 'reads records from the database given a raw query string' do
+  describe "relation" do
+    describe "read" do
+      it "reads records from the database given a raw query string" do
         repository = UserRepository.new
-        repository.create(name: 'L')
+        repository.create(name: "L")
 
         users = repository.find_all_by_manual_query
         expect(users).to be_a_kind_of(Array)
@@ -115,18 +117,18 @@ RSpec.describe 'Repository (base)' do
     end
   end
 
-  describe '#create' do
-    it 'creates record from data' do
+  describe "#create" do
+    it "creates record from data" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
+      user = repository.create(name: "L")
 
       expect(user).to be_an_instance_of(User)
       expect(user.id).to_not be_nil
-      expect(user.name).to eq('L')
+      expect(user.name).to eq("L")
     end
 
-    it 'creates record from entity' do
-      entity = User.new(name: 'L')
+    it "creates record from entity" do
+      entity = User.new(name: "L")
       repository = UserRepository.new
       user = repository.create(entity)
 
@@ -135,74 +137,74 @@ RSpec.describe 'Repository (base)' do
 
       expect(user).to be_an_instance_of(User)
       expect(user.id).to_not be_nil
-      expect(user.name).to eq('L')
+      expect(user.name).to eq("L")
     end
 
     with_platform(engine: :jruby, db: :sqlite) do
-      it 'automatically touches timestamps'
+      it "automatically touches timestamps"
     end
 
     unless_platform(engine: :jruby, db: :sqlite) do
-      it 'automatically touches timestamps' do
+      it "automatically touches timestamps" do
         repository = UserRepository.new
-        user = repository.create(name: 'L')
+        user = repository.create(name: "L")
 
         expect(user.created_at).to be_within(2).of(Time.now.utc)
         expect(user.updated_at).to be_within(2).of(Time.now.utc)
       end
 
-      it 'respects given timestamps' do
+      it "respects given timestamps" do
         repository = UserRepository.new
-        given_time = Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
+        given_time = Time.new(2010, 1, 1, 12, 0, 0, "+00:00")
 
-        user = repository.create(name: 'L', created_at: given_time, updated_at: given_time)
+        user = repository.create(name: "L", created_at: given_time, updated_at: given_time)
 
         expect(user.created_at).to be_within(2).of(given_time)
         expect(user.updated_at).to be_within(2).of(given_time)
       end
 
-      it 'can update timestamps' do
+      it "can update timestamps" do
         repository = UserRepository.new
-        user = repository.create(name: 'L')
+        user = repository.create(name: "L")
         expect(user.created_at).to be_within(2).of(Time.now.utc)
         expect(user.updated_at).to be_within(2).of(Time.now.utc)
 
-        given_time = Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
+        given_time = Time.new(2010, 1, 1, 12, 0, 0, "+00:00")
         updated = repository.update(
           user.id,
           created_at: given_time,
           updated_at: given_time
         )
 
-        expect(updated.name).to eq('L')
+        expect(updated.name).to eq("L")
         expect(updated.created_at).to be_within(2).of(given_time)
         expect(updated.updated_at).to be_within(2).of(given_time)
       end
 
       # Bug: https://github.com/hanami/model/issues/412
-      it 'can have only creation timestamp' do
-        user = UserRepository.new.create(name: 'L')
+      it "can have only creation timestamp" do
+        user = UserRepository.new.create(name: "L")
         repository = AvatarRepository.new
-        account = repository.create(url: 'http://foo.com', user_id: user.id)
+        account = repository.create(url: "http://foo.com", user_id: user.id)
         expect(account.created_at).to be_within(2).of(Time.now.utc)
       end
     end
 
     # Bug: https://github.com/hanami/model/issues/237
-    it 'respects database defaults' do
+    it "respects database defaults" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
+      user = repository.create(name: "L")
 
       expect(user.comments_count).to eq(0)
     end
 
     # Bug: https://github.com/hanami/model/issues/272
-    it 'accepts booleans as attributes' do
-      user = UserRepository.new.create(name: 'L', active: false)
+    it "accepts booleans as attributes" do
+      user = UserRepository.new.create(name: "L", active: false)
       expect(user.active).to eq(false)
     end
 
-    it 'raises error when generic database error is raised'
+    it "raises error when generic database error is raised"
     # it 'raises error when generic database error is raised' do
     #   expected_error = Hanami::Model::DatabaseError
     #   message = Platform.match do
@@ -225,8 +227,8 @@ RSpec.describe 'Repository (base)' do
     it 'raises error when "not null" database constraint is violated' do
       expected_error = Hanami::Model::NotNullConstraintViolationError
       message = Platform.match do
-        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
-        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_NOTNULL]  A NOT NULL constraint failed (NOT NULL constraint failed: users.active)' }
+        engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException" }
+        engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_NOTNULL]  A NOT NULL constraint failed (NOT NULL constraint failed: users.active)" }
 
         engine(:ruby).db(:postgresql)  { 'PG::NotNullViolation: ERROR:  null value in column "active" violates not-null constraint' }
         engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: null value in column "active" violates not-null constraint' }
@@ -235,7 +237,7 @@ RSpec.describe 'Repository (base)' do
         engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Column 'active' cannot be null" }
       end
 
-      expect { UserRepository.new.create(name: 'L', active: nil) }.to raise_error do |error|
+      expect { UserRepository.new.create(name: "L", active: nil) }.to raise_error do |error|
         expect(error).to be_a(expected_error)
         expect(error.message).to include(message)
       end
@@ -246,8 +248,8 @@ RSpec.describe 'Repository (base)' do
 
       expected_error = Hanami::Model::UniqueConstraintViolationError
       message = Platform.match do
-        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
-        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_UNIQUE]  A UNIQUE constraint failed (UNIQUE constraint failed: users.email)' }
+        engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException" }
+        engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_UNIQUE]  A UNIQUE constraint failed (UNIQUE constraint failed: users.email)" }
 
         engine(:ruby).db(:postgresql)  { 'PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "users_email_index"' }
         engine(:jruby).db(:postgresql) { %(Java::OrgPostgresqlUtil::PSQLException: ERROR: duplicate key value violates unique constraint "users_email_index"\n  Detail: Key (email)=(#{email}) already exists.) }
@@ -257,9 +259,9 @@ RSpec.describe 'Repository (base)' do
       end
 
       repository = UserRepository.new
-      repository.create(name: 'Test', email: email)
+      repository.create(name: "Test", email: email)
 
-      expect { repository.create(name: 'L', email: email) }.to raise_error do |error|
+      expect { repository.create(name: "L", email: email) }.to raise_error do |error|
         expect(error).to be_a(expected_error)
         expect(error.message).to include(message)
       end
@@ -268,17 +270,17 @@ RSpec.describe 'Repository (base)' do
     it 'raises error when "foreign key" constraint is violated' do
       expected_error = Hanami::Model::ForeignKeyConstraintViolationError
       message = Platform.match do
-        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
-        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_FOREIGNKEY]  A foreign key constraint failed (FOREIGN KEY constraint failed)' }
+        engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException" }
+        engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_FOREIGNKEY]  A foreign key constraint failed (FOREIGN KEY constraint failed)" }
 
         engine(:ruby).db(:postgresql)  { 'PG::ForeignKeyViolation: ERROR:  insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
         engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
 
-        engine(:ruby).db(:mysql)  { 'Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails' }
-        engine(:jruby).db(:mysql) { 'Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)' }
+        engine(:ruby).db(:mysql)  { "Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails" }
+        engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)" }
       end
 
-      expect { AvatarRepository.new.create(user_id: 999_999_999, url: 'url') }.to raise_error do |error|
+      expect { AvatarRepository.new.create(user_id: 999_999_999, url: "url") }.to raise_error do |error|
         expect(error).to be_a(expected_error)
         expect(error.message).to include(message)
       end
@@ -291,31 +293,31 @@ RSpec.describe 'Repository (base)' do
         expected = Hanami::Model::CheckConstraintViolationError
 
         message = Platform.match do
-          engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException: CHECK constraint failed' }
-          engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: users)' }
+          engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException: CHECK constraint failed" }
+          engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: users)" }
 
           engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "users_age_check"' }
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "users_age_check"' }
         end
 
-        expect { UserRepository.new.create(name: 'L', age: 1) }.to raise_error do |error|
+        expect { UserRepository.new.create(name: "L", age: 1) }.to raise_error do |error|
           expect(error).to         be_a(expected)
           expect(error.message).to include(message)
         end
       end
 
-      it 'raises error when constraint is violated' do
+      it "raises error when constraint is violated" do
         expected = Hanami::Model::CheckConstraintViolationError
 
         message = Platform.match do
-          engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException: CHECK constraint failed' }
-          engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: comments_count_constraint)' }
+          engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException: CHECK constraint failed" }
+          engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: comments_count_constraint)" }
 
           engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "comments_count_constraint"' }
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "comments_count_constraint"' }
         end
 
-        expect { UserRepository.new.create(name: 'L', comments_count: -1) }.to raise_error do |error|
+        expect { UserRepository.new.create(name: "L", comments_count: -1) }.to raise_error do |error|
           expect(error).to         be_a(expected)
           expect(error.message).to include(message)
         end
@@ -323,21 +325,21 @@ RSpec.describe 'Repository (base)' do
     end
   end
 
-  describe '#update' do
-    it 'updates record from data' do
+  describe "#update" do
+    it "updates record from data" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
-      updated = repository.update(user.id, name: 'Luca')
+      user = repository.create(name: "L")
+      updated = repository.update(user.id, name: "Luca")
 
       expect(updated).to be_an_instance_of(User)
       expect(updated.id).to eq(user.id)
-      expect(updated.name).to eq('Luca')
+      expect(updated.name).to eq("Luca")
     end
 
-    it 'updates record from entity' do
-      entity = User.new(name: 'Luca')
+    it "updates record from entity" do
+      entity = User.new(name: "Luca")
       repository = UserRepository.new
-      user = repository.create(name: 'L')
+      user = repository.create(name: "L")
       updated = repository.update(user.id, entity)
 
       # It doesn't mutate original entity
@@ -345,33 +347,33 @@ RSpec.describe 'Repository (base)' do
 
       expect(updated).to be_an_instance_of(User)
       expect(updated.id).to eq(user.id)
-      expect(updated.name).to eq('Luca')
+      expect(updated.name).to eq("Luca")
     end
 
-    it 'returns nil when record cannot be found' do
+    it "returns nil when record cannot be found" do
       repository = UserRepository.new
-      updated = repository.update('9999999', name: 'Luca')
+      updated = repository.update("9999999", name: "Luca")
 
       expect(updated).to be_nil
     end
 
     with_platform(engine: :jruby, db: :sqlite) do
-      it 'automatically touches timestamps'
+      it "automatically touches timestamps"
     end
 
     unless_platform(engine: :jruby, db: :sqlite) do
-      it 'automatically touches timestamps' do
+      it "automatically touches timestamps" do
         repository = UserRepository.new
-        user = repository.create(name: 'L')
+        user = repository.create(name: "L")
         sleep 0.1
-        updated = repository.update(user.id, name: 'Luca')
+        updated = repository.update(user.id, name: "Luca")
 
         expect(updated.created_at).to be_within(2).of(user.created_at)
         expect(updated.updated_at).to be_within(2).of(Time.now)
       end
     end
 
-    it 'raises error when generic database error is raised'
+    it "raises error when generic database error is raised"
     # it 'raises error when generic database error is raised' do
     #   expected_error = Hanami::Model::DatabaseError
     #   message = Platform.match do
@@ -399,8 +401,8 @@ RSpec.describe 'Repository (base)' do
       it 'raises error when "not null" database constraint is violated' do
         expected_error = Hanami::Model::NotNullConstraintViolationError
         message = Platform.match do
-          engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
-          engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_NOTNULL]  A NOT NULL constraint failed (NOT NULL constraint failed: users.active)' }
+          engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException" }
+          engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_NOTNULL]  A NOT NULL constraint failed (NOT NULL constraint failed: users.active)" }
 
           engine(:ruby).db(:postgresql)  { 'PG::NotNullViolation: ERROR:  null value in column "active" violates not-null constraint' }
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: null value in column "active" violates not-null constraint' }
@@ -410,7 +412,7 @@ RSpec.describe 'Repository (base)' do
         end
 
         repository = UserRepository.new
-        user = repository.create(name: 'L')
+        user = repository.create(name: "L")
 
         expect { repository.update(user.id, active: nil) }.to raise_error do |error|
           expect(error).to be_a(expected_error)
@@ -424,8 +426,8 @@ RSpec.describe 'Repository (base)' do
 
       expected_error = Hanami::Model::UniqueConstraintViolationError
       message = Platform.match do
-        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
-        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_UNIQUE]  A UNIQUE constraint failed (UNIQUE constraint failed: users.email)' }
+        engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException" }
+        engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_UNIQUE]  A UNIQUE constraint failed (UNIQUE constraint failed: users.email)" }
 
         engine(:ruby).db(:postgresql)  { 'PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "users_email_index"' }
         engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: duplicate key value violates unique constraint "users_email_index"' }
@@ -435,8 +437,8 @@ RSpec.describe 'Repository (base)' do
       end
 
       repository = UserRepository.new
-      user = repository.create(name: 'L')
-      repository.create(name: 'UpdateTest', email: email)
+      user = repository.create(name: "L")
+      repository.create(name: "UpdateTest", email: email)
 
       expect { repository.update(user.id, email: email) }.to raise_error do |error|
         expect(error).to be_a(expected_error)
@@ -447,19 +449,19 @@ RSpec.describe 'Repository (base)' do
     it 'raises error when "foreign key" constraint is violated' do
       expected_error = Hanami::Model::ForeignKeyConstraintViolationError
       message = Platform.match do
-        engine(:ruby).db(:sqlite)  { 'SQLite3::ConstraintException' }
-        engine(:jruby).db(:sqlite) { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_FOREIGNKEY]  A foreign key constraint failed (FOREIGN KEY constraint failed)' }
+        engine(:ruby).db(:sqlite)  { "SQLite3::ConstraintException" }
+        engine(:jruby).db(:sqlite) { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_FOREIGNKEY]  A foreign key constraint failed (FOREIGN KEY constraint failed)" }
 
         engine(:ruby).db(:postgresql)  { 'PG::ForeignKeyViolation: ERROR:  insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
         engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: insert or update on table "avatars" violates foreign key constraint "avatars_user_id_fkey"' }
 
-        engine(:ruby).db(:mysql)  { 'Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails' }
-        engine(:jruby).db(:mysql) { 'Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)' }
+        engine(:ruby).db(:mysql)  { "Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails" }
+        engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)" }
       end
 
-      user = UserRepository.new.create(name: 'L')
+      user = UserRepository.new.create(name: "L")
       repository = AvatarRepository.new
-      avatar = repository.create(user_id: user.id, url: 'a valid url')
+      avatar = repository.create(user_id: user.id, url: "a valid url")
 
       expect { repository.update(avatar.id, user_id: 999_999_999) }.to raise_error do |error|
         expect(error).to be_a(expected_error)
@@ -474,15 +476,15 @@ RSpec.describe 'Repository (base)' do
         expected = Hanami::Model::CheckConstraintViolationError
 
         message = Platform.match do
-          engine(:ruby).db(:sqlite)   { 'SQLite3::ConstraintException: CHECK constraint failed' }
-          engine(:jruby).db(:sqlite)  { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: users)' }
+          engine(:ruby).db(:sqlite)   { "SQLite3::ConstraintException: CHECK constraint failed" }
+          engine(:jruby).db(:sqlite)  { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: users)" }
 
           engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "users_age_check"' }
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "users_age_check"' }
         end
 
         repository = UserRepository.new
-        user = repository.create(name: 'L')
+        user = repository.create(name: "L")
 
         expect { repository.update(user.id, age: 17) }.to raise_error do |error|
           expect(error).to         be_a(expected)
@@ -490,19 +492,19 @@ RSpec.describe 'Repository (base)' do
         end
       end
 
-      it 'raises error when constraint is violated' do
+      it "raises error when constraint is violated" do
         expected = Hanami::Model::CheckConstraintViolationError
 
         message = Platform.match do
-          engine(:ruby).db(:sqlite)   { 'SQLite3::ConstraintException: CHECK constraint failed' }
-          engine(:jruby).db(:sqlite)  { 'Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: comments_count_constraint)' }
+          engine(:ruby).db(:sqlite)   { "SQLite3::ConstraintException: CHECK constraint failed" }
+          engine(:jruby).db(:sqlite)  { "Java::OrgSqlite::SQLiteException: [SQLITE_CONSTRAINT_CHECK]  A CHECK constraint failed (CHECK constraint failed: comments_count_constraint)" }
 
           engine(:ruby).db(:postgresql)  { 'PG::CheckViolation: ERROR:  new row for relation "users" violates check constraint "comments_count_constraint"' }
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "comments_count_constraint"' }
         end
 
         repository = UserRepository.new
-        user = repository.create(name: 'L')
+        user = repository.create(name: "L")
 
         expect { repository.update(user.id, comments_count: -2) }.to raise_error do |error|
           expect(error).to         be_a(expected)
@@ -512,53 +514,53 @@ RSpec.describe 'Repository (base)' do
     end
   end
 
-  describe '#delete' do
-    it 'deletes record' do
+  describe "#delete" do
+    it "deletes record" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
+      user = repository.create(name: "L")
       deleted = repository.delete(user.id)
 
       expect(deleted).to be_an_instance_of(User)
       expect(deleted.id).to eq(user.id)
-      expect(deleted.name).to eq('L')
+      expect(deleted.name).to eq("L")
 
       found = repository.find(user.id)
       expect(found).to be_nil
     end
 
-    it 'returns nil when record cannot be found' do
+    it "returns nil when record cannot be found" do
       repository = UserRepository.new
-      deleted = repository.delete('9999999')
+      deleted = repository.delete("9999999")
 
       expect(deleted).to be_nil
     end
   end
 
-  describe '#transaction' do
+  describe "#transaction" do
   end
 
-  describe 'custom finder' do
-    it 'returns records' do
+  describe "custom finder" do
+    it "returns records" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
-      found = repository.by_name('L')
+      user = repository.create(name: "L")
+      found = repository.by_name("L")
 
       expect(found.to_a).to include(user)
     end
 
-    it 'uses root relation' do
+    it "uses root relation" do
       repository = UserRepository.new
-      user = repository.create(name: 'L')
-      found = repository.by_name_with_root('L')
+      user = repository.create(name: "L")
+      found = repository.by_name_with_root("L")
 
       expect(found.to_a).to include(user)
     end
 
-    it 'selects only a single column' do
+    it "selects only a single column" do
       repository = UserRepository.new
       repository.clear
 
-      repository.create([{ name: 'L', age: 35 }, { name: 'MG', age: 34 }])
+      repository.create([{ name: "L", age: 35 }, { name: "MG", age: 34 }])
       found = repository.ids
 
       expect(found.size).to be(2)
@@ -570,11 +572,11 @@ RSpec.describe 'Repository (base)' do
       end
     end
 
-    it 'selects multiple columns' do
+    it "selects multiple columns" do
       repository = UserRepository.new
       repository.clear
 
-      repository.create([{ name: 'L', age: 35 }, { name: 'MG', age: 34 }])
+      repository.create([{ name: "L", age: 35 }, { name: "MG", age: 34 }])
       found = repository.select_id_and_name
 
       expect(found.size).to be(2)
@@ -588,19 +590,19 @@ RSpec.describe 'Repository (base)' do
   end
 
   with_platform(db: :postgresql) do
-    describe 'PostgreSQL' do
-      it 'finds record by primary key (UUID)' do
+    describe "PostgreSQL" do
+      it "finds record by primary key (UUID)" do
         repository = SourceFileRepository.new
-        file = repository.create(name: 'path/to/file.rb', languages: ['ruby'], metadata: { coverage: 100.0 }, content: 'class Foo; end')
+        file = repository.create(name: "path/to/file.rb", languages: ["ruby"], metadata: { coverage: 100.0 }, content: "class Foo; end")
         found = repository.find(file.id)
 
-        expect(file.languages).to eq(['ruby'])
+        expect(file.languages).to eq(["ruby"])
         expect(file.metadata).to eq(coverage: 100.0)
 
         expect(found).to eq(file)
       end
 
-      it 'returns nil for nil primary key (UUID)' do
+      it "returns nil for nil primary key (UUID)" do
         repository = SourceFileRepository.new
 
         found = repository.find(nil)
@@ -611,7 +613,7 @@ RSpec.describe 'Repository (base)' do
       #
       #   Sequel::DatabaseError: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for uuid: "9999999"
       #   LINE 1: ...", "updated_at" FROM "source_files" WHERE ("id" = '9999999')...
-      it 'returns nil for missing record (UUID)'
+      it "returns nil for missing record (UUID)"
       # it 'returns nil for missing record (UUID)' do
       #   repository = SourceFileRepository.new
 
@@ -619,21 +621,21 @@ RSpec.describe 'Repository (base)' do
       #   expect(found).to be_nil
       # end
 
-      describe 'JSON types' do
-        it 'writes hashes' do
-          hash = { first_name: 'John', age: 53, married: true, car: nil }
+      describe "JSON types" do
+        it "writes hashes" do
+          hash = { first_name: "John", age: 53, married: true, car: nil }
           repository = SourceFileRepository.new
-          column_type = repository.create(metadata: hash, name: 'test', content: 'test', json_info: hash)
+          column_type = repository.create(metadata: hash, name: "test", content: "test", json_info: hash)
           found = repository.find(column_type.id)
 
           expect(found.metadata).to eq(hash)
           expect(found.json_info).to eq(hash)
         end
 
-        it 'writes arrays' do
-          array = ['abc', 1, true, nil]
+        it "writes arrays" do
+          array = ["abc", 1, true, nil]
           repository = SourceFileRepository.new
-          column_type = repository.create(metadata: array, name: 'test', content: 'test', json_info: array)
+          column_type = repository.create(metadata: array, name: "test", content: "test", json_info: array)
           found = repository.find(column_type.id)
 
           expect(found.metadata).to eq(array)
@@ -642,50 +644,50 @@ RSpec.describe 'Repository (base)' do
       end
 
       describe "when timestamps aren't enabled" do
-        it 'writes the proper PG types' do
+        it "writes the proper PG types" do
           repository = ProductRepository.new
 
-          product = repository.create(name: 'NeoVim', categories: ['software'])
+          product = repository.create(name: "NeoVim", categories: ["software"])
           found = repository.find(product.id)
 
-          expect(product.categories).to eq(['software'])
+          expect(product.categories).to eq(["software"])
 
           expect(found).to eq(product)
         end
 
-        it 'succeeds even if timestamps is the only plugin' do
+        it "succeeds even if timestamps is the only plugin" do
           repository = ProductRepository.new
 
           product = repository
                     .command(:create, repository.root, use: %i[timestamps])
-                    .call(name: 'NeoVim', categories: ['software'])
+                    .call(name: "NeoVim", categories: ["software"])
 
           found = repository.find(product.id)
 
-          expect(product.categories).to eq(['software'])
+          expect(product.categories).to eq(["software"])
 
           expect(found.to_h).to eq(product.to_h)
         end
       end
     end
 
-    describe 'enum database type' do
-      it 'allows to write data' do
+    describe "enum database type" do
+      it "allows to write data" do
         repository = ColorRepository.new
-        color = repository.create(name: 'red')
+        color = repository.create(name: "red")
 
         expect(color).to be_a_kind_of(Color)
-        expect(color.name).to eq('red')
+        expect(color.name).to eq("red")
       end
 
-      it 'raises error if the value is not included in the enum' do
+      it "raises error if the value is not included in the enum" do
         repository = ColorRepository.new
         message = Platform.match do
           engine(:ruby)  { %(PG::InvalidTextRepresentation: ERROR:  invalid input value for enum rainbow: "grey") }
           engine(:jruby) { %(Java::OrgPostgresqlUtil::PSQLException: ERROR: invalid input value for enum rainbow: "grey") }
         end
 
-        expect { repository.create(name: 'grey') }.to raise_error do |error|
+        expect { repository.create(name: "grey") }.to raise_error do |error|
           expect(error).to be_a(Hanami::Model::Error)
           expect(error.message).to include(message)
         end

--- a/spec/integration/hanami/model/repository/command_spec.rb
+++ b/spec/integration/hanami/model/repository/command_spec.rb
@@ -1,25 +1,27 @@
-RSpec.describe 'Customized commands' do
+# frozen_string_literal: true
+
+RSpec.describe "Customized commands" do
   subject(:authors) { AuthorRepository.new }
 
   let(:data) do
-    [{ name: 'Arthur C. Clarke' }, { name: 'Phillip K. Dick' }]
+    [{ name: "Arthur C. Clarke" }, { name: "Phillip K. Dick" }]
   end
 
-  context 'the mapper' do
-    it 'is enabled by default' do
+  context "the mapper" do
+    it "is enabled by default" do
       result = authors.create_many(data)
       expect(result).to be_an Array
       expect(result).to all(be_an(Author))
     end
 
-    it 'can be explictly turned off' do
+    it "can be explictly turned off" do
       result = authors.create_many(data, opts: { mapper: nil })
       expect(result).to all(be_an(ROM::Struct))
     end
   end
 
-  context 'timestamps' do
-    it 'are enabled by default' do
+  context "timestamps" do
+    it "are enabled by default" do
       result = authors.create_many(data)
       expect(result.first.created_at).to be_within(2).of(Time.now.utc)
     end

--- a/spec/integration/hanami/model/repository/legacy_spec.rb
+++ b/spec/integration/hanami/model/repository/legacy_spec.rb
@@ -1,123 +1,125 @@
-RSpec.describe 'Repository (legacy)' do
-  describe '#find' do
-    it 'finds record by primary key' do
+# frozen_string_literal: true
+
+RSpec.describe "Repository (legacy)" do
+  describe "#find" do
+    it "finds record by primary key" do
       repository = OperatorRepository.new
-      operator = repository.create(name: 'F')
+      operator = repository.create(name: "F")
       found = repository.find(operator.id)
 
       expect(operator).to eq(found)
     end
 
-    it 'returns nil for missing record' do
+    it "returns nil for missing record" do
       repository = OperatorRepository.new
-      found = repository.find('9999999')
+      found = repository.find("9999999")
 
       expect(found).to be_nil
     end
   end
 
-  describe '#all' do
-    it 'returns all the records' do
+  describe "#all" do
+    it "returns all the records" do
       repository = OperatorRepository.new
-      operator = repository.create(name: 'F')
+      operator = repository.create(name: "F")
 
       expect(repository.all).to be_an_instance_of(Array)
       expect(repository.all).to include(operator)
     end
   end
 
-  describe '#first' do
-    it 'returns first record from table' do
+  describe "#first" do
+    it "returns first record from table" do
       repository = OperatorRepository.new
       repository.clear
 
-      operator = repository.create(name: 'Janis Joplin')
-      repository.create(name: 'Jon')
+      operator = repository.create(name: "Janis Joplin")
+      repository.create(name: "Jon")
 
       expect(repository.first).to eq(operator)
     end
   end
 
-  describe '#last' do
-    it 'returns last record from table' do
+  describe "#last" do
+    it "returns last record from table" do
       repository = OperatorRepository.new
       repository.clear
 
-      repository.create(name: 'Rob')
-      operator = repository.create(name: 'Amy Winehouse')
+      repository.create(name: "Rob")
+      operator = repository.create(name: "Amy Winehouse")
 
       expect(repository.last).to eq(operator)
     end
   end
 
-  describe '#clear' do
-    it 'clears all the records' do
+  describe "#clear" do
+    it "clears all the records" do
       repository = OperatorRepository.new
-      repository.create(name: 'F')
+      repository.create(name: "F")
 
       repository.clear
       expect(repository.all).to be_empty
     end
   end
 
-  describe '#execute' do
+  describe "#execute" do
   end
 
-  describe '#fetch' do
+  describe "#fetch" do
   end
 
-  describe '#create' do
-    it 'creates record' do
+  describe "#create" do
+    it "creates record" do
       repository = OperatorRepository.new
-      operator = repository.create(name: 'F')
+      operator = repository.create(name: "F")
 
       expect(operator).to be_an_instance_of(Operator)
       expect(operator.id).to_not be_nil
-      expect(operator.name).to eq('F')
+      expect(operator.name).to eq("F")
     end
   end
 
-  describe '#update' do
-    it 'updates record' do
+  describe "#update" do
+    it "updates record" do
       repository = OperatorRepository.new
-      operator = repository.create(name: 'F')
-      updated = repository.update(operator.id, name: 'Flo')
+      operator = repository.create(name: "F")
+      updated = repository.update(operator.id, name: "Flo")
 
       expect(updated).to be_an_instance_of(Operator)
       expect(updated.id).to eq(operator.id)
-      expect(updated.name).to eq('Flo')
+      expect(updated.name).to eq("Flo")
     end
 
-    it 'returns nil when record cannot be found' do
+    it "returns nil when record cannot be found" do
       repository = OperatorRepository.new
-      updated = repository.update('9999999', name: 'Flo')
+      updated = repository.update("9999999", name: "Flo")
 
       expect(updated).to be_nil
     end
   end
 
-  describe '#delete' do
-    it 'deletes record' do
+  describe "#delete" do
+    it "deletes record" do
       repository = OperatorRepository.new
-      operator = repository.create(name: 'F')
+      operator = repository.create(name: "F")
       deleted = repository.delete(operator.id)
 
       expect(deleted).to be_an_instance_of(Operator)
       expect(deleted.id).to eq(operator.id)
-      expect(deleted.name).to eq('F')
+      expect(deleted.name).to eq("F")
 
       found = repository.find(operator.id)
       expect(found).to be_nil
     end
 
-    it 'returns nil when record cannot be found' do
+    it "returns nil when record cannot be found" do
       repository = OperatorRepository.new
-      deleted = repository.delete('9999999')
+      deleted = repository.delete("9999999")
 
       expect(deleted).to be_nil
     end
   end
 
-  describe '#transaction' do
+  describe "#transaction" do
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -14,7 +16,7 @@ RSpec.configure do |config|
 
   config.warnings = true
 
-  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.default_formatter = "doc" if config.files_to_run.one?
 
   config.profile_examples = 10
 
@@ -22,11 +24,11 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 end
 
-$LOAD_PATH.unshift 'lib'
-require 'hanami/model'
+$LOAD_PATH.unshift "lib"
+require "hanami/model"
 
-require_relative './support/coverage'
-require_relative './support/test_io'
-require_relative './support/platform'
-require_relative './support/database'
-require_relative './support/fixtures'
+require_relative "./support/coverage"
+require_relative "./support/test_io"
+require_relative "./support/platform"
+require_relative "./support/database"
+require_relative "./support/fixtures"

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,7 +1,9 @@
-if ENV['COVERAGE'] == 'true'
-  require 'simplecov'
+# frozen_string_literal: true
+
+if ENV["COVERAGE"] == "true"
+  require "simplecov"
   SimpleCov.start
 
-  require 'codecov'
+  require "codecov"
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Database
   class Setup
-    DEFAULT_ADAPTER = 'sqlite'.freeze
+    DEFAULT_ADAPTER = "sqlite"
 
-    def initialize(adapter: ENV['DB'])
+    def initialize(adapter: ENV["DB"])
       @strategy = Strategy.for(adapter || DEFAULT_ADAPTER)
     end
 
@@ -12,9 +14,9 @@ module Database
   end
 
   module Strategies
-    require_relative './database/strategies/sqlite'
-    require_relative './database/strategies/postgresql'
-    require_relative './database/strategies/mysql'
+    require_relative "./database/strategies/sqlite"
+    require_relative "./database/strategies/postgresql"
+    require_relative "./database/strategies/mysql"
 
     def self.strategies
       constants.map do |const|
@@ -40,7 +42,7 @@ module Database
   end
 
   def self.engine
-    ENV['HANAMI_DATABASE_TYPE'].to_sym
+    ENV["HANAMI_DATABASE_TYPE"].to_sym
   end
 
   def self.engine?(name)

--- a/spec/support/database/strategies/abstract.rb
+++ b/spec/support/database/strategies/abstract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Database
   module Strategies
     class Abstract
@@ -22,7 +24,7 @@ module Database
       end
 
       def database_name
-        'hanami_model'
+        "hanami_model"
       end
 
       def load_dependencies
@@ -30,7 +32,7 @@ module Database
       end
 
       def export_env
-        ENV['HANAMI_DATABASE_NAME'] = database_name
+        ENV["HANAMI_DATABASE_NAME"] = database_name
       end
 
       def create_database
@@ -39,10 +41,10 @@ module Database
 
       def configure
         returing = Hanami::Model.configure do
-          adapter ENV['HANAMI_DATABASE_ADAPTER'].to_sym, ENV['HANAMI_DATABASE_URL']
+          adapter ENV["HANAMI_DATABASE_ADAPTER"].to_sym, ENV["HANAMI_DATABASE_URL"]
         end
 
-        returing == Hanami::Model or raise 'Hanami::Model.configure should return Hanami::Model'
+        returing == Hanami::Model or raise "Hanami::Model.configure should return Hanami::Model"
       end
 
       def after

--- a/spec/support/database/strategies/mysql.rb
+++ b/spec/support/database/strategies/mysql.rb
@@ -1,4 +1,6 @@
-require_relative 'sql'
+# frozen_string_literal: true
+
+require_relative "sql"
 
 module Database
   module Strategies
@@ -7,27 +9,27 @@ module Database
         protected
 
         def load_dependencies
-          require 'hanami/model/sql'
-          require 'jdbc/mysql'
+          require "hanami/model/sql"
+          require "jdbc/mysql"
         end
 
         def export_env
           super
-          ENV['HANAMI_DATABASE_URL'] = "jdbc:mysql://#{host}/#{database_name}?#{credentials}"
+          ENV["HANAMI_DATABASE_URL"] = "jdbc:mysql://#{host}/#{database_name}?#{credentials}"
         end
 
         def host
-          ENV['HANAMI_DATABASE_HOST'] || '127.0.0.1'
+          ENV["HANAMI_DATABASE_HOST"] || "127.0.0.1"
         end
 
         def credentials
           Hash[
-            'user'     => ENV['HANAMI_DATABASE_USERNAME'],
-            'password' => ENV['HANAMI_DATABASE_PASSWORD'],
-            'useSSL'   => 'false'
+            "user"     => ENV["HANAMI_DATABASE_USERNAME"],
+            "password" => ENV["HANAMI_DATABASE_PASSWORD"],
+            "useSSL"   => "false"
           ].map do |key, value|
             "#{key}=#{value}" unless Hanami::Utils::Blank.blank?(value)
-          end.compact.join('&')
+          end.compact.join("&")
         end
       end
 
@@ -36,8 +38,8 @@ module Database
 
         def export_env
           super
-          ENV['HANAMI_DATABASE_USERNAME'] = 'travis'
-          ENV['HANAMI_DATABASE_URL'] = "mysql2://#{credentials}@#{host}/#{database_name}"
+          ENV["HANAMI_DATABASE_USERNAME"] = "travis"
+          ENV["HANAMI_DATABASE_URL"] = "mysql2://#{credentials}@#{host}/#{database_name}"
         end
 
         def create_database
@@ -55,7 +57,7 @@ module Database
       end
 
       def self.eligible?(adapter)
-        adapter.start_with?('mysql')
+        adapter.start_with?("mysql")
       end
 
       def initialize
@@ -66,16 +68,16 @@ module Database
       protected
 
       def load_dependencies
-        require 'hanami/model/sql'
-        require 'mysql2'
+        require "hanami/model/sql"
+        require "mysql2"
       end
 
       def export_env
         super
-        ENV['HANAMI_DATABASE_TYPE'] = 'mysql'
-        ENV['HANAMI_DATABASE_USERNAME'] ||= 'root'
-        ENV['HANAMI_DATABASE_PASSWORD'] ||= ''
-        ENV['HANAMI_DATABASE_URL'] = "mysql2://#{credentials}@#{host}/#{database_name}"
+        ENV["HANAMI_DATABASE_TYPE"] = "mysql"
+        ENV["HANAMI_DATABASE_USERNAME"] ||= "root"
+        ENV["HANAMI_DATABASE_PASSWORD"] ||= ""
+        ENV["HANAMI_DATABASE_URL"] = "mysql2://#{credentials}@#{host}/#{database_name}"
       end
 
       def create_database

--- a/spec/support/database/strategies/postgresql.rb
+++ b/spec/support/database/strategies/postgresql.rb
@@ -1,4 +1,6 @@
-require_relative 'sql'
+# frozen_string_literal: true
+
+require_relative "sql"
 
 module Database
   module Strategies
@@ -7,15 +9,15 @@ module Database
         protected
 
         def load_dependencies
-          require 'hanami/model/sql'
-          require 'jdbc/postgres'
+          require "hanami/model/sql"
+          require "jdbc/postgres"
 
           Jdbc::Postgres.load_driver
         end
 
         def export_env
           super
-          ENV['HANAMI_DATABASE_URL'] = "jdbc:postgresql://#{host}/#{database_name}"
+          ENV["HANAMI_DATABASE_URL"] = "jdbc:postgresql://#{host}/#{database_name}"
         end
       end
 
@@ -24,12 +26,12 @@ module Database
 
         def export_env
           super
-          ENV['HANAMI_DATABASE_USERNAME'] = 'postgres'
+          ENV["HANAMI_DATABASE_USERNAME"] = "postgres"
         end
       end
 
       def self.eligible?(adapter)
-        adapter.start_with?('postgres')
+        adapter.start_with?("postgres")
       end
 
       def initialize
@@ -40,8 +42,8 @@ module Database
       protected
 
       def load_dependencies
-        require 'hanami/model/sql'
-        require 'pg'
+        require "hanami/model/sql"
+        require "pg"
       end
 
       def create_database
@@ -56,9 +58,9 @@ module Database
 
       def export_env
         super
-        ENV['HANAMI_DATABASE_TYPE'] = 'postgresql'
-        ENV['HANAMI_DATABASE_URL'] = "postgres://#{host}/#{database_name}"
-        ENV['HANAMI_DATABASE_USERNAME'] = `whoami`.strip.freeze
+        ENV["HANAMI_DATABASE_TYPE"] = "postgresql"
+        ENV["HANAMI_DATABASE_URL"] = "postgres://#{host}/#{database_name}"
+        ENV["HANAMI_DATABASE_USERNAME"] = `whoami`.strip.freeze
       end
 
       private

--- a/spec/support/database/strategies/sql.rb
+++ b/spec/support/database/strategies/sql.rb
@@ -1,7 +1,9 @@
-require_relative 'abstract'
-require 'hanami/utils/blank'
-require 'pathname'
-require 'stringio'
+# frozen_string_literal: true
+
+require_relative "abstract"
+require "hanami/utils/blank"
+require "pathname"
+require "stringio"
 
 module Database
   module Strategies
@@ -20,18 +22,18 @@ module Database
 
       def export_env
         super
-        ENV['HANAMI_DATABASE_ADAPTER'] = 'sql'
-        ENV['HANAMI_DATABASE_LOGGER'] = logger.to_s
+        ENV["HANAMI_DATABASE_ADAPTER"] = "sql"
+        ENV["HANAMI_DATABASE_LOGGER"] = logger.to_s
       end
 
       def configure # rubocop:disable Metrics/AbcSize
         Hanami::Model.configure do
-          adapter    ENV['HANAMI_DATABASE_ADAPTER'].to_sym, ENV['HANAMI_DATABASE_URL']
-          logger     ENV['HANAMI_DATABASE_LOGGER'], level: :debug
-          migrations Dir.pwd + '/spec/support/fixtures/database_migrations'
-          schema     Dir.pwd + '/tmp/schema.sql'
+          adapter    ENV["HANAMI_DATABASE_ADAPTER"].to_sym, ENV["HANAMI_DATABASE_URL"]
+          logger     ENV["HANAMI_DATABASE_LOGGER"], level: :debug
+          migrations Dir.pwd + "/spec/support/fixtures/database_migrations"
+          schema     Dir.pwd + "/tmp/schema.sql"
 
-          migrations_logger ENV['HANAMI_DATABASE_LOGGER']
+          migrations_logger ENV["HANAMI_DATABASE_LOGGER"]
 
           gateway do |g|
             g.connection.extension(:pg_enum) if Database.engine?(:postgresql)
@@ -47,23 +49,23 @@ module Database
 
       def migrate
         TestIO.with_stdout do
-          require 'hanami/model/migrator'
+          require "hanami/model/migrator"
           Hanami::Model::Migrator.migrate
         end
       end
 
       def credentials
-        [ENV['HANAMI_DATABASE_USERNAME'], ENV['HANAMI_DATABASE_PASSWORD']].reject do |token|
+        [ENV["HANAMI_DATABASE_USERNAME"], ENV["HANAMI_DATABASE_PASSWORD"]].reject do |token|
           Hanami::Utils::Blank.blank?(token)
-        end.join(':')
+        end.join(":")
       end
 
       def host
-        ENV['HANAMI_DATABASE_HOST'] || 'localhost'
+        ENV["HANAMI_DATABASE_HOST"] || "localhost"
       end
 
       def logger
-        Pathname.new('tmp').join('hanami_model.log')
+        Pathname.new("tmp").join("hanami_model.log")
       end
     end
   end

--- a/spec/support/database/strategies/sqlite.rb
+++ b/spec/support/database/strategies/sqlite.rb
@@ -1,5 +1,7 @@
-require_relative 'sql'
-require 'pathname'
+# frozen_string_literal: true
+
+require_relative "sql"
+require "pathname"
 
 module Database
   module Strategies
@@ -8,14 +10,14 @@ module Database
         protected
 
         def load_dependencies
-          require 'hanami/model/sql'
-          require 'jdbc/sqlite3'
+          require "hanami/model/sql"
+          require "jdbc/sqlite3"
           Jdbc::SQLite3.load_driver
         end
 
         def export_env
           super
-          ENV['HANAMI_DATABASE_URL'] = "jdbc:sqlite://#{database_name}"
+          ENV["HANAMI_DATABASE_URL"] = "jdbc:sqlite://#{database_name}"
         end
       end
 
@@ -23,7 +25,7 @@ module Database
       end
 
       def self.eligible?(adapter)
-        adapter.start_with?('sqlite')
+        adapter.start_with?("sqlite")
       end
 
       def initialize
@@ -34,12 +36,12 @@ module Database
       protected
 
       def database_name
-        Pathname.new(__dir__).join('..', '..', '..', '..', 'tmp', 'sqlite', "#{super}.sqlite3").to_s
+        Pathname.new(__dir__).join("..", "..", "..", "..", "tmp", "sqlite", "#{super}.sqlite3").to_s
       end
 
       def load_dependencies
-        require 'hanami/model/sql'
-        require 'sqlite3'
+        require "hanami/model/sql"
+        require "sqlite3"
       end
 
       def create_database
@@ -51,8 +53,8 @@ module Database
 
       def export_env
         super
-        ENV['HANAMI_DATABASE_TYPE'] = 'sqlite'
-        ENV['HANAMI_DATABASE_URL'] = "sqlite://#{database_name}"
+        ENV["HANAMI_DATABASE_TYPE"] = "sqlite"
+        ENV["HANAMI_DATABASE_URL"] = "sqlite://#{database_name}"
       end
     end
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ostruct"
 
 class BaseParams < OpenStruct

--- a/spec/support/fixtures/database_migrations/20150612081248_column_types.rb
+++ b/spec/support/fixtures/database_migrations/20150612081248_column_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     case Database.engine
@@ -5,12 +7,12 @@ Hanami::Model.migration do
       create_table :column_types do
         column :integer1, Integer
         column :integer2, :integer
-        column :integer3, 'integer'
+        column :integer3, "integer"
 
         column :string1, String
         column :string2, :string
-        column :string3, 'string'
-        column :string4, 'varchar(3)'
+        column :string3, "string"
+        column :string4, "varchar(3)"
 
         column :string5, String, size: 50
         column :string6, String, fixed: true
@@ -18,7 +20,7 @@ Hanami::Model.migration do
         column :string8, String, text: true
 
         column :file1, File
-        column :file2, 'blob'
+        column :file2, "blob"
 
         column :number1, Fixnum # rubocop:disable Lint/UnifiedInteger
         column :number2, :Bignum
@@ -51,14 +53,14 @@ Hanami::Model.migration do
       create_table :column_types do
         column :integer1, Integer
         column :integer2, :integer
-        column :integer3, 'integer'
+        column :integer3, "integer"
 
         column :string1, String
-        column :string2, 'text'
-        column :string3, 'character varying(1)'
-        column :string4, 'varchar(2)'
-        column :string5, 'character(3)'
-        column :string6, 'char(4)'
+        column :string2, "text"
+        column :string3, "character varying(1)"
+        column :string4, "varchar(2)"
+        column :string5, "character(3)"
+        column :string6, "char(4)"
 
         column :string7, String, size: 50
         column :string8, String, fixed: true
@@ -66,7 +68,7 @@ Hanami::Model.migration do
         column :string10, String, text: true
 
         column :file1, File
-        column :file2, 'bytea'
+        column :file2, "bytea"
 
         column :number1, Fixnum # rubocop:disable Lint/UnifiedInteger
         column :number2, :Bignum
@@ -85,37 +87,37 @@ Hanami::Model.migration do
         column :boolean1, TrueClass
         column :boolean2, FalseClass
 
-        column :array1, 'integer[]'
-        column :array2, 'integer[3]'
-        column :array3, 'text[][]'
+        column :array1, "integer[]"
+        column :array2, "integer[3]"
+        column :array3, "text[][]"
 
-        column :money1, 'money'
+        column :money1, "money"
 
-        column :enum1, 'mood'
+        column :enum1, "mood"
 
-        column :geometric1, 'point'
-        column :geometric2, 'line'
-        column :geometric3, 'circle', default: '<(15,15), 1>'
+        column :geometric1, "point"
+        column :geometric2, "line"
+        column :geometric3, "circle", default: "<(15,15), 1>"
 
-        column :net1, 'cidr', default: '192.168/24'
+        column :net1, "cidr", default: "192.168/24"
 
-        column :uuid1, 'uuid', default: Hanami::Model::Sql.function(:uuid_generate_v4)
+        column :uuid1, "uuid", default: Hanami::Model::Sql.function(:uuid_generate_v4)
 
-        column :xml1, 'xml'
+        column :xml1, "xml"
 
-        column :json1, 'json'
-        column :json2, 'jsonb'
+        column :json1, "json"
+        column :json2, "jsonb"
 
-        column :composite1, 'inventory_item', default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
+        column :composite1, "inventory_item", default: Hanami::Model::Sql.literal("ROW('fuzzy dice', 42, 1.99)")
       end
     when :mysql
       create_table :column_types do
         column :integer1, Integer
         column :integer2, :integer
-        column :integer3, 'integer'
+        column :integer3, "integer"
 
         column :string1, String
-        column :string2, 'varchar(3)'
+        column :string2, "varchar(3)"
 
         column :string5, String, size: 50
         column :string6, String, fixed: true
@@ -123,7 +125,7 @@ Hanami::Model.migration do
         column :string8, String, text: true
 
         column :file1, File
-        column :file2, 'blob'
+        column :file2, "blob"
 
         column :number1, Fixnum # rubocop:disable Lint/UnifiedInteger
         column :number2, :Bignum

--- a/spec/support/fixtures/database_migrations/20150612084656_default_values.rb
+++ b/spec/support/fixtures/database_migrations/20150612084656_default_values.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     case Database.engine
     when :sqlite
       create_table :default_values do
         column :a, Integer,    default: 23
-        column :b, String,     default: 'Hanami'
+        column :b, String,     default: "Hanami"
         column :c, Fixnum,     default: -1 # rubocop:disable Lint/UnifiedInteger
         column :d, :Bignum,    default: 0
         column :e, Float,      default: 3.14
@@ -19,13 +21,13 @@ Hanami::Model.migration do
     when :postgresql
       create_table :default_values do
         column :a, Integer,    default: 23
-        column :b, String,     default: 'Hanami'
+        column :b, String,     default: "Hanami"
         column :c, Fixnum,     default: -1 # rubocop:disable Lint/UnifiedInteger
         column :d, :Bignum,    default: 0
         column :e, Float,      default: 3.14
         column :f, BigDecimal, default: 1.0
         column :g, Numeric,    default: 943_943
-        column :h, Date,       default: 'now'
+        column :h, Date,       default: "now"
         column :i, DateTime,   default: DateTime.now
         column :j, Time,       default: Time.now
         column :k, TrueClass,  default: true
@@ -34,7 +36,7 @@ Hanami::Model.migration do
     when :mysql
       create_table :default_values do
         column :a, Integer,    default: 23
-        column :b, String,     default: 'Hanami'
+        column :b, String,     default: "Hanami"
         column :c, Fixnum,     default: -1 # rubocop:disable Lint/UnifiedInteger
         column :d, :Bignum,    default: 0
         column :e, Float,      default: 3.14

--- a/spec/support/fixtures/database_migrations/20150612093458_null_constraints.rb
+++ b/spec/support/fixtures/database_migrations/20150612093458_null_constraints.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     create_table :null_constraints do

--- a/spec/support/fixtures/database_migrations/20150612093810_column_indexes.rb
+++ b/spec/support/fixtures/database_migrations/20150612093810_column_indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     create_table :column_indexes do

--- a/spec/support/fixtures/database_migrations/20150612094740_primary_keys.rb
+++ b/spec/support/fixtures/database_migrations/20150612094740_primary_keys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     create_table :primary_keys_1 do

--- a/spec/support/fixtures/database_migrations/20150612115204_foreign_keys.rb
+++ b/spec/support/fixtures/database_migrations/20150612115204_foreign_keys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     create_table :artists do

--- a/spec/support/fixtures/database_migrations/20150612122233_table_constraints.rb
+++ b/spec/support/fixtures/database_migrations/20150612122233_table_constraints.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
-    case ENV['HANAMI_DATABASE_TYPE']
-    when 'sqlite'
+    case ENV["HANAMI_DATABASE_TYPE"]
+    when "sqlite"
       create_table :table_constraints do
         column :age, Integer
         constraint(:age_constraint) { age > 18 }
@@ -9,7 +11,7 @@ Hanami::Model.migration do
         column :role, String
         check %(role IN("contributor", "manager", "owner"))
       end
-    when 'postgresql'
+    when "postgresql"
       create_table :table_constraints do
         column :age, Integer
         constraint(:age_constraint) { age > 18 }
@@ -17,7 +19,7 @@ Hanami::Model.migration do
         column :role, String
         check %(role IN('contributor', 'manager', 'owner'))
       end
-    when 'mysql'
+    when "mysql"
       create_table :table_constraints do
         column :age, Integer
         constraint(:age_constraint) { age > 18 }

--- a/spec/support/fixtures/database_migrations/20150612124205_table_alterations.rb
+++ b/spec/support/fixtures/database_migrations/20150612124205_table_alterations.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
-    case ENV['HANAMI_DATABASE_TYPE']
-    when 'sqlite'
+    case ENV["HANAMI_DATABASE_TYPE"]
+    when "sqlite"
       create_table :songs do
         column :title, String
         column :useless, String
@@ -19,7 +21,7 @@ Hanami::Model.migration do
         set_column_type :useless,         File
 
         rename_column :title, :primary_title
-        set_column_default :primary_title, 'Unknown title'
+        set_column_default :primary_title, "Unknown title"
 
         # add_index :album_id
         # drop_index :artist_id
@@ -34,7 +36,7 @@ Hanami::Model.migration do
         drop_constraint :useless_min_length
         drop_column     :useless
       end
-    when 'postgresql'
+    when "postgresql"
       create_table :songs do
         column :title, String
         column :useless, String
@@ -52,7 +54,7 @@ Hanami::Model.migration do
         # set_column_type :useless, File
 
         rename_column :title, :primary_title
-        set_column_default :primary_title, 'Unknown title'
+        set_column_default :primary_title, "Unknown title"
 
         # add_index :album_id
         # drop_index :artist_id

--- a/spec/support/fixtures/database_migrations/20160830094800_create_users.rb
+++ b/spec/support/fixtures/database_migrations/20160830094800_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :users

--- a/spec/support/fixtures/database_migrations/20160830094851_create_authors.rb
+++ b/spec/support/fixtures/database_migrations/20160830094851_create_authors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :authors

--- a/spec/support/fixtures/database_migrations/20160830094941_create_books.rb
+++ b/spec/support/fixtures/database_migrations/20160830094941_create_books.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :books

--- a/spec/support/fixtures/database_migrations/20160830095033_create_t_operator.rb
+++ b/spec/support/fixtures/database_migrations/20160830095033_create_t_operator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :t_operator

--- a/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
+++ b/spec/support/fixtures/database_migrations/20160905125728_create_source_files.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     case Database.engine
     when :postgresql
       create_table :source_files do
-        column :id,         'uuid',   primary_key: true, default: Hanami::Model::Sql.function(:uuid_generate_v4)
+        column :id,         "uuid",   primary_key: true, default: Hanami::Model::Sql.function(:uuid_generate_v4)
         column :name,       String,   null: false
-        column :languages,  'text[]'
-        column :metadata,   'jsonb', null: false
-        column :json_info,  'json'
+        column :languages,  "text[]"
+        column :metadata,   "jsonb", null: false
+        column :json_info,  "json"
         column :content,    File,     null: false
         column :created_at, DateTime, null: false
         column :updated_at, DateTime, null: false

--- a/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
+++ b/spec/support/fixtures/database_migrations/20160909150704_create_avatars.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :avatars

--- a/spec/support/fixtures/database_migrations/20161104143844_create_warehouses.rb
+++ b/spec/support/fixtures/database_migrations/20161104143844_create_warehouses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :warehouses

--- a/spec/support/fixtures/database_migrations/20161114094644_create_products.rb
+++ b/spec/support/fixtures/database_migrations/20161114094644_create_products.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     case Database.engine
@@ -5,7 +7,7 @@ Hanami::Model.migration do
       create_table :products do
         primary_key :id
         column :name,       String
-        column :categories, 'text[]'
+        column :categories, "text[]"
       end
     else
       create_table :products do

--- a/spec/support/fixtures/database_migrations/20170103142428_create_colors.rb
+++ b/spec/support/fixtures/database_migrations/20170103142428_create_colors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     case Database.engine

--- a/spec/support/fixtures/database_migrations/20170124081339_create_labels.rb
+++ b/spec/support/fixtures/database_migrations/20170124081339_create_labels.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     create_table :labels do

--- a/spec/support/fixtures/database_migrations/20170517115243_create_tokens.rb
+++ b/spec/support/fixtures/database_migrations/20170517115243_create_tokens.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :tokens

--- a/spec/support/fixtures/database_migrations/20170519172332_create_categories.rb
+++ b/spec/support/fixtures/database_migrations/20170519172332_create_categories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :categories

--- a/spec/support/fixtures/database_migrations/20171002201227_create_posts_and_comments.rb
+++ b/spec/support/fixtures/database_migrations/20171002201227_create_posts_and_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   change do
     drop_table?   :posts

--- a/spec/support/fixtures/migrations/20160831073534_create_reviews.rb
+++ b/spec/support/fixtures/migrations/20160831073534_create_reviews.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   up do
     create_table :reviews do

--- a/spec/support/fixtures/migrations/20160831090612_add_rating_to_reviews.rb
+++ b/spec/support/fixtures/migrations/20160831090612_add_rating_to_reviews.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 Hanami::Model.migration do
   up do
-    add_column :reviews, :rating, 'integer', default: 0
+    add_column :reviews, :rating, "integer", default: 0
   end
 
   down do

--- a/spec/support/platform.rb
+++ b/spec/support/platform.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 module Platform
-  require_relative 'platform/os'
-  require_relative 'platform/engine'
-  require_relative 'platform/db'
-  require_relative 'platform/matcher'
+  require_relative "platform/os"
+  require_relative "platform/engine"
+  require_relative "platform/db"
+  require_relative "platform/matcher"
 
   def self.ci?
-    ENV['TRAVIS'] == 'true'
+    ENV["TRAVIS"] == "true"
   end
 
   def self.match(&blk)

--- a/spec/support/platform/db.rb
+++ b/spec/support/platform/db.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Platform
   module Db
     def self.db?(name)

--- a/spec/support/platform/engine.rb
+++ b/spec/support/platform/engine.rb
@@ -1,4 +1,6 @@
-require 'hanami/utils'
+# frozen_string_literal: true
+
+require "hanami/utils"
 
 module Platform
   module Engine
@@ -16,7 +18,7 @@ module Platform
       private
 
       def ruby?
-        RUBY_ENGINE == 'ruby'
+        RUBY_ENGINE == "ruby"
       end
 
       def jruby?

--- a/spec/support/platform/matcher.rb
+++ b/spec/support/platform/matcher.rb
@@ -1,4 +1,6 @@
-require 'hanami/utils/basic_object'
+# frozen_string_literal: true
+
+require "hanami/utils/basic_object"
 
 module Platform
   class Matcher

--- a/spec/support/platform/os.rb
+++ b/spec/support/platform/os.rb
@@ -1,4 +1,6 @@
-require 'rbconfig'
+# frozen_string_literal: true
+
+require "rbconfig"
 
 module Platform
   module Os
@@ -7,7 +9,7 @@ module Platform
     end
 
     def self.current
-      case RbConfig::CONFIG['host_os']
+      case RbConfig::CONFIG["host_os"]
       when /linux/  then :linux
       when /darwin/ then :macos
       end

--- a/spec/support/test_io.rb
+++ b/spec/support/test_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TestIO
   def self.with_stdout
     stdout = $stdout
@@ -9,6 +11,6 @@ module TestIO
   end
 
   def self.stream
-    File.new(ENV['HANAMI_DATABASE_LOGGER'], "a+")
+    File.new(ENV["HANAMI_DATABASE_LOGGER"], "a+")
   end
 end

--- a/spec/unit/hanami/entity/automatic_schema_spec.rb
+++ b/spec/unit/hanami/entity/automatic_schema_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity do
-  describe 'automatic schema' do
+  describe "automatic schema" do
     let(:described_class) { Author }
 
     let(:input) do
@@ -10,43 +12,43 @@ RSpec.describe Hanami::Entity do
       end.new
     end
 
-    describe '#initialize' do
-      it 'can be instantiated without attributes' do
+    describe "#initialize" do
+      it "can be instantiated without attributes" do
         entity = described_class.new
 
         expect(entity).to be_a_kind_of(described_class)
       end
 
-      it 'accepts a hash' do
-        entity = described_class.new(id: 1, name: 'Luca', books: books = [Book.new], created_at: now = Time.now.utc)
+      it "accepts a hash" do
+        entity = described_class.new(id: 1, name: "Luca", books: books = [Book.new], created_at: now = Time.now.utc)
 
         expect(entity.id).to eq(1)
-        expect(entity.name).to eq('Luca')
+        expect(entity.name).to eq("Luca")
         expect(entity.books).to eq(books)
         expect(entity.created_at).to be_within(2).of(now)
       end
 
-      it 'accepts object that implements #to_hash' do
+      it "accepts object that implements #to_hash" do
         entity = described_class.new(input)
 
         expect(entity.id).to eq(1)
       end
 
-      it 'freezes the instance' do
+      it "freezes the instance" do
         entity = described_class.new
 
         expect(entity).to be_frozen
       end
 
-      it 'coerces values' do
+      it "coerces values" do
         now = Time.now
         entity = described_class.new(created_at: now.to_s)
 
         expect(entity.created_at).to be_within(2).of(now)
       end
 
-      it 'coerces values for array of objects' do
-        entity = described_class.new(books: books = [{ title: 'TDD' }, { title: 'Refactoring' }])
+      it "coerces values for array of objects" do
+        entity = described_class.new(books: books = [{ title: "TDD" }, { title: "Refactoring" }])
 
         books.each_with_index do |book, i|
           b = entity.books[i]
@@ -56,45 +58,45 @@ RSpec.describe Hanami::Entity do
         end
       end
 
-      it 'raises error if initialized with wrong array object' do
+      it "raises error if initialized with wrong array object" do
         object = Object.new
         expect { described_class.new(books: [object]) }.to raise_error do |error|
           expect(error).to be_a(TypeError)
-          expect(error.message).to include('[#<Object:0x')
-          expect(error.message).to include('>] (Array) has invalid type for :books')
+          expect(error.message).to include("[#<Object:0x")
+          expect(error.message).to include(">] (Array) has invalid type for :books")
         end
       end
     end
 
-    describe '#id' do
-      it 'returns the value' do
+    describe "#id" do
+      it "returns the value" do
         entity = described_class.new(id: 1)
 
         expect(entity.id).to eq(1)
       end
 
-      it 'returns nil if not present in attributes' do
+      it "returns nil if not present in attributes" do
         entity = described_class.new
 
         expect(entity.id).to be_nil
       end
     end
 
-    describe 'accessors' do
-      it 'exposes accessors from schema' do
-        entity = described_class.new(name: 'Luca')
+    describe "accessors" do
+      it "exposes accessors from schema" do
+        entity = described_class.new(name: "Luca")
 
-        expect(entity.name).to eq('Luca')
+        expect(entity.name).to eq("Luca")
       end
 
-      it 'raises error for unknown methods' do
+      it "raises error for unknown methods" do
         entity = described_class.new
 
         expect { entity.foo }
           .to raise_error(NoMethodError, /undefined method `foo'/)
       end
 
-      it 'raises error when #attributes is invoked' do
+      it "raises error when #attributes is invoked" do
         entity = described_class.new
 
         expect { entity.attributes }
@@ -102,54 +104,54 @@ RSpec.describe Hanami::Entity do
       end
     end
 
-    describe '#to_h' do
-      it 'serializes attributes into hash' do
-        entity = described_class.new(id: 1, name: 'Luca')
+    describe "#to_h" do
+      it "serializes attributes into hash" do
+        entity = described_class.new(id: 1, name: "Luca")
 
-        expect(entity.to_h).to eq(Hash[id: 1, name: 'Luca'])
+        expect(entity.to_h).to eq(Hash[id: 1, name: "Luca"])
       end
 
-      it 'must be an instance of ::Hash' do
+      it "must be an instance of ::Hash" do
         entity = described_class.new
 
         expect(entity.to_h).to be_an_instance_of(::Hash)
       end
 
-      it 'ignores unknown attributes' do
-        entity = described_class.new(foo: 'bar')
+      it "ignores unknown attributes" do
+        entity = described_class.new(foo: "bar")
 
         expect(entity.to_h).to eq(Hash[])
       end
 
-      it 'prevents information escape' do
+      it "prevents information escape" do
         entity = described_class.new(books: books = [Book.new(id: 1), Book.new(id: 2)])
 
         entity.to_h[:books].reverse!
         expect(entity.books).to eq(books)
       end
 
-      it 'is aliased as #to_hash' do
-        entity = described_class.new(name: 'Luca')
+      it "is aliased as #to_hash" do
+        entity = described_class.new(name: "Luca")
 
         expect(entity.to_hash).to eq(entity.to_h)
       end
     end
 
-    describe '#respond_to?' do
-      it 'returns ture for id' do
+    describe "#respond_to?" do
+      it "returns ture for id" do
         entity = described_class.new
 
         expect(entity).to respond_to(:id)
       end
 
-      it 'returns true for methods with the same name of attributes defined by schema' do
+      it "returns true for methods with the same name of attributes defined by schema" do
         entity = described_class.new
 
         expect(entity).to respond_to(:name)
       end
 
-      it 'returns false for methods not in the set of attributes defined by schema' do
-        entity = described_class.new(foo: 'bar')
+      it "returns false for methods not in the set of attributes defined by schema" do
+        entity = described_class.new(foo: "bar")
 
         expect(entity).to_not respond_to(:foo)
       end

--- a/spec/unit/hanami/entity/manual_schema/base_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/base_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity do
-  describe 'manual schema (base)' do
+  describe "manual schema (base)" do
     let(:described_class) { Account }
 
     let(:input) do
@@ -10,38 +12,38 @@ RSpec.describe Hanami::Entity do
       end.new
     end
 
-    describe '#initialize' do
-      it 'can be instantiated without attributes' do
+    describe "#initialize" do
+      it "can be instantiated without attributes" do
         entity = described_class.new
 
         expect(entity).to be_a_kind_of(described_class)
       end
 
-      it 'accepts a hash' do
-        entity = described_class.new(id: 1, owner: owner = User.new(name: "MG"), users: users = [User.new], name: 'Acme Inc.', codes: [1, 2, 3], email: 'account@acme-inc.test', created_at: now = DateTime.now)
+      it "accepts a hash" do
+        entity = described_class.new(id: 1, owner: owner = User.new(name: "MG"), users: users = [User.new], name: "Acme Inc.", codes: [1, 2, 3], email: "account@acme-inc.test", created_at: now = DateTime.now)
 
         expect(entity.id).to eq(1)
-        expect(entity.name).to eq('Acme Inc.')
+        expect(entity.name).to eq("Acme Inc.")
         expect(entity.owner).to eq(owner)
         expect(entity.users).to eq(users)
         expect(entity.codes).to eq([1, 2, 3])
-        expect(entity.email).to eq('account@acme-inc.test')
+        expect(entity.email).to eq("account@acme-inc.test")
         expect(entity.created_at).to be_within(1).of(now)
       end
 
-      it 'accepts object that implements #to_hash' do
+      it "accepts object that implements #to_hash" do
         entity = described_class.new(input)
 
         expect(entity.id).to eq(1)
       end
 
-      it 'freezes the instance' do
+      it "freezes the instance" do
         entity = described_class.new
 
         expect(entity).to be_frozen
       end
 
-      it 'coerces values' do
+      it "coerces values" do
         now = DateTime.now
         entity = described_class.new(created_at: now.to_s)
 
@@ -49,21 +51,21 @@ RSpec.describe Hanami::Entity do
         expect(entity.created_at).to be_within(1).of(now)
       end
 
-      it 'coerces values for array of primitives' do
+      it "coerces values for array of primitives" do
         entity = described_class.new(codes: %w[4 5 6])
 
         expect(entity.codes).to eq([4, 5, 6])
       end
 
-      it 'coerces values for single object' do
-        entity = described_class.new(owner: owner = { name: 'L' })
+      it "coerces values for single object" do
+        entity = described_class.new(owner: owner = { name: "L" })
 
         expect(entity.owner).to be_a_kind_of(User)
         expect(entity.owner.name).to eq(owner.fetch(:name))
       end
 
-      it 'coerces values for array of objects' do
-        entity = described_class.new(users: users = [{ name: 'L' }, { name: 'MG' }])
+      it "coerces values for array of objects" do
+        entity = described_class.new(users: users = [{ name: "L" }, { name: "MG" }])
 
         users.each_with_index do |user, i|
           u = entity.users[i]
@@ -73,12 +75,12 @@ RSpec.describe Hanami::Entity do
         end
       end
 
-      it 'raises error if initialized with wrong primitive' do
+      it "raises error if initialized with wrong primitive" do
         expect { described_class.new(id: :foo) }
-          .to raise_error(TypeError, ':foo (Symbol) has invalid type for :id violates constraints (type?(Integer, :foo) failed)')
+          .to raise_error(TypeError, ":foo (Symbol) has invalid type for :id violates constraints (type?(Integer, :foo) failed)")
       end
 
-      it 'raises error if initialized with wrong array primitive' do
+      it "raises error if initialized with wrong array primitive" do
         message = Platform.match do
           engine(:jruby) { "no implicit conversion of Object into Integer" }
           default        { "can't convert Object into Integer" }
@@ -88,70 +90,70 @@ RSpec.describe Hanami::Entity do
       end
 
       it "raises error if type constraint isn't honored" do
-        expect { described_class.new(email: 'test') }
+        expect { described_class.new(email: "test") }
           .to raise_error(TypeError, '"test" (String) has invalid type for :email violates constraints (format?(/@/, "test") failed)')
       end
 
       it "doesn't override manual defined schema" do
-        expect { Warehouse.new(code: 'foo') }
+        expect { Warehouse.new(code: "foo") }
           .to raise_error(TypeError, '"foo" (String) has invalid type for :code violates constraints (format?(/\Awh\-/, "foo") failed)')
       end
 
-      it 'symbolizes nested hash keys according to schema' do
+      it "symbolizes nested hash keys according to schema" do
         entity = PageVisit.new(
           id: 42,
           start: DateTime.now,
           end: (Time.now + 53).to_datetime,
           visitor: {
-            'user_agent' => 'w3m/0.5.3', 'language' => { 'en' => 0.9 }
+            "user_agent" => "w3m/0.5.3", "language" => { "en" => 0.9 }
           },
           page_info: {
-            'name' => 'landing page',
+            "name" => "landing page",
             scroll_depth: 0.7,
-            'meta' => { 'version' => '0.8.3', updated_at: 1_492_769_467_000 }
+            "meta" => { "version" => "0.8.3", updated_at: 1_492_769_467_000 }
           }
         )
 
         expect(entity.visitor).to eq(
-          user_agent: 'w3m/0.5.3', language: { en: 0.9 }
+          user_agent: "w3m/0.5.3", language: { en: 0.9 }
         )
         expect(entity.page_info).to eq(
-          name: 'landing page',
+          name: "landing page",
           scroll_depth: 0.7,
-          meta: { version: '0.8.3', updated_at: 1_492_769_467_000 }
+          meta: { version: "0.8.3", updated_at: 1_492_769_467_000 }
         )
       end
     end
 
-    describe '#id' do
-      it 'returns the value' do
+    describe "#id" do
+      it "returns the value" do
         entity = described_class.new(id: 1)
 
         expect(entity.id).to eq(1)
       end
 
-      it 'returns nil if not present in attributes' do
+      it "returns nil if not present in attributes" do
         entity = described_class.new
 
         expect(entity.id).to be_nil
       end
     end
 
-    describe 'accessors' do
-      it 'exposes accessors from schema' do
-        entity = described_class.new(name: 'Acme Inc.')
+    describe "accessors" do
+      it "exposes accessors from schema" do
+        entity = described_class.new(name: "Acme Inc.")
 
-        expect(entity.name).to eq('Acme Inc.')
+        expect(entity.name).to eq("Acme Inc.")
       end
 
-      it 'raises error for unknown methods' do
+      it "raises error for unknown methods" do
         entity = described_class.new
 
         expect { entity.foo }
           .to raise_error(NoMethodError, /undefined method `foo'/)
       end
 
-      it 'raises error when #attributes is invoked' do
+      it "raises error when #attributes is invoked" do
         entity = described_class.new
 
         expect { entity.attributes }
@@ -159,54 +161,54 @@ RSpec.describe Hanami::Entity do
       end
     end
 
-    describe '#to_h' do
-      it 'serializes attributes into hash' do
-        entity = described_class.new(id: 1, name: 'Acme Inc.')
+    describe "#to_h" do
+      it "serializes attributes into hash" do
+        entity = described_class.new(id: 1, name: "Acme Inc.")
 
-        expect(entity.to_h).to eq(Hash[id: 1, name: 'Acme Inc.'])
+        expect(entity.to_h).to eq(Hash[id: 1, name: "Acme Inc."])
       end
 
-      it 'must be an instance of ::Hash' do
+      it "must be an instance of ::Hash" do
         entity = described_class.new
 
         expect(entity.to_h).to be_an_instance_of(::Hash)
       end
 
-      it 'ignores unknown attributes' do
-        entity = described_class.new(foo: 'bar')
+      it "ignores unknown attributes" do
+        entity = described_class.new(foo: "bar")
 
         expect(entity.to_h).to eq(Hash[])
       end
 
-      it 'prevents information escape' do
+      it "prevents information escape" do
         entity = described_class.new(users: users = [User.new(id: 1), User.new(id: 2)])
 
         entity.to_h[:users].reverse!
         expect(entity.users).to eq(users)
       end
 
-      it 'is aliased as #to_hash' do
-        entity = described_class.new(name: 'Acme Inc.')
+      it "is aliased as #to_hash" do
+        entity = described_class.new(name: "Acme Inc.")
 
         expect(entity.to_hash).to eq(entity.to_h)
       end
     end
 
-    describe '#respond_to?' do
-      it 'returns ture for id' do
+    describe "#respond_to?" do
+      it "returns ture for id" do
         entity = described_class.new
 
         expect(entity).to respond_to(:id)
       end
 
-      it 'returns true for methods with the same name of attributes defined by schema' do
+      it "returns true for methods with the same name of attributes defined by schema" do
         entity = described_class.new
 
         expect(entity).to respond_to(:name)
       end
 
-      it 'returns false for methods not in the set of attributes defined by schema' do
-        entity = described_class.new(foo: 'bar')
+      it "returns false for methods not in the set of attributes defined by schema" do
+        entity = described_class.new(foo: "bar")
 
         expect(entity).to_not respond_to(:foo)
       end

--- a/spec/unit/hanami/entity/manual_schema/strict_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/strict_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity do
-  describe 'manual schema (strict)' do
+  describe "manual schema (strict)" do
     let(:described_class) { Person }
 
     let(:input) do
@@ -10,7 +12,7 @@ RSpec.describe Hanami::Entity do
       end.new
     end
 
-    describe '#initialize' do
+    describe "#initialize" do
       it "can't be instantiated without attributes" do
         expect { described_class.new }.to raise_error(ArgumentError, ":id is missing in Hash input")
       end
@@ -34,14 +36,14 @@ RSpec.describe Hanami::Entity do
         expect(entity.name).to eq("Luca")
       end
 
-      it 'accepts object that implements #to_hash' do
+      it "accepts object that implements #to_hash" do
         entity = described_class.new(input)
 
         expect(entity.id).to   eq(2)
         expect(entity.name).to eq("MG")
       end
 
-      it 'freezes the instance' do
+      it "freezes the instance" do
         entity = described_class.new(id: 1, name: "Luca")
 
         expect(entity).to be_frozen

--- a/spec/unit/hanami/entity/manual_schema/types_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/types_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity do
-  describe 'manual schema (types)' do
+  describe "manual schema (types)" do
     [nil, :schema, :strict, :weak, :permissive, :strict_with_defaults, :symbolized].each do |type|
       it "allows to build schema with #{type.inspect}" do
         Class.new(described_class) do

--- a/spec/unit/hanami/entity/schema/definition_spec.rb
+++ b/spec/unit/hanami/entity/schema/definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity::Schema::Definition do
   let(:described_class) { Hanami::Entity::Schema::Definition }
   let(:subject) do
@@ -6,8 +8,8 @@ RSpec.describe Hanami::Entity::Schema::Definition do
     end
   end
 
-  describe '#initialize' do
-    it 'returns frozen instance' do
+  describe "#initialize" do
+    it "returns frozen instance" do
       subject = described_class.new {}
 
       expect(subject).to be_frozen
@@ -18,26 +20,26 @@ RSpec.describe Hanami::Entity::Schema::Definition do
     end
   end
 
-  describe '#call' do
-    it 'returns empty hash when nil is given' do
+  describe "#call" do
+    it "returns empty hash when nil is given" do
       result = subject.call(nil)
 
       expect(result).to eq({})
     end
 
-    it 'processes attributes' do
+    it "processes attributes" do
       result = subject.call(id: 1)
 
       expect(result).to eq(id: 1)
     end
 
-    it 'ignores unknown attributes' do
-      result = subject.call(foo: 'bar')
+    it "ignores unknown attributes" do
+      result = subject.call(foo: "bar")
 
       expect(result).to eq({})
     end
 
-    it 'raises error if the process fails' do
+    it "raises error if the process fails" do
       message = Platform.match do
         engine(:jruby) { "no implicit conversion of Symbol into Integer" }
         default        { "can't convert Symbol into Integer" }
@@ -47,12 +49,12 @@ RSpec.describe Hanami::Entity::Schema::Definition do
     end
   end
 
-  describe '#attribute?' do
-    it 'returns true for known attributes' do
+  describe "#attribute?" do
+    it "returns true for known attributes" do
       expect(subject.attribute?(:id)).to eq(true)
     end
 
-    it 'returns false for unknown attributes' do
+    it "returns false for unknown attributes" do
       expect(subject.attribute?(:foo)).to eq(false)
     end
   end

--- a/spec/unit/hanami/entity/schema/schemaless_spec.rb
+++ b/spec/unit/hanami/entity/schema/schemaless_spec.rb
@@ -1,21 +1,23 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity::Schema::Schemaless do
   let(:subject) { Hanami::Entity::Schema::Schemaless.new }
 
-  describe '#initialize' do
-    it 'returns frozen instance' do
+  describe "#initialize" do
+    it "returns frozen instance" do
       expect(subject).to be_frozen
     end
   end
 
-  describe '#call' do
-    it 'returns empty hash when nil is given' do
+  describe "#call" do
+    it "returns empty hash when nil is given" do
       result = subject.call(nil)
 
       expect(result).to eq({})
     end
 
-    it 'returns duped hash' do
-      input = { foo: 'bar' }
+    it "returns duped hash" do
+      input = { foo: "bar" }
       result = subject.call(input)
 
       expect(result).to eq(input)
@@ -23,8 +25,8 @@ RSpec.describe Hanami::Entity::Schema::Schemaless do
     end
   end
 
-  describe '#attribute?' do
-    it 'always returns true' do
+  describe "#attribute?" do
+    it "always returns true" do
       expect(subject.attribute?(:foo)).to eq(true)
     end
   end

--- a/spec/unit/hanami/entity/schema_spec.rb
+++ b/spec/unit/hanami/entity/schema_spec.rb
@@ -1,51 +1,53 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity::Schema do
   let(:described_class) { Hanami::Entity::Schema }
 
-  describe 'without definition' do
+  describe "without definition" do
     let(:subject) { described_class.new }
 
-    describe '#call' do
-      it 'processes attributes' do
-        result = subject.call('foo' => 'bar')
+    describe "#call" do
+      it "processes attributes" do
+        result = subject.call("foo" => "bar")
 
-        expect(result).to eq(foo: 'bar')
+        expect(result).to eq(foo: "bar")
       end
     end
 
-    describe '#attribute?' do
-      it 'always returns true' do
+    describe "#attribute?" do
+      it "always returns true" do
         expect(subject.attribute?(:foo)).to eq true
       end
     end
   end
 
-  describe 'with definition' do
+  describe "with definition" do
     let(:subject) do
       described_class.new do
         attribute :id, Hanami::Model::Types::Coercible::Int
       end
     end
 
-    describe '#call' do
-      it 'processes attributes' do
-        result = subject.call(id: '1')
+    describe "#call" do
+      it "processes attributes" do
+        result = subject.call(id: "1")
 
         expect(result).to eq(id: 1)
       end
 
-      it 'ignores unknown attributes' do
-        result = subject.call(foo: 'bar')
+      it "ignores unknown attributes" do
+        result = subject.call(foo: "bar")
 
         expect(result).to eq({})
       end
     end
 
-    describe '#attribute?' do
-      it 'returns true for known attributes' do
+    describe "#attribute?" do
+      it "returns true for known attributes" do
         expect(subject.attribute?(:id)).to eq true
       end
 
-      it 'returns false for unknown attributes' do
+      it "returns false for unknown attributes" do
         expect(subject.attribute?(:foo)).to eq false
       end
     end

--- a/spec/unit/hanami/entity/schemaless_spec.rb
+++ b/spec/unit/hanami/entity/schemaless_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Entity do
-  describe 'schemaless' do
+  describe "schemaless" do
     let(:described_class) do
       Class.new(Hanami::Entity)
     end
@@ -12,109 +14,109 @@ RSpec.describe Hanami::Entity do
       end.new
     end
 
-    describe '#initialize' do
-      it 'can be instantiated without attributes' do
+    describe "#initialize" do
+      it "can be instantiated without attributes" do
         entity = described_class.new
 
         expect(entity).to be_a_kind_of(described_class)
       end
 
-      it 'accepts a hash' do
-        entity = described_class.new(foo: 1, 'bar' => 2)
+      it "accepts a hash" do
+        entity = described_class.new(foo: 1, "bar" => 2)
 
         expect(entity.foo).to eq(1)
         expect(entity.bar).to eq(2)
       end
 
-      it 'accepts object that implements #to_hash' do
+      it "accepts object that implements #to_hash" do
         entity = described_class.new(input)
 
         expect(entity.a).to eq(1)
       end
 
-      it 'freezes the instance' do
+      it "freezes the instance" do
         entity = described_class.new
 
         expect(entity).to be_frozen
       end
     end
 
-    describe '#id' do
-      it 'returns the value' do
+    describe "#id" do
+      it "returns the value" do
         entity = described_class.new(id: 1)
 
         expect(entity.id).to eq(1)
       end
 
-      it 'returns nil if not present in attributes' do
+      it "returns nil if not present in attributes" do
         entity = described_class.new
 
         expect(entity.id).to be_nil
       end
     end
 
-    describe 'accessors' do
-      it 'exposes accessors for given keys' do
-        entity = described_class.new(name: 'Luca')
+    describe "accessors" do
+      it "exposes accessors for given keys" do
+        entity = described_class.new(name: "Luca")
 
-        expect(entity.name).to eq('Luca')
+        expect(entity.name).to eq("Luca")
       end
 
-      it 'returns nil for unknown methods' do
+      it "returns nil for unknown methods" do
         entity = described_class.new
 
         expect(entity.foo).to be_nil
       end
 
-      it 'returns nil for #attributes' do
+      it "returns nil for #attributes" do
         entity = described_class.new
 
         expect(entity.attributes).to be_nil
       end
     end
 
-    describe '#to_h' do
-      it 'serializes attributes into hash' do
-        entity = described_class.new(foo: 1, 'bar' => { 'baz' => 2 })
+    describe "#to_h" do
+      it "serializes attributes into hash" do
+        entity = described_class.new(foo: 1, "bar" => { "baz" => 2 })
 
         expect(entity.to_h).to eq(Hash[foo: 1, bar: { baz: 2 }])
       end
 
-      it 'must be an instance of ::Hash' do
+      it "must be an instance of ::Hash" do
         entity = described_class.new
 
         expect(entity.to_h).to be_an_instance_of(::Hash)
       end
 
-      it 'prevents information escape' do
+      it "prevents information escape" do
         entity = described_class.new(a: [1, 2, 3])
 
         entity.to_h[:a].reverse!
         expect(entity.a).to eq([1, 2, 3])
       end
 
-      it 'is aliased as #to_hash' do
-        entity = described_class.new(foo: 'bar')
+      it "is aliased as #to_hash" do
+        entity = described_class.new(foo: "bar")
 
         expect(entity.to_h).to eq(entity.to_hash)
       end
     end
 
-    describe '#respond_to?' do
-      it 'returns ture for id' do
+    describe "#respond_to?" do
+      it "returns ture for id" do
         entity = described_class.new
 
         expect(entity).to respond_to(:id)
       end
 
-      it 'returns true for present keys' do
-        entity = described_class.new(foo: 1, 'bar' => 2)
+      it "returns true for present keys" do
+        entity = described_class.new(foo: 1, "bar" => 2)
 
         expect(entity).to respond_to(:foo)
         expect(entity).to respond_to(:bar)
       end
 
-      it 'returns false for missing keys' do
+      it "returns false for missing keys" do
         entity = described_class.new
 
         expect(entity).to respond_to(:baz)

--- a/spec/unit/hanami/entity_spec.rb
+++ b/spec/unit/hanami/entity_spec.rb
@@ -1,40 +1,42 @@
-require 'ostruct'
+# frozen_string_literal: true
+
+require "ostruct"
 
 RSpec.describe Hanami::Entity do
   let(:described_class) do
     Class.new(Hanami::Entity)
   end
 
-  describe 'equality' do
-    it 'returns true if same class and same id' do
+  describe "equality" do
+    it "returns true if same class and same id" do
       entity1 = described_class.new(id: 1)
       entity2 = described_class.new(id: 1)
 
       expect(entity1).to eq(entity2), "Expected #{entity1.inspect} to equal #{entity2.inspect}"
     end
 
-    it 'returns false if same class but different id' do
+    it "returns false if same class but different id" do
       entity1 = described_class.new(id: 1)
       entity2 = described_class.new(id: 1000)
 
       expect(entity1).to_not eq(entity2), "Expected #{entity1.inspect} to NOT equal #{entity2.inspect}"
     end
 
-    it 'returns false if different class but same id' do
+    it "returns false if different class but same id" do
       entity1 = described_class.new(id: 1)
       entity2 = OpenStruct.new(id: 1)
 
       expect(entity1).to_not eq(entity2), "Expected #{entity1.inspect} to NOT equal #{entity2.inspect}"
     end
 
-    it 'returns false if different class and different id' do
+    it "returns false if different class and different id" do
       entity1 = described_class.new(id: 1)
       entity2 = OpenStruct.new(id: 1000)
 
       expect(entity1).to_not eq(entity2), "Expected #{entity1.inspect} to NOT equal #{entity2.inspect}"
     end
 
-    it 'returns true when both the ids are nil' do
+    it "returns true when both the ids are nil" do
       entity1 = described_class.new
       entity2 = described_class.new
 
@@ -42,29 +44,29 @@ RSpec.describe Hanami::Entity do
     end
   end
 
-  describe '#hash' do
-    it 'returns predictable object hashing' do
+  describe "#hash" do
+    it "returns predictable object hashing" do
       entity1 = described_class.new(id: 1)
       entity2 = described_class.new(id: 1)
 
       expect(entity1.hash).to eq(entity2.hash), "Expected #{entity1.hash} to equal #{entity2.hash}"
     end
 
-    it 'returns different object hash for same class but different id' do
+    it "returns different object hash for same class but different id" do
       entity1 = described_class.new(id: 1)
       entity2 = described_class.new(id: 1000)
 
       expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
     end
 
-    it 'returns different object hash for different class but same id' do
+    it "returns different object hash for different class but same id" do
       entity1 = described_class.new(id: 1)
       entity2 = Class.new(Hanami::Entity).new(id: 1)
 
       expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
     end
 
-    it 'returns different object hash for different class and different id' do
+    it "returns different object hash for different class and different id" do
       entity1 = described_class.new(id: 1)
       entity2 = Class.new(Hanami::Entity).new(id: 2)
 

--- a/spec/unit/hanami/model/check_constraint_validation_error_spec.rb
+++ b/spec/unit/hanami/model/check_constraint_validation_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::CheckConstraintViolationError do
   it "inherits from Hanami::Model::ConstraintViolationError" do
     expect(described_class.ancestors).to include(Hanami::Model::ConstraintViolationError)

--- a/spec/unit/hanami/model/configuration_spec.rb
+++ b/spec/unit/hanami/model/configuration_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Configuration do
   before do
-    database_directory = Pathname.pwd.join('tmp', 'db')
-    database_directory.join('migrations').mkpath
+    database_directory = Pathname.pwd.join("tmp", "db")
+    database_directory.join("migrations").mkpath
 
-    FileUtils.touch database_directory.join('schema.sql')
+    FileUtils.touch database_directory.join("schema.sql")
   end
 
   let(:subject) { Hanami::Model::Configuration.new(configurator) }
@@ -14,13 +16,13 @@ RSpec.describe Hanami::Model::Configuration do
     Hanami::Model::Configurator.build do
       adapter :sql, adapter_url
 
-      migrations 'tmp/db/migrations'
-      schema     'tmp/db/schema.sql'
+      migrations "tmp/db/migrations"
+      schema     "tmp/db/schema.sql"
     end
   end
 
   let(:url) do
-    db = 'tmp/db/bookshelf.sqlite'
+    db = "tmp/db/bookshelf.sqlite"
 
     Platform.match do
       engine(:ruby)  { "sqlite://#{db}" }
@@ -28,14 +30,14 @@ RSpec.describe Hanami::Model::Configuration do
     end
   end
 
-  describe '#url' do
-    it 'equals to the configured url' do
+  describe "#url" do
+    it "equals to the configured url" do
       expect(subject.url).to eq(url)
     end
   end
 
-  describe '#connection' do
-    it 'returns a raw connection aganist the database' do
+  describe "#connection" do
+    it "returns a raw connection aganist the database" do
       connection = subject.connection
 
       expect(connection).to be_a_kind_of(Sequel::Database)
@@ -43,8 +45,8 @@ RSpec.describe Hanami::Model::Configuration do
     end
   end
 
-  describe '#gateway' do
-    it 'returns default ROM gateway' do
+  describe "#gateway" do
+    it "returns default ROM gateway" do
       gateway = subject.gateway
 
       expect(gateway).to be_a_kind_of(ROM::Gateway)
@@ -52,23 +54,23 @@ RSpec.describe Hanami::Model::Configuration do
     end
   end
 
-  describe '#root' do
-    it 'returns current directory' do
+  describe "#root" do
+    it "returns current directory" do
       expect(subject.root).to eq(Pathname.pwd)
     end
   end
 
-  describe '#migrations' do
-    it 'returns path to migrations' do
-      expected = subject.root.join('tmp', 'db', 'migrations')
+  describe "#migrations" do
+    it "returns path to migrations" do
+      expected = subject.root.join("tmp", "db", "migrations")
 
       expect(subject.migrations).to eq(expected)
     end
   end
 
-  describe '#schema' do
-    it 'returns path to database schema' do
-      expected = subject.root.join('tmp', 'db', 'schema.sql')
+  describe "#schema" do
+    it "returns path to database schema" do
+      expected = subject.root.join("tmp", "db", "schema.sql")
 
       expect(subject.schema).to eq(expected)
     end

--- a/spec/unit/hanami/model/constraint_violation_error_spec.rb
+++ b/spec/unit/hanami/model/constraint_violation_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::ConstraintViolationError do
   it "inherits from Hanami::Model::Error" do
     expect(described_class.ancestors).to include(Hanami::Model::Error)

--- a/spec/unit/hanami/model/disconnect_spec.rb
+++ b/spec/unit/hanami/model/disconnect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This test is tightly coupled to Sequel
 #
 # We should improve connection management via ROM

--- a/spec/unit/hanami/model/error_spec.rb
+++ b/spec/unit/hanami/model/error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Error do
   it "inherits from StandardError" do
     expect(described_class.ancestors).to include(StandardError)

--- a/spec/unit/hanami/model/foreign_key_constraint_violation_error_spec.rb
+++ b/spec/unit/hanami/model/foreign_key_constraint_violation_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::ForeignKeyConstraintViolationError do
   it "inherits from Hanami::Model::ConstraintViolationError" do
     expect(described_class.ancestors).to include(Hanami::Model::ConstraintViolationError)

--- a/spec/unit/hanami/model/load_spec.rb
+++ b/spec/unit/hanami/model/load_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model.load!" do
   let(:message) { "Cannot find corresponding type for form" }
 

--- a/spec/unit/hanami/model/mapped_relation_spec.rb
+++ b/spec/unit/hanami/model/mapped_relation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::MappedRelation do
   subject { described_class.new(relation) }
   let(:relation) { UserRepository.new.users }

--- a/spec/unit/hanami/model/migrator/adapter_spec.rb
+++ b/spec/unit/hanami/model/migrator/adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Migrator::Adapter do
   extend PlatformHelpers
 
@@ -12,7 +14,7 @@ RSpec.describe Hanami::Model::Migrator::Adapter do
     end
 
     let(:configuration) { instance_double("Hanami::Model::Configuration") }
-    let(:url)           { ENV['HANAMI_DATABASE_URL'] }
+    let(:url)           { ENV["HANAMI_DATABASE_URL"] }
 
     with_platform(db: :sqlite) do
       context "when sqlite" do

--- a/spec/unit/hanami/model/migrator/connection_spec.rb
+++ b/spec/unit/hanami/model/migrator/connection_spec.rb
@@ -1,82 +1,84 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Migrator::Connection do
   extend PlatformHelpers
 
   let(:connection) { Hanami::Model::Migrator::Connection.new(hanami_model_configuration) }
 
-  describe 'when not a jdbc connection' do
+  describe "when not a jdbc connection" do
     let(:hanami_model_configuration) { OpenStruct.new(url: url) }
     let(:url) { "postgresql://postgres:s3cr3T@127.0.0.1:5432/database" }
 
-    describe '#jdbc?' do
-      it 'returns false' do
+    describe "#jdbc?" do
+      it "returns false" do
         expect(connection.jdbc?).to eq(false)
       end
     end
 
-    describe '#global_uri' do
-      it 'returns connection URI without database' do
-        expect(connection.global_uri.scan('database').empty?).to eq(true)
+    describe "#global_uri" do
+      it "returns connection URI without database" do
+        expect(connection.global_uri.scan("database").empty?).to eq(true)
       end
     end
 
-    describe '#parsed_uri?' do
-      it 'returns an URI instance' do
+    describe "#parsed_uri?" do
+      it "returns an URI instance" do
         expect(connection.parsed_uri).to be_a_kind_of(URI)
       end
     end
 
-    describe '#host' do
-      it 'returns configured host' do
-        expect(connection.host).to eq('127.0.0.1')
+    describe "#host" do
+      it "returns configured host" do
+        expect(connection.host).to eq("127.0.0.1")
       end
     end
 
-    describe '#port' do
-      it 'returns configured port' do
+    describe "#port" do
+      it "returns configured port" do
         expect(connection.port).to eq(5432)
       end
     end
 
-    describe '#database' do
-      it 'returns configured database' do
-        expect(connection.database).to eq('database')
+    describe "#database" do
+      it "returns configured database" do
+        expect(connection.database).to eq("database")
       end
     end
 
-    describe '#user' do
-      it 'returns configured user' do
-        expect(connection.user).to eq('postgres')
+    describe "#user" do
+      it "returns configured user" do
+        expect(connection.user).to eq("postgres")
       end
 
-      describe 'when there is no user option' do
+      describe "when there is no user option" do
         let(:hanami_model_configuration) do
-          OpenStruct.new(url: 'postgresql://127.0.0.1:5432/database')
+          OpenStruct.new(url: "postgresql://127.0.0.1:5432/database")
         end
 
-        it 'returns nil' do
+        it "returns nil" do
           expect(connection.user).to be_nil
         end
       end
     end
 
-    describe '#password' do
-      it 'returns configured password' do
-        expect(connection.password).to eq('s3cr3T')
+    describe "#password" do
+      it "returns configured password" do
+        expect(connection.password).to eq("s3cr3T")
       end
 
-      describe 'when there is no password option' do
+      describe "when there is no password option" do
         let(:hanami_model_configuration) do
-          OpenStruct.new(url: 'postgresql://127.0.0.1/database')
+          OpenStruct.new(url: "postgresql://127.0.0.1/database")
         end
 
-        it 'returns nil' do
+        it "returns nil" do
           expect(connection.password).to be_nil
         end
       end
     end
 
     describe "#raw" do
-      let(:url) { ENV['HANAMI_DATABASE_URL'] }
+      let(:url) { ENV["HANAMI_DATABASE_URL"] }
 
       with_platform(db: :sqlite) do
         context "when sqlite" do
@@ -119,107 +121,107 @@ RSpec.describe Hanami::Model::Migrator::Connection do
     end
 
     # See https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-    describe 'when connection components in uri params' do
+    describe "when connection components in uri params" do
       let(:hanami_model_configuration) do
         OpenStruct.new(
-          url: 'postgresql:///mydb?host=localhost&port=6433&user=postgres&password=testpasswd'
+          url: "postgresql:///mydb?host=localhost&port=6433&user=postgres&password=testpasswd"
         )
       end
 
-      it 'returns configured database' do
-        expect(connection.database).to eq('mydb')
+      it "returns configured database" do
+        expect(connection.database).to eq("mydb")
       end
 
-      it 'returns configured user' do
-        expect(connection.user).to eq('postgres')
+      it "returns configured user" do
+        expect(connection.user).to eq("postgres")
       end
 
-      it 'returns configured password' do
-        expect(connection.password).to eq('testpasswd')
+      it "returns configured password" do
+        expect(connection.password).to eq("testpasswd")
       end
 
-      it 'returns configured host' do
-        expect(connection.host).to eq('localhost')
+      it "returns configured host" do
+        expect(connection.host).to eq("localhost")
       end
 
-      it 'returns configured port' do
+      it "returns configured port" do
         expect(connection.port).to eq(6433)
       end
 
-      describe 'with blank port' do
+      describe "with blank port" do
         let(:hanami_model_configuration) do
           OpenStruct.new(
-            url: 'postgresql:///mydb?host=localhost&port=&user=postgres&password=testpasswd'
+            url: "postgresql:///mydb?host=localhost&port=&user=postgres&password=testpasswd"
           )
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect(connection.port).to be_nil
         end
       end
     end
   end
 
-  describe 'when jdbc connection' do
+  describe "when jdbc connection" do
     let(:hanami_model_configuration) do
       OpenStruct.new(
-        url: 'jdbc:postgresql://127.0.0.1:5432/database?user=postgres&password=s3cr3T'
+        url: "jdbc:postgresql://127.0.0.1:5432/database?user=postgres&password=s3cr3T"
       )
     end
 
-    describe '#jdbc?' do
-      it 'returns true' do
+    describe "#jdbc?" do
+      it "returns true" do
         expect(connection.jdbc?).to eq(true)
       end
     end
 
-    describe '#host' do
-      it 'returns configured host' do
-        expect(connection.host).to eq('127.0.0.1')
+    describe "#host" do
+      it "returns configured host" do
+        expect(connection.host).to eq("127.0.0.1")
       end
     end
 
-    describe '#port' do
-      it 'returns configured port' do
+    describe "#port" do
+      it "returns configured port" do
         expect(connection.port).to eq(5432)
       end
     end
 
-    describe '#user' do
-      it 'returns configured user' do
-        expect(connection.user).to eq('postgres')
+    describe "#user" do
+      it "returns configured user" do
+        expect(connection.user).to eq("postgres")
       end
 
-      describe 'when there is no user option' do
+      describe "when there is no user option" do
         let(:hanami_model_configuration) do
-          OpenStruct.new(url: 'jdbc:postgresql://127.0.0.1/database')
+          OpenStruct.new(url: "jdbc:postgresql://127.0.0.1/database")
         end
 
-        it 'returns nil' do
+        it "returns nil" do
           expect(connection.user).to be_nil
         end
       end
     end
 
-    describe '#password' do
-      it 'returns configured password' do
-        expect(connection.password).to eq('s3cr3T')
+    describe "#password" do
+      it "returns configured password" do
+        expect(connection.password).to eq("s3cr3T")
       end
 
-      describe 'when there is no password option' do
+      describe "when there is no password option" do
         let(:hanami_model_configuration) do
-          OpenStruct.new(url: 'jdbc:postgresql://127.0.0.1/database')
+          OpenStruct.new(url: "jdbc:postgresql://127.0.0.1/database")
         end
 
-        it 'returns nil' do
+        it "returns nil" do
           expect(connection.password).to be_nil
         end
       end
     end
 
-    describe '#database' do
-      it 'returns configured database' do
-        expect(connection.database).to eq('database')
+    describe "#database" do
+      it "returns configured database" do
+        expect(connection.database).to eq("database")
       end
     end
   end

--- a/spec/unit/hanami/model/migrator/mysql.rb
+++ b/spec/unit/hanami/model/migrator/mysql.rb
@@ -1,7 +1,9 @@
-require 'ostruct'
-require 'securerandom'
+# frozen_string_literal: true
 
-RSpec.shared_examples 'migrator_mysql' do
+require "ostruct"
+require "securerandom"
+
+RSpec.shared_examples "migrator_mysql" do
   let(:migrator) do
     Hanami::Model::Migrator.new(configuration: configuration)
   end
@@ -9,9 +11,9 @@ RSpec.shared_examples 'migrator_mysql' do
   let(:random) { SecureRandom.hex(4) }
 
   # General variables
-  let(:migrations)     { Pathname.new(__dir__ + '/../../../../support/fixtures/migrations') }
+  let(:migrations)     { Pathname.new(__dir__ + "/../../../../support/fixtures/migrations") }
   let(:schema)         { nil }
-  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV['HANAMI_DATABASE_LOGGER'])) }
+  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV["HANAMI_DATABASE_LOGGER"])) }
   let(:configuration)  { Hanami::Model::Configuration.new(config) }
 
   # Variables for `apply` and `prepare`
@@ -23,7 +25,7 @@ RSpec.shared_examples 'migrator_mysql' do
     migrator.drop rescue nil # rubocop:disable Style/RescueModifier
   end
 
-  describe 'MySQL' do
+  describe "MySQL" do
     let(:database) { "mysql_#{random}" }
 
     let(:url) do
@@ -35,8 +37,8 @@ RSpec.shared_examples 'migrator_mysql' do
       end
     end
 
-    describe 'create' do
-      it 'creates the database' do
+    describe "create" do
+      it "creates the database" do
         migrator.create
 
         connection = Sequel.connect(url)
@@ -52,23 +54,23 @@ RSpec.shared_examples 'migrator_mysql' do
         end
       end
 
-      it 'raises error if database is busy' do
+      it "raises error if database is busy" do
         migrator.create
         Sequel.connect(url).tables
 
         expect { migrator.create }.to raise_error do |error|
           expect(error).to be_a(Hanami::Model::MigrationError)
-          expect(error.message).to include('Database creation failed. If the database exists,')
-          expect(error.message).to include('then its console may be open. See this issue for more details:')
-          expect(error.message).to include('https://github.com/hanami/model/issues/250')
+          expect(error.message).to include("Database creation failed. If the database exists,")
+          expect(error.message).to include("then its console may be open. See this issue for more details:")
+          expect(error.message).to include("https://github.com/hanami/model/issues/250")
         end
       end
 
       # See https://github.com/hanami/model/issues/381
-      describe 'when database name contains a dash' do
+      describe "when database name contains a dash" do
         let(:database) { "db-name-create_#{random}" }
 
-        it 'creates the database' do
+        it "creates the database" do
           migrator.create
 
           connection = Sequel.connect(url)
@@ -77,12 +79,12 @@ RSpec.shared_examples 'migrator_mysql' do
       end
     end
 
-    describe 'drop' do
+    describe "drop" do
       before do
         migrator.create
       end
 
-      it 'drops the database' do
+      it "drops the database" do
         migrator.drop
         expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
       end
@@ -104,10 +106,10 @@ RSpec.shared_examples 'migrator_mysql' do
       end
 
       # See https://github.com/hanami/model/issues/381
-      describe 'when database name contains a dash' do
+      describe "when database name contains a dash" do
         let(:database) { "db-name-drop_#{random}" }
 
-        it 'drops the database' do
+        it "drops the database" do
           migrator.drop
 
           expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
@@ -115,13 +117,13 @@ RSpec.shared_examples 'migrator_mysql' do
       end
     end
 
-    describe 'migrate' do
+    describe "migrate" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../../../../support/fixtures/empty_migrations') }
+      describe "when no migrations" do
+        let(:migrations) { Pathname.new(__dir__ + "/../../../../support/fixtures/empty_migrations") }
 
         it "it doesn't alter database" do
           migrator.migrate
@@ -131,8 +133,8 @@ RSpec.shared_examples 'migrator_mysql' do
         end
       end
 
-      describe 'when migrations are present' do
-        it 'migrates the database' do
+      describe "when migrations are present" do
+        it "migrates the database" do
           migrator.migrate
 
           connection = Sequel.connect(url)
@@ -146,7 +148,7 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:db_type)).to eq("int(11)")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -156,21 +158,21 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:db_type)).to eq("varchar(255)")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
           expect(name).to eq(:rating)
 
           expect(options.fetch(:allow_null)).to eq(true)
-          expect(options.fetch(:default)).to eq('0')
+          expect(options.fetch(:default)).to eq("0")
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:db_type)).to eq("int(11)")
           expect(options.fetch(:primary_key)).to eq(false)
         end
       end
 
-      describe 'when migrations are ran twice' do
+      describe "when migrations are ran twice" do
         before do
           migrator.migrate
         end
@@ -184,13 +186,13 @@ RSpec.shared_examples 'migrator_mysql' do
         end
       end
 
-      describe 'migrate down' do
+      describe "migrate down" do
         before do
           migrator.migrate
         end
 
-        it 'migrates the database' do
-          migrator.migrate(version: '20160831073534') # see spec/support/fixtures/migrations
+        it "migrates the database" do
+          migrator.migrate(version: "20160831073534") # see spec/support/fixtures/migrations
 
           connection = Sequel.connect(url)
           expect(connection.tables).to_not be_empty
@@ -203,7 +205,7 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:db_type)).to eq("int(11)")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -213,7 +215,7 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:db_type)).to eq("varchar(255)")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (rolled back second migration)
@@ -223,13 +225,13 @@ RSpec.shared_examples 'migrator_mysql' do
       end
     end
 
-    describe 'rollback' do
+    describe "rollback" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../../../../support/fixtures/empty_migrations') }
+      describe "when no migrations" do
+        let(:migrations) { Pathname.new(__dir__ + "/../../../../support/fixtures/empty_migrations") }
 
         it "it doesn't alter database" do
           migrator.rollback
@@ -239,8 +241,8 @@ RSpec.shared_examples 'migrator_mysql' do
         end
       end
 
-      describe 'when migrations are present' do
-        it 'rollbacks one migration (default)' do
+      describe "when migrations are present" do
+        it "rollbacks one migration (default)" do
           migrator.migrate
           migrator.rollback
 
@@ -255,7 +257,7 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('int(11)')
+          expect(options.fetch(:db_type)).to eq("int(11)")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -265,7 +267,7 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:db_type)).to eq("varchar(255)")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
@@ -273,7 +275,7 @@ RSpec.shared_examples 'migrator_mysql' do
           expect(options).to eq(nil)
         end
 
-        it 'rollbacks several migrations' do
+        it "rollbacks several migrations" do
           migrator.migrate
           migrator.rollback(steps: 2)
 
@@ -283,7 +285,7 @@ RSpec.shared_examples 'migrator_mysql' do
       end
     end
 
-    describe 'apply' do
+    describe "apply" do
       let(:migrations) { target_migrations }
       let(:schema) { root.join("schema-#{random}.sql") }
 
@@ -296,15 +298,15 @@ RSpec.shared_examples 'migrator_mysql' do
         clean_migrations
       end
 
-      it 'migrates to latest version' do
+      it "migrates to latest version" do
         migrator.apply
         connection = Sequel.connect(url)
         migration = connection[:schema_migrations].to_a.last
 
-        expect(migration.fetch(:filename)).to include('20160831090612') # see spec/support/fixtures/migrations
+        expect(migration.fetch(:filename)).to include("20160831090612") # see spec/support/fixtures/migrations
       end
 
-      it 'dumps database schema.sql' do
+      it "dumps database schema.sql" do
         migrator.apply
         actual = schema.read
 
@@ -332,7 +334,7 @@ RSpec.shared_examples 'migrator_mysql' do
         expect(actual).to include %(UNLOCK TABLES;)
       end
 
-      it 'deletes all the migrations' do
+      it "deletes all the migrations" do
         migrator.apply
         expect(target_migrations.children).to be_empty
       end
@@ -360,7 +362,7 @@ RSpec.shared_examples 'migrator_mysql' do
       end
     end
 
-    describe 'prepare' do
+    describe "prepare" do
       let(:migrations) { target_migrations }
       let(:schema)     { root.join("schema-#{random}.sql") }
 
@@ -374,13 +376,13 @@ RSpec.shared_examples 'migrator_mysql' do
         clean_migrations
       end
 
-      it 'creates database, loads schema and migrate' do
+      it "creates database, loads schema and migrate" do
         # Simulate already existing schema.sql, without existing database and pending migrations
         connection = Sequel.connect(url)
         Hanami::Model::Migrator::Adapter.for(configuration).dump
 
-        migration = target_migrations.join('20160831095616_create_abuses.rb')
-        File.open(migration, 'w+') do |f|
+        migration = target_migrations.join("20160831095616_create_abuses.rb")
+        File.open(migration, "w+") do |f|
           f.write <<~RUBY
             Hanami::Model.migration do
               change do
@@ -413,7 +415,7 @@ RUBY
         expect(connection.tables).to include(:reviews)
       end
 
-      it 'drops the database and recreates it' do
+      it "drops the database and recreates it" do
         migrator.prepare
 
         connection = Sequel.connect(url)
@@ -422,24 +424,24 @@ RUBY
       end
     end
 
-    describe 'version' do
+    describe "version" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations were ran' do
-        it 'returns nil' do
+      describe "when no migrations were ran" do
+        it "returns nil" do
           expect(migrator.version).to be_nil
         end
       end
 
-      describe 'with migrations' do
+      describe "with migrations" do
         before do
           migrator.migrate
         end
 
-        it 'returns current database version' do
-          expect(migrator.version).to eq('20160831090612') # see spec/support/fixtures/migrations)
+        it "returns current database version" do
+          expect(migrator.version).to eq("20160831090612") # see spec/support/fixtures/migrations)
         end
       end
     end

--- a/spec/unit/hanami/model/migrator/postgresql.rb
+++ b/spec/unit/hanami/model/migrator/postgresql.rb
@@ -1,7 +1,9 @@
-require 'ostruct'
-require 'securerandom'
+# frozen_string_literal: true
 
-RSpec.shared_examples 'migrator_postgresql' do
+require "ostruct"
+require "securerandom"
+
+RSpec.shared_examples "migrator_postgresql" do
   let(:migrator) do
     Hanami::Model::Migrator.new(configuration: configuration)
   end
@@ -9,9 +11,9 @@ RSpec.shared_examples 'migrator_postgresql' do
   let(:random) { SecureRandom.hex(4) }
 
   # General variables
-  let(:migrations)     { Pathname.new(__dir__ + '/../../../../support/fixtures/migrations') }
+  let(:migrations)     { Pathname.new(__dir__ + "/../../../../support/fixtures/migrations") }
   let(:schema)         { nil }
-  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV['HANAMI_DATABASE_LOGGER'])) }
+  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV["HANAMI_DATABASE_LOGGER"])) }
   let(:configuration)  { Hanami::Model::Configuration.new(config) }
 
   # Variables for `apply` and `prepare`
@@ -24,7 +26,7 @@ RSpec.shared_examples 'migrator_postgresql' do
     migrator.drop rescue nil # rubocop:disable Style/RescueModifier
   end
 
-  describe 'PostgreSQL' do
+  describe "PostgreSQL" do
     let(:database) { random }
     let(:url) do
       db = database
@@ -35,34 +37,34 @@ RSpec.shared_examples 'migrator_postgresql' do
       end
     end
 
-    describe 'create' do
+    describe "create" do
       before do
         migrator.create
       end
 
-      it 'creates the database' do
+      it "creates the database" do
         connection = Sequel.connect(url)
         expect(connection.tables).to be_empty
       end
 
-      it 'raises error if database is busy' do
+      it "raises error if database is busy" do
         Sequel.connect(url).tables
         expect { migrator.create }.to raise_error do |error|
           expect(error).to be_a(Hanami::Model::MigrationError)
 
-          expect(error.message).to include('createdb: database creation failed. If the database exists,')
-          expect(error.message).to include('then its console may be open. See this issue for more details:')
-          expect(error.message).to include('https://github.com/hanami/model/issues/250')
+          expect(error.message).to include("createdb: database creation failed. If the database exists,")
+          expect(error.message).to include("then its console may be open. See this issue for more details:")
+          expect(error.message).to include("https://github.com/hanami/model/issues/250")
         end
       end
     end
 
-    describe 'drop' do
+    describe "drop" do
       before do
         migrator.create
       end
 
-      it 'drops the database' do
+      it "drops the database" do
         migrator.drop
 
         expect { Sequel.connect(url).tables }.to raise_error(Sequel::DatabaseConnectionError)
@@ -80,17 +82,17 @@ RSpec.shared_examples 'migrator_postgresql' do
       before do
         # We accomplish having a command not be available by setting PATH
         # to an empty string, which means *no commands* are available.
-        @original_path = ENV['PATH']
-        ENV['PATH'] = ''
+        @original_path = ENV["PATH"]
+        ENV["PATH"] = ""
       end
 
       after do
-        ENV['PATH'] = @original_path
+        ENV["PATH"] = @original_path
       end
 
-      it 'raises MigrationError on missing `createdb`' do
+      it "raises MigrationError on missing `createdb`" do
         message = Platform.match do
-          os(:macos).engine(:jruby) { 'createdb' }
+          os(:macos).engine(:jruby) { "createdb" }
           default { "Could not find executable in your PATH: `createdb`" }
         end
 
@@ -100,9 +102,9 @@ RSpec.shared_examples 'migrator_postgresql' do
         end
       end
 
-      it 'raises MigrationError on missing `dropdb`' do
+      it "raises MigrationError on missing `dropdb`" do
         message = Platform.match do
-          os(:macos).engine(:jruby) { 'dropdb' }
+          os(:macos).engine(:jruby) { "dropdb" }
           default { "Could not find executable in your PATH: `dropdb`" }
         end
 
@@ -113,13 +115,13 @@ RSpec.shared_examples 'migrator_postgresql' do
       end
     end
 
-    describe 'migrate' do
+    describe "migrate" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../../../../support/fixtures/empty_migrations') }
+      describe "when no migrations" do
+        let(:migrations) { Pathname.new(__dir__ + "/../../../../support/fixtures/empty_migrations") }
 
         it "it doesn't alter database" do
           migrator.migrate
@@ -129,8 +131,8 @@ RSpec.shared_examples 'migrator_postgresql' do
         end
       end
 
-      describe 'when migrations are present' do
-        it 'migrates the database' do
+      describe "when migrations are present" do
+        it "migrates the database" do
           migrator.migrate
 
           connection = Sequel.connect(url)
@@ -144,7 +146,7 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -154,21 +156,21 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('text')
+          expect(options.fetch(:db_type)).to eq("text")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
           expect(name).to eq(:rating)
 
           expect(options.fetch(:allow_null)).to eq(true)
-          expect(options.fetch(:default)).to eq('0')
+          expect(options.fetch(:default)).to eq("0")
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(false)
         end
       end
 
-      describe 'when migrations are ran twice' do
+      describe "when migrations are ran twice" do
         before do
           migrator.migrate
         end
@@ -183,13 +185,13 @@ RSpec.shared_examples 'migrator_postgresql' do
         end
       end
 
-      describe 'migrate down' do
+      describe "migrate down" do
         before do
           migrator.migrate
         end
 
-        it 'migrates the database' do
-          migrator.migrate(version: '20160831073534') # see spec/support/fixtures/migrations
+        it "migrates the database" do
+          migrator.migrate(version: "20160831073534") # see spec/support/fixtures/migrations
 
           connection = Sequel.connect(url)
           expect(connection.tables).to_not be_empty
@@ -202,7 +204,7 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -212,7 +214,7 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('text')
+          expect(options.fetch(:db_type)).to eq("text")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (rolled back second migration)
@@ -222,13 +224,13 @@ RSpec.shared_examples 'migrator_postgresql' do
       end
     end
 
-    describe 'rollback' do
+    describe "rollback" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../../../../support/fixtures/empty_migrations') }
+      describe "when no migrations" do
+        let(:migrations) { Pathname.new(__dir__ + "/../../../../support/fixtures/empty_migrations") }
 
         it "it doesn't alter database" do
           migrator.rollback
@@ -238,8 +240,8 @@ RSpec.shared_examples 'migrator_postgresql' do
         end
       end
 
-      describe 'when migrations are present' do
-        it 'rollbacks one migration (default)' do
+      describe "when migrations are present" do
+        it "rollbacks one migration (default)" do
           migrator.migrate
           migrator.rollback
 
@@ -254,7 +256,7 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to eq("nextval('reviews_id_seq'::regclass)")
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -264,7 +266,7 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('text')
+          expect(options.fetch(:db_type)).to eq("text")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
@@ -272,7 +274,7 @@ RSpec.shared_examples 'migrator_postgresql' do
           expect(options).to eq(nil)
         end
 
-        it 'rollbacks several migrations' do
+        it "rollbacks several migrations" do
           migrator.migrate
           migrator.rollback(steps: 2)
 
@@ -282,7 +284,7 @@ RSpec.shared_examples 'migrator_postgresql' do
       end
     end
 
-    describe 'apply' do
+    describe "apply" do
       let(:migrations) { target_migrations }
       let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
 
@@ -295,15 +297,15 @@ RSpec.shared_examples 'migrator_postgresql' do
         clean_migrations
       end
 
-      it 'migrates to latest version' do
+      it "migrates to latest version" do
         migrator.apply
         connection = Sequel.connect(url)
         migration = connection[:schema_migrations].to_a.last
 
-        expect(migration.fetch(:filename)).to include('20160831090612') # see spec/support/fixtures/migrations
+        expect(migration.fetch(:filename)).to include("20160831090612") # see spec/support/fixtures/migrations
       end
 
-      it 'dumps database schema.sql' do
+      it "dumps database schema.sql" do
         migrator.apply
         actual = schema.read
 
@@ -355,7 +357,7 @@ RSpec.shared_examples 'migrator_postgresql' do
         SQL
       end
 
-      it 'deletes all the migrations' do
+      it "deletes all the migrations" do
         migrator.apply
         expect(target_migrations.children).to be_empty
       end
@@ -383,7 +385,7 @@ RSpec.shared_examples 'migrator_postgresql' do
       end
     end
 
-    describe 'prepare' do
+    describe "prepare" do
       let(:migrations) { target_migrations }
       let(:schema)     { root.join("schema-postgresql-#{random}.sql") }
 
@@ -396,12 +398,12 @@ RSpec.shared_examples 'migrator_postgresql' do
         clean_migrations
       end
 
-      it 'creates database, loads schema and migrate' do
+      it "creates database, loads schema and migrate" do
         # Simulate already existing schema.sql, without existing database and pending migrations
         Hanami::Model::Migrator::Adapter.for(configuration).dump
 
-        migration = target_migrations.join('20160831095616_create_abuses.rb')
-        File.open(migration, 'w+') do |f|
+        migration = target_migrations.join("20160831095616_create_abuses.rb")
+        File.open(migration, "w+") do |f|
           f.write <<-RUBY
           Hanami::Model.migration do
             change do
@@ -435,7 +437,7 @@ RSpec.shared_examples 'migrator_postgresql' do
         expect(connection.tables).to include(:reviews)
       end
 
-      it 'drops the database and recreates it' do
+      it "drops the database and recreates it" do
         migrator.prepare
 
         connection = Sequel.connect(url)
@@ -444,24 +446,24 @@ RSpec.shared_examples 'migrator_postgresql' do
       end
     end
 
-    describe 'version' do
+    describe "version" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations were ran' do
-        it 'returns nil' do
+      describe "when no migrations were ran" do
+        it "returns nil" do
           expect(migrator.version).to be_nil
         end
       end
 
-      describe 'with migrations' do
+      describe "with migrations" do
         before do
           migrator.migrate
         end
 
-        it 'returns current database version' do
-          expect(migrator.version).to eq('20160831090612') # see spec/support/fixtures/migrations)
+        it "returns current database version" do
+          expect(migrator.version).to eq("20160831090612") # see spec/support/fixtures/migrations)
         end
       end
     end

--- a/spec/unit/hanami/model/migrator/sqlite.rb
+++ b/spec/unit/hanami/model/migrator/sqlite.rb
@@ -1,7 +1,9 @@
-require 'ostruct'
-require 'securerandom'
+# frozen_string_literal: true
 
-RSpec.shared_examples 'migrator_sqlite' do
+require "ostruct"
+require "securerandom"
+
+RSpec.shared_examples "migrator_sqlite" do
   let(:migrator) do
     Hanami::Model::Migrator.new(configuration: configuration)
   end
@@ -9,9 +11,9 @@ RSpec.shared_examples 'migrator_sqlite' do
   let(:random) { SecureRandom.hex }
 
   # General variables
-  let(:migrations)     { Pathname.new(__dir__ + '/../../../../support/fixtures/migrations') }
+  let(:migrations)     { Pathname.new(__dir__ + "/../../../../support/fixtures/migrations") }
   let(:schema)         { nil }
-  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV['HANAMI_DATABASE_LOGGER'])) }
+  let(:config)         { OpenStruct.new(backend: :sql, url: url, _migrations: migrations, _schema: schema, migrations_logger: Hanami::Model::Migrator::Logger.new(ENV["HANAMI_DATABASE_LOGGER"])) }
   let(:configuration)  { Hanami::Model::Configuration.new(config) }
   let(:url) do
     db = database
@@ -31,51 +33,51 @@ RSpec.shared_examples 'migrator_sqlite' do
     migrator.drop rescue nil # rubocop:disable Style/RescueModifier
   end
 
-  describe 'SQLite filesystem' do
+  describe "SQLite filesystem" do
     let(:database) do
       Pathname.new("#{__dir__}/../../../../../tmp/create-#{random}.sqlite3").expand_path
     end
 
-    describe 'create' do
-      it 'creates the database' do
+    describe "create" do
+      it "creates the database" do
         migrator.create
         expect(File.exist?(database)).to be_truthy, "Expected database #{database} to exist"
       end
 
       describe "when it doesn't have write permissions" do
-        let(:database) { '/usr/bin/create.sqlite3' }
+        let(:database) { "/usr/bin/create.sqlite3" }
 
-        it 'raises an error' do
+        it "raises an error" do
           error = Platform.match do
             os(:macos).engine(:jruby) { Java::JavaLang::RuntimeException }
             default { Hanami::Model::MigrationError }
           end
 
           message = Platform.match do
-            os(:macos).engine(:jruby) { 'Unhandled IOException: java.io.IOException: unhandled errno: Operation not permitted' }
-            default { 'Permission denied: /usr/bin/create.sqlite3' }
+            os(:macos).engine(:jruby) { "Unhandled IOException: java.io.IOException: unhandled errno: Operation not permitted" }
+            default { "Permission denied: /usr/bin/create.sqlite3" }
           end
 
           expect { migrator.create }.to raise_error(error, message)
         end
       end
 
-      describe 'when the path is relative' do
-        let(:database) { 'create.sqlite3' }
+      describe "when the path is relative" do
+        let(:database) { "create.sqlite3" }
 
-        it 'creates the database' do
+        it "creates the database" do
           migrator.create
           expect(File.exist?(database)).to be_truthy, "Expected database #{database} to exist"
         end
       end
     end
 
-    describe 'drop' do
+    describe "drop" do
       before do
         migrator.create
       end
 
-      it 'drops the database' do
+      it "drops the database" do
         migrator.drop
         expect(File.exist?(database)).to be_falsey, "Expected database #{database} to NOT exist"
       end
@@ -88,13 +90,13 @@ RSpec.shared_examples 'migrator_sqlite' do
       end
     end
 
-    describe 'migrate' do
+    describe "migrate" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../../../../support/fixtures/empty_migrations') }
+      describe "when no migrations" do
+        let(:migrations) { Pathname.new(__dir__ + "/../../../../support/fixtures/empty_migrations") }
 
         it "it doesn't alter database" do
           migrator.migrate
@@ -104,8 +106,8 @@ RSpec.shared_examples 'migrator_sqlite' do
         end
       end
 
-      describe 'when migrations are present' do
-        it 'migrates the database' do
+      describe "when migrations are present" do
+        it "migrates the database" do
           migrator.migrate
 
           connection = Sequel.connect(url)
@@ -119,7 +121,7 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -129,21 +131,21 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:db_type)).to eq("varchar(255)")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
           expect(name).to eq(:rating)
 
           expect(options.fetch(:allow_null)).to eq(true)
-          expect(options.fetch(:default)).to eq('0')
+          expect(options.fetch(:default)).to eq("0")
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(false)
         end
       end
 
-      describe 'when migrations are ran twice' do
+      describe "when migrations are ran twice" do
         before do
           migrator.migrate
         end
@@ -157,13 +159,13 @@ RSpec.shared_examples 'migrator_sqlite' do
         end
       end
 
-      describe 'migrate down' do
+      describe "migrate down" do
         before do
           migrator.migrate
         end
 
-        it 'migrates the database' do
-          migrator.migrate(version: '20160831073534') # see spec/support/fixtures/migrations
+        it "migrates the database" do
+          migrator.migrate(version: "20160831073534") # see spec/support/fixtures/migrations
 
           connection = Sequel.connect(url)
           expect(connection.tables).to_not be_empty
@@ -176,7 +178,7 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -186,7 +188,7 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:db_type)).to eq("varchar(255)")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (rolled back second migration)
@@ -196,13 +198,13 @@ RSpec.shared_examples 'migrator_sqlite' do
       end
     end
 
-    describe 'rollback' do
+    describe "rollback" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations' do
-        let(:migrations) { Pathname.new(__dir__ + '/../../../../support/fixtures/empty_migrations') }
+      describe "when no migrations" do
+        let(:migrations) { Pathname.new(__dir__ + "/../../../../support/fixtures/empty_migrations") }
 
         it "it doesn't alter database" do
           migrator.rollback
@@ -212,8 +214,8 @@ RSpec.shared_examples 'migrator_sqlite' do
         end
       end
 
-      describe 'when migrations are present' do
-        it 'rollbacks one migration (default)' do
+      describe "when migrations are present" do
+        it "rollbacks one migration (default)" do
           migrator.migrate
           migrator.rollback
 
@@ -228,7 +230,7 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:integer)
-          expect(options.fetch(:db_type)).to eq('integer')
+          expect(options.fetch(:db_type)).to eq("integer")
           expect(options.fetch(:primary_key)).to eq(true)
           expect(options.fetch(:auto_increment)).to eq(true)
 
@@ -238,7 +240,7 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options.fetch(:allow_null)).to eq(false)
           expect(options.fetch(:default)).to be_nil
           expect(options.fetch(:type)).to eq(:string)
-          expect(options.fetch(:db_type)).to eq('varchar(255)')
+          expect(options.fetch(:db_type)).to eq("varchar(255)")
           expect(options.fetch(:primary_key)).to eq(false)
 
           name, options = table[2] # rating (second migration)
@@ -246,7 +248,7 @@ RSpec.shared_examples 'migrator_sqlite' do
           expect(options).to eq(nil)
         end
 
-        it 'rollbacks several migrations' do
+        it "rollbacks several migrations" do
           migrator.migrate
           migrator.rollback(steps: 2)
 
@@ -256,7 +258,7 @@ RSpec.shared_examples 'migrator_sqlite' do
       end
     end
 
-    describe 'apply' do
+    describe "apply" do
       let(:migrations) { target_migrations }
       let(:schema)     { root.join("schema-sqlite-#{random}.sql") }
 
@@ -268,15 +270,15 @@ RSpec.shared_examples 'migrator_sqlite' do
         clean_migrations
       end
 
-      it 'migrates to latest version' do
+      it "migrates to latest version" do
         migrator.apply
         connection = Sequel.connect(url)
         migration = connection[:schema_migrations].to_a.last
 
-        expect(migration.fetch(:filename)).to include('20160831090612') # see spec/support/fixtures/migrations
+        expect(migration.fetch(:filename)).to include("20160831090612") # see spec/support/fixtures/migrations
       end
 
-      it 'dumps database schema.sql' do
+      it "dumps database schema.sql" do
         migrator.apply
         actual = schema.read
 
@@ -286,7 +288,7 @@ RSpec.shared_examples 'migrator_sqlite' do
         expect(actual).to include %(INSERT INTO "schema_migrations" VALUES('20160831090612_add_rating_to_reviews.rb');)
       end
 
-      it 'deletes all the migrations' do
+      it "deletes all the migrations" do
         migrator.apply
         expect(target_migrations.children).to be_empty
       end
@@ -321,7 +323,7 @@ RSpec.shared_examples 'migrator_sqlite' do
       end
     end
 
-    describe 'prepare' do
+    describe "prepare" do
       let(:migrations) { target_migrations }
       let(:schema)     { root.join("schema-sqlite-#{random}.sql") }
 
@@ -333,13 +335,13 @@ RSpec.shared_examples 'migrator_sqlite' do
         clean_migrations
       end
 
-      it 'creates database, loads schema and migrate' do
+      it "creates database, loads schema and migrate" do
         # Simulate already existing schema.sql, without existing database and pending migrations
         connection = Sequel.connect(url)
         Hanami::Model::Migrator::Adapter.for(configuration).dump
 
-        migration = target_migrations.join('20160831095616_create_abuses.rb')
-        File.open(migration, 'w+') do |f|
+        migration = target_migrations.join("20160831095616_create_abuses.rb")
+        File.open(migration, "w+") do |f|
           f.write <<~RUBY
             Hanami::Model.migration do
               change do
@@ -367,7 +369,7 @@ RUBY
         expect(connection.tables).to eq(%i[schema_migrations reviews])
       end
 
-      it 'drops the database and recreate it' do
+      it "drops the database and recreate it" do
         migrator.create
         migrator.prepare
 
@@ -377,24 +379,24 @@ RUBY
       end
     end
 
-    describe 'version' do
+    describe "version" do
       before do
         migrator.create
       end
 
-      describe 'when no migrations were ran' do
-        it 'returns nil' do
+      describe "when no migrations were ran" do
+        it "returns nil" do
           expect(migrator.version).to be_nil
         end
       end
 
-      describe 'with migrations' do
+      describe "with migrations" do
         before do
           migrator.migrate
         end
 
-        it 'returns current database version' do
-          expect(migrator.version).to eq('20160831090612') # see spec/support/fixtures/migrations)
+        it "returns current database version" do
+          expect(migrator.version).to eq("20160831090612") # see spec/support/fixtures/migrations)
         end
       end
     end

--- a/spec/unit/hanami/model/migrator_spec.rb
+++ b/spec/unit/hanami/model/migrator_spec.rb
@@ -1,4 +1,6 @@
-require 'hanami/model/migrator'
+# frozen_string_literal: true
+
+require "hanami/model/migrator"
 require_relative "./migrator/#{Database.engine}"
 
 RSpec.describe Hanami::Model::Migrator do

--- a/spec/unit/hanami/model/not_null_constraint_violation_error_spec.rb
+++ b/spec/unit/hanami/model/not_null_constraint_violation_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::NotNullConstraintViolationError do
   it "inherits from Hanami::Model::ConstraintViolationError" do
     expect(described_class.ancestors).to include(Hanami::Model::ConstraintViolationError)

--- a/spec/unit/hanami/model/sql/console/mysql.rb
+++ b/spec/unit/hanami/model/sql/console/mysql.rb
@@ -1,13 +1,15 @@
-require 'hanami/model/sql/consoles/mysql'
+# frozen_string_literal: true
+
+require "hanami/model/sql/consoles/mysql"
 
 RSpec.shared_examples "sql_console_mysql" do
   let(:console) { Hanami::Model::Sql::Consoles::Mysql.new(uri) }
 
-  describe '#connection_string' do
-    let(:uri) { URI.parse('mysql://username:password@localhost:1234/foo_development') }
+  describe "#connection_string" do
+    let(:uri) { URI.parse("mysql://username:password@localhost:1234/foo_development") }
 
-    it 'returns a connection string' do
-      expect(console.connection_string).to eq('mysql -h localhost -D foo_development -P 1234 -u username -p password')
+    it "returns a connection string" do
+      expect(console.connection_string).to eq("mysql -h localhost -D foo_development -P 1234 -u username -p password")
     end
   end
 end

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -1,42 +1,44 @@
-require 'hanami/model/sql/consoles/postgresql'
+# frozen_string_literal: true
+
+require "hanami/model/sql/consoles/postgresql"
 
 RSpec.shared_examples "sql_console_postgresql" do
   let(:console) { Hanami::Model::Sql::Consoles::Postgresql.new(uri) }
 
-  describe '#connection_string' do
-    let(:uri) { URI.parse('postgres://username:password@localhost:1234/foo_development') }
+  describe "#connection_string" do
+    let(:uri) { URI.parse("postgres://username:password@localhost:1234/foo_development") }
 
-    it 'returns a connection string' do
-      expect(console.connection_string).to eq('psql -h localhost -d foo_development -p 1234 -U username')
+    it "returns a connection string" do
+      expect(console.connection_string).to eq("psql -h localhost -d foo_development -p 1234 -U username")
     end
 
-    it 'sets the PGPASSWORD environment variable' do
+    it "sets the PGPASSWORD environment variable" do
       console.connection_string
-      expect(ENV['PGPASSWORD']).to eq('password')
-      ENV.delete('PGPASSWORD')
+      expect(ENV["PGPASSWORD"]).to eq("password")
+      ENV.delete("PGPASSWORD")
     end
 
-    context 'when the password contains percent encoded characters' do
-      let(:uri) { URI.parse('postgres://username:p%40ss@localhost:1234/foo_development') }
+    context "when the password contains percent encoded characters" do
+      let(:uri) { URI.parse("postgres://username:p%40ss@localhost:1234/foo_development") }
 
-      it 'sets the PGPASSWORD environment variable decoding special characters' do
+      it "sets the PGPASSWORD environment variable decoding special characters" do
         console.connection_string
-        expect(ENV['PGPASSWORD']).to eq('p@ss')
-        ENV.delete('PGPASSWORD')
+        expect(ENV["PGPASSWORD"]).to eq("p@ss")
+        ENV.delete("PGPASSWORD")
       end
     end
 
-    context 'when components of the  hierarchical part of the URI can also be given as parameters' do
-      let(:uri) { URI.parse('postgres:///foo_development?user=username&password=password&host=localhost&port=1234') }
+    context "when components of the  hierarchical part of the URI can also be given as parameters" do
+      let(:uri) { URI.parse("postgres:///foo_development?user=username&password=password&host=localhost&port=1234") }
 
-      it 'returns a connection string' do
-        expect(console.connection_string).to eq('psql -h localhost -d foo_development -p 1234 -U username')
+      it "returns a connection string" do
+        expect(console.connection_string).to eq("psql -h localhost -d foo_development -p 1234 -U username")
       end
 
-      it 'sets the PGPASSWORD environment variable' do
+      it "sets the PGPASSWORD environment variable" do
         console.connection_string
-        expect(ENV['PGPASSWORD']).to eq('password')
-        ENV.delete('PGPASSWORD')
+        expect(ENV["PGPASSWORD"]).to eq("password")
+        ENV.delete("PGPASSWORD")
       end
     end
   end

--- a/spec/unit/hanami/model/sql/console/sqlite.rb
+++ b/spec/unit/hanami/model/sql/console/sqlite.rb
@@ -1,19 +1,21 @@
-require 'hanami/model/sql/consoles/sqlite'
+# frozen_string_literal: true
+
+require "hanami/model/sql/consoles/sqlite"
 
 RSpec.shared_examples "sql_console_sqlite" do
   let(:console) { Hanami::Model::Sql::Consoles::Sqlite.new(uri) }
 
-  describe '#connection_string' do
-    describe 'with shell ok database uri' do
-      let(:uri) { URI.parse('sqlite://foo/bar.db') }
-      it 'returns a connection string for Sqlite3' do
-        expect(console.connection_string).to eq('sqlite3 foo/bar.db')
+  describe "#connection_string" do
+    describe "with shell ok database uri" do
+      let(:uri) { URI.parse("sqlite://foo/bar.db") }
+      it "returns a connection string for Sqlite3" do
+        expect(console.connection_string).to eq("sqlite3 foo/bar.db")
       end
     end
 
-    describe 'with non shell ok database uri' do
-      let(:uri) { URI.parse('sqlite://foo/%20bar.db') }
-      it 'returns an escaped connection string for Sqlite3' do
+    describe "with non shell ok database uri" do
+      let(:uri) { URI.parse("sqlite://foo/%20bar.db") }
+      it "returns an escaped connection string for Sqlite3" do
         expect(console.connection_string).to eq('sqlite3 foo/\\%20bar.db')
       end
     end

--- a/spec/unit/hanami/model/sql/console_spec.rb
+++ b/spec/unit/hanami/model/sql/console_spec.rb
@@ -1,32 +1,34 @@
-require 'hanami/model/sql/console'
+# frozen_string_literal: true
+
+require "hanami/model/sql/console"
 
 RSpec.describe Hanami::Model::Sql::Console do
-  describe 'deciding on which SQL console class to use, based on URI scheme' do
-    let(:uri) { 'username:password@localhost:1234/foo_development' }
+  describe "deciding on which SQL console class to use, based on URI scheme" do
+    let(:uri) { "username:password@localhost:1234/foo_development" }
 
     case Database.engine
     when :sqlite
-      it 'sqlite:// uri returns an instance of Console::Sqlite' do
+      it "sqlite:// uri returns an instance of Console::Sqlite" do
         console = Hanami::Model::Sql::Console.new("sqlite://#{uri}").send(:console)
         expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Sqlite)
       end
     when :postgresql
-      it 'postgres:// uri returns an instance of Console::Postgresql' do
+      it "postgres:// uri returns an instance of Console::Postgresql" do
         console = Hanami::Model::Sql::Console.new("postgres://#{uri}").send(:console)
         expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
       end
 
-      it 'postgresql:// uri returns an instance of Console::Postgresql' do
+      it "postgresql:// uri returns an instance of Console::Postgresql" do
         console = Hanami::Model::Sql::Console.new("postgresql://#{uri}").send(:console)
         expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
       end
     when :mysql
-      it 'mysql:// uri returns an instance of Console::Mysql' do
+      it "mysql:// uri returns an instance of Console::Mysql" do
         console = Hanami::Model::Sql::Console.new("mysql://#{uri}").send(:console)
         expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
       end
 
-      it 'mysql2:// uri returns an instance of Console::Mysql' do
+      it "mysql2:// uri returns an instance of Console::Mysql" do
         console = Hanami::Model::Sql::Console.new("mysql2://#{uri}").send(:console)
         expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
       end

--- a/spec/unit/hanami/model/sql/entity/schema/automatic_spec.rb
+++ b/spec/unit/hanami/model/sql/entity/schema/automatic_spec.rb
@@ -1,21 +1,23 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Sql::Entity::Schema do
-  describe 'automatic' do
+  describe "automatic" do
     subject { Author.schema }
 
-    describe '#initialize' do
-      it 'returns frozen instance' do
+    describe "#initialize" do
+      it "returns frozen instance" do
         expect(subject).to be_frozen
       end
     end
 
-    describe '#call' do
-      it 'returns empty hash when nil is given' do
+    describe "#call" do
+      it "returns empty hash when nil is given" do
         result = subject.call(nil)
 
         expect(result).to eq({})
       end
 
-      it 'processes attributes' do
+      it "processes attributes" do
         now = Time.now
         result = subject.call(id: 1, created_at: now.to_s)
 
@@ -23,19 +25,19 @@ RSpec.describe Hanami::Model::Sql::Entity::Schema do
         expect(result.fetch(:created_at)).to be_within(2).of(now)
       end
 
-      it 'ignores unknown attributes' do
-        result = subject.call(foo: 'bar')
+      it "ignores unknown attributes" do
+        result = subject.call(foo: "bar")
 
         expect(result).to eq({})
       end
     end
 
-    describe '#attribute?' do
-      it 'returns true for known attributes' do
+    describe "#attribute?" do
+      it "returns true for known attributes" do
         expect(subject.attribute?(:id)).to eq(true)
       end
 
-      it 'returns false for unknown attributes' do
+      it "returns false for unknown attributes" do
         expect(subject.attribute?(:foo)).to eq(false)
       end
     end

--- a/spec/unit/hanami/model/sql/entity/schema/mapping_spec.rb
+++ b/spec/unit/hanami/model/sql/entity/schema/mapping_spec.rb
@@ -1,39 +1,41 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Sql::Entity::Schema do
-  describe 'mapping' do
+  describe "mapping" do
     subject { Operator.schema }
 
-    describe '#initialize' do
-      it 'returns frozen instance' do
+    describe "#initialize" do
+      it "returns frozen instance" do
         expect(subject).to be_frozen
       end
     end
 
-    describe '#call' do
-      it 'returns empty hash when nil is given' do
+    describe "#call" do
+      it "returns empty hash when nil is given" do
         result = subject.call(nil)
 
         expect(result).to eq({})
       end
 
-      it 'processes attributes' do
+      it "processes attributes" do
         result = subject.call(id: 1, name: :foo)
 
-        expect(result).to eq(id: 1, name: 'foo')
+        expect(result).to eq(id: 1, name: "foo")
       end
 
-      it 'ignores unknown attributes' do
-        result = subject.call(foo: 'bar')
+      it "ignores unknown attributes" do
+        result = subject.call(foo: "bar")
 
         expect(result).to eq({})
       end
     end
 
-    describe '#attribute?' do
-      it 'returns true for known attributes' do
+    describe "#attribute?" do
+      it "returns true for known attributes" do
         expect(subject.attribute?(:id)).to eq(true)
       end
 
-      it 'returns false for unknown attributes' do
+      it "returns false for unknown attributes" do
         expect(subject.attribute?(:foo)).to eq(false)
       end
     end

--- a/spec/unit/hanami/model/sql/schema/array_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/array_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Array" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Array }
 
@@ -9,69 +11,69 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Array" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_ary' do
+  it "coerces object that respond to #to_ary" do
     expect(described_class[input]).to eq(input.to_ary)
   end
 
-  it 'coerces string' do
-    input = 'foo'
+  it "coerces string" do
+    input = "foo"
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :foo
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for integer' do
+  it "raises error for integer" do
     input = 11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for float' do
+  it "raises error for float" do
     input = 3.14
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for bigdecimal' do
+  it "raises error for bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for date' do
+  it "raises error for date" do
     input = Date.today
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for datetime' do
+  it "raises error for datetime" do
     input = DateTime.new
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'raises error for time' do
+  it "raises error for time" do
     input = Time.now
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")
   end
 
-  it 'coerces array' do
+  it "coerces array" do
     input = []
     expect(described_class[input]).to eq(input)
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Array(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql/schema/bool_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/bool_spec.rb
@@ -1,76 +1,78 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Bool" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Bool }
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'returns true for true' do
+  it "returns true for true" do
     input = true
     expect(described_class[input]).to eq(input)
   end
 
-  it 'returns false for false' do
+  it "returns false for false" do
     input = true
     expect(described_class[input]).to eq(input)
   end
 
-  it 'raises error for string' do
-    input = 'foo'
+  it "raises error for string" do
+    input = "foo"
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :foo
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for integer' do
+  it "raises error for integer" do
     input = 11
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for float' do
+  it "raises error for float" do
     input = 3.14
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for bigdecimal' do
+  it "raises error for bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for date' do
+  it "raises error for date" do
     input = Date.today
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for datetime' do
+  it "raises error for datetime" do
     input = DateTime.new
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for time' do
+  it "raises error for time" do
     input = Time.now
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(TypeError, "#{input.inspect} violates constraints (type?(FalseClass, #{input.inspect}) failed)")

--- a/spec/unit/hanami/model/sql/schema/date_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Date" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Date }
 
@@ -9,85 +11,85 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Date" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_date' do
+  it "coerces object that respond to #to_date" do
     expect(described_class[input]).to eq(input.to_date)
   end
 
-  it 'coerces string' do
+  it "coerces string" do
     date = Date.today
     input = date.to_s
 
     expect(described_class[input]).to eq(date)
   end
 
-  it 'coerces Hanami string' do
+  it "coerces Hanami string" do
     input = Hanami::Utils::String.new(Date.today)
     expect(described_class[input]).to eq(Date.parse(input))
   end
 
-  it 'raises error for meaningless string' do
-    input = 'foo'
+  it "raises error for meaningless string" do
+    input = "foo"
     expect { described_class[input] }
-      .to raise_error(ArgumentError, 'invalid date')
+      .to raise_error(ArgumentError, "invalid date")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :foo
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
   end
 
-  it 'raises error for integer' do
+  it "raises error for integer" do
     input = 11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
   end
 
-  it 'raises error for float' do
+  it "raises error for float" do
     input = 3.14
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
   end
 
-  it 'raises error for bigdecimal' do
+  it "raises error for bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
   end
 
-  it 'coerces date' do
+  it "coerces date" do
     input = Date.today
     date = input
 
     expect(described_class[input]).to eq(date)
   end
 
-  it 'coerces datetime' do
+  it "coerces datetime" do
     input = DateTime.new
     date = input.to_date
 
     expect(described_class[input]).to eq(date)
   end
 
-  it 'coerces time' do
+  it "coerces time" do
     input = Time.now
     date = input.to_date
 
     expect(described_class[input]).to eq(date)
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Date(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql/schema/date_time_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/date_time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::DateTime" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::DateTime }
 
@@ -9,85 +11,85 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::DateTime" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_datetime' do
+  it "coerces object that respond to #to_datetime" do
     expect(described_class[input]).to eq(input.to_datetime)
   end
 
-  it 'coerces string' do
+  it "coerces string" do
     date = DateTime.new
     input = date.to_s
 
     expect(described_class[input]).to eq(date)
   end
 
-  it 'coerces Hanami string' do
+  it "coerces Hanami string" do
     input = Hanami::Utils::String.new(DateTime.new)
     expect(described_class[input]).to eq(DateTime.parse(input))
   end
 
-  it 'raises error for meaningless string' do
-    input = 'foo'
+  it "raises error for meaningless string" do
+    input = "foo"
     expect { described_class[input] }
-      .to raise_error(ArgumentError, 'invalid date')
+      .to raise_error(ArgumentError, "invalid date")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :foo
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
   end
 
-  it 'raises error for integer' do
+  it "raises error for integer" do
     input = 11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
   end
 
-  it 'raises error for float' do
+  it "raises error for float" do
     input = 3.14
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
   end
 
-  it 'raises error for bigdecimal' do
+  it "raises error for bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
   end
 
-  it 'coerces date' do
+  it "coerces date" do
     input = Date.today
     date_time = input.to_datetime
 
     expect(described_class[input]).to eq(date_time)
   end
 
-  it 'coerces datetime' do
+  it "coerces datetime" do
     input = DateTime.new
     date_time = input
 
     expect(described_class[input]).to eq(date_time)
   end
 
-  it 'coerces time' do
+  it "coerces time" do
     input = Time.now
     date_time = input.to_datetime
 
     expect(described_class[input]).to be_within(2).of(date_time)
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for DateTime(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql/schema/decimal_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/decimal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Decimal" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Decimal }
 
@@ -9,81 +11,81 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Decimal" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_d' do
+  it "coerces object that respond to #to_d" do
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'coerces string representing int' do
-    input = '1'
+  it "coerces string representing int" do
+    input = "1"
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'coerces Hanami string representing int' do
-    input = Hanami::Utils::String.new('1')
+  it "coerces Hanami string representing int" do
+    input = Hanami::Utils::String.new("1")
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'coerces string representing float' do
-    input = '3.14'
+  it "coerces string representing float" do
+    input = "3.14"
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'coerces Hanami string representing float' do
-    input = Hanami::Utils::String.new('3.14')
+  it "coerces Hanami string representing float" do
+    input = Hanami::Utils::String.new("3.14")
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :house_11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
   end
 
-  it 'coerces integer' do
+  it "coerces integer" do
     input = 23
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'coerces float' do
+  it "coerces float" do
     input = 3.14
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'coerces bigdecimal' do
+  it "coerces bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect(described_class[input]).to eq(input.to_d)
   end
 
-  it 'raises error for date' do
+  it "raises error for date" do
     input = Date.today
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
   end
 
-  it 'raises error for datetime' do
+  it "raises error for datetime" do
     input = DateTime.new
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
   end
 
-  it 'raises error for time' do
+  it "raises error for time" do
     input = Time.now
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for BigDecimal(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql/schema/float_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/float_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Float" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Float }
 
@@ -9,87 +11,87 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Float" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_f' do
+  it "coerces object that respond to #to_f" do
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'coerces string representing int' do
-    input = '1'
+  it "coerces string representing int" do
+    input = "1"
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'coerces Hanami string representing int' do
-    input = Hanami::Utils::String.new('1')
+  it "coerces Hanami string representing int" do
+    input = Hanami::Utils::String.new("1")
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'coerces string representing float' do
-    input = '3.14'
+  it "coerces string representing float" do
+    input = "3.14"
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'coerces Hanami string representing float' do
-    input = Hanami::Utils::String.new('3.14')
+  it "coerces Hanami string representing float" do
+    input = Hanami::Utils::String.new("3.14")
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'raises error for meaningless string' do
-    input = 'foo'
+  it "raises error for meaningless string" do
+    input = "foo"
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :house_11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
   end
 
-  it 'coerces integer' do
+  it "coerces integer" do
     input = 23
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'coerces float' do
+  it "coerces float" do
     input = 3.14
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'coerces bigdecimal' do
+  it "coerces bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect(described_class[input]).to eq(input.to_f)
   end
 
-  it 'raises error for date' do
+  it "raises error for date" do
     input = Date.today
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
   end
 
-  it 'raises error for datetime' do
+  it "raises error for datetime" do
     input = DateTime.new
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
   end
 
-  it 'raises error for time' do
+  it "raises error for time" do
     input = Time.now
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Float(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql/schema/hash_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/hash_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Hash" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Hash }
 
@@ -9,70 +11,70 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Hash" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_hash' do
+  it "coerces object that respond to #to_hash" do
     expect(described_class[input]).to eq(input.to_hash)
   end
 
-  it 'coerces string' do
-    input = 'foo'
+  it "coerces string" do
+    input = "foo"
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :foo
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for integer' do
+  it "raises error for integer" do
     input = 11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for float' do
+  it "raises error for float" do
     input = 3.14
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for bigdecimal' do
+  it "raises error for bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for date' do
+  it "raises error for date" do
     input = Date.today
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for datetime' do
+  it "raises error for datetime" do
     input = DateTime.new
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for time' do
+  it "raises error for time" do
     input = Time.now
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Hash(): #{input.inspect}")
   end
 
-  it 'coerces hash' do
+  it "coerces hash" do
     input = {}
     expect(described_class[input]).to eq(input)
   end

--- a/spec/unit/hanami/model/sql/schema/int_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/int_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Int" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Int }
 
@@ -9,77 +11,77 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Int" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_int' do
+  it "coerces object that respond to #to_int" do
     expect(described_class[input]).to eq(input.to_int)
   end
 
-  it 'coerces string representing int' do
-    input = '1'
+  it "coerces string representing int" do
+    input = "1"
     expect(described_class[input]).to eq(input.to_i)
   end
 
-  it 'coerces Hanami string representing int' do
-    input = Hanami::Utils::String.new('1')
+  it "coerces Hanami string representing int" do
+    input = Hanami::Utils::String.new("1")
     expect(described_class[input]).to eq(input.to_i)
   end
 
-  it 'raises error for meaningless string' do
-    input = 'foo'
+  it "raises error for meaningless string" do
+    input = "foo"
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :house_11
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
   end
 
-  it 'coerces integer' do
+  it "coerces integer" do
     input = 23
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces float' do
+  it "coerces float" do
     input = 3.14
     expect(described_class[input]).to eq(input.to_i)
   end
 
-  it 'coerces bigdecimal' do
+  it "coerces bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect(described_class[input]).to eq(input.to_i)
   end
 
-  it 'raises error for date' do
+  it "raises error for date" do
     input = Date.today
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
   end
 
-  it 'raises error for datetime' do
+  it "raises error for datetime" do
     input = DateTime.new
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
   end
 
-  it 'raises error for time' do
+  it "raises error for time" do
     input = Time.now
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Integer(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql/schema/string_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/string_spec.rb
@@ -1,57 +1,59 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::String" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::String }
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces string' do
-    input = 'foo'
+  it "coerces string" do
+    input = "foo"
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces symbol' do
+  it "coerces symbol" do
     input = :foo
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces integer' do
+  it "coerces integer" do
     input = 23
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces float' do
+  it "coerces float" do
     input = 3.14
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces bigdecimal' do
+  it "coerces bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces date' do
+  it "coerces date" do
     input = Date.today
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces datetime' do
+  it "coerces datetime" do
     input = DateTime.new
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces time' do
+  it "coerces time" do
     input = Time.now
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces array' do
+  it "coerces array" do
     input = []
     expect(described_class[input]).to eq(input.to_s)
   end
 
-  it 'coerces hash' do
+  it "coerces hash" do
     input = {}
     expect(described_class[input]).to eq(input.to_s)
   end

--- a/spec/unit/hanami/model/sql/schema/time_spec.rb
+++ b/spec/unit/hanami/model/sql/schema/time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::Sql::Types::Schema::Time" do
   let(:described_class) { Hanami::Model::Sql::Types::Schema::Time }
 
@@ -9,86 +11,86 @@ RSpec.describe "Hanami::Model::Sql::Types::Schema::Time" do
     end.new
   end
 
-  it 'returns nil for nil' do
+  it "returns nil for nil" do
     input = nil
     expect(described_class[input]).to eq(input)
   end
 
-  it 'coerces object that respond to #to_time' do
+  it "coerces object that respond to #to_time" do
     expect(described_class[input]).to be_within(2).of(input.to_time)
   end
 
-  it 'coerces string' do
+  it "coerces string" do
     time = Time.now
     input = time.to_s
 
     expect(described_class[input]).to be_within(2).of(time)
   end
 
-  it 'coerces Hanami string' do
+  it "coerces Hanami string" do
     input = Hanami::Utils::String.new(Time.now)
     expect(described_class[input]).to be_within(2).of(Time.parse(input))
   end
 
-  it 'raises error for meaningless string' do
-    input = 'foo'
+  it "raises error for meaningless string" do
+    input = "foo"
     expect { described_class[input] }
       .to raise_error(ArgumentError, "no time information in #{input.inspect}")
   end
 
-  it 'raises error for symbol' do
+  it "raises error for symbol" do
     input = :foo
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
   end
 
-  it 'coerces integer' do
+  it "coerces integer" do
     input = 11
     time = Time.at(input)
 
     expect(described_class[input]).to be_within(2).of(time)
   end
 
-  it 'raises error for float' do
+  it "raises error for float" do
     input = 3.14
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
   end
 
-  it 'raises error for bigdecimal' do
+  it "raises error for bigdecimal" do
     input = BigDecimal.new(3.14, 10)
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
   end
 
-  it 'coerces date' do
+  it "coerces date" do
     input = Date.today
     time = input.to_time
 
     expect(described_class[input]).to be_within(2).of(time)
   end
 
-  it 'coerces datetime' do
+  it "coerces datetime" do
     input = DateTime.new
     time = input.to_time
 
     expect(described_class[input]).to be_within(2).of(time)
   end
 
-  it 'coerces time' do
+  it "coerces time" do
     input = Time.now
     time = input
 
     expect(described_class[input]).to be_within(2).of(time)
   end
 
-  it 'raises error for array' do
+  it "raises error for array" do
     input = []
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")
   end
 
-  it 'raises error for hash' do
+  it "raises error for hash" do
     input = {}
     expect { described_class[input] }
       .to raise_error(ArgumentError, "invalid value for Time(): #{input.inspect}")

--- a/spec/unit/hanami/model/sql_spec.rb
+++ b/spec/unit/hanami/model/sql_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::Sql do
   describe ".migration" do
     it "returns a new migration" do

--- a/spec/unit/hanami/model/unique_constraint_violation_error_spec.rb
+++ b/spec/unit/hanami/model/unique_constraint_violation_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Hanami::Model::UniqueConstraintViolationError do
   it "inherits from Hanami::Model::ConstraintViolationError" do
     expect(described_class.ancestors).to include(Hanami::Model::ConstraintViolationError)

--- a/spec/unit/hanami/model/version_spec.rb
+++ b/spec/unit/hanami/model/version_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe "Hanami::Model::VERSION" do
   it "exposes version" do
-    expect(Hanami::Model::VERSION).to eq("1.1.0")
+    expect(Hanami::Model::VERSION).to eq("2.0.0.alpha1")
   end
 end

--- a/spec/unit/hanami/model/version_spec.rb
+++ b/spec/unit/hanami/model/version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Hanami::Model::VERSION" do
   it "exposes version" do
     expect(Hanami::Model::VERSION).to eq("1.1.0")


### PR DESCRIPTION
Hello!

Just started with Hanami and I thought [this issue](https://github.com/hanami/hanami/issues/921) would be a good opportunity for a first dive-in! And the JRuby version 9.2.0.0 was just released! 💃 

[I also made this PR for the Devtools repo](https://github.com/hanami/devtools/pull/2), so I could check the tests with the rubocop unstable's `TargetRubyVersion` changed.


To provide as much information as possible:

- To check the tests with the new `TargetRubyVersion` I modified (not committed) the `inherit_form` in Devtools' `.rubocop-unstable.yml`.
- Run the tests! However, got 1 offense:
```Inspecting 136 files
.....................C..................................................................................................................

Offenses:

lib/hanami/model/migrator/mysql_adapter.rb:26:24: C: Performance/RegexpMatch: Use match? instead of match when MatchData is not used.
          message = if e.message.match(/database exists/) # rubocop:disable Performance/RedundantMatch
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/hanami/model/migrator/mysql_adapter.rb:40:24: C: Performance/RegexpMatch: Use match? instead of match when MatchData is not used.
          message = if e.message.match(/doesn\'t exist/) # rubocop:disable Performance/RedundantMatch
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

- I made the changes requested and re-run the tests:
```Inspecting 136 files
.....................W..................................................................................................................

Offenses:

lib/hanami/model/migrator/mysql_adapter.rb:26:60: W: Lint/UnneededCopDisableDirective: Unnecessary disabling of Performance/RedundantMatch.
          message = if e.message.match?(/database exists/) # rubocop:disable Performance/RedundantMatch
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/hanami/model/migrator/mysql_adapter.rb:40:59: W: Lint/UnneededCopDisableDirective: Unnecessary disabling of Performance/RedundantMatch.
          message = if e.message.match?(/doesn\'t exist/) # rubocop:disable Performance/RedundantMatch
                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I did as Rubocop commands and removed the directive!


The next tests run looked fine! 🍻  So I understand the last two changes make sense but let me know.

Thank you! 🌷 
