### PR TITLE
Revert unintended change to has_many

### DIFF
--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -113,7 +113,7 @@ module Hanami
         # @since 0.7.0
         # @api private
         def command(target, relation, options = {})
-          repository.command(target => relation, **options)
+          repository.command(target, relation, options)
         end
 
         # @since 0.7.0

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -155,7 +155,6 @@ module Hanami
     def command(*args, **opts, &block)
       opts[:use] = COMMAND_PLUGINS | Array(opts[:use])
       opts[:mapper] = opts.fetch(:mapper, Model::MappedRelation.mapper_name)
-
       super(*args, **opts, &block)
     end
 


### PR DESCRIPTION
IIRC when I was making sure that using rom commands like create(relation, result: :many) I needed to override the command method from rom.
During the exploration and testing I had to change the call to it inside has_many so the arguments were passed correctly.
And guess what? After I solved the issue I completely forgot about the change, since everything worked. >.<