### PR TITLE
Remove global state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
            HANAMI_DATABASE_USERNAME: root
            HANAMI_DATABASE_PASSWORD: hanami
            HANAMI_DATABASE_HOST: 127.0.0.1
-       - image: cytopia/mysql-5.7
+       - image: circleci/mysql:5.7-ram
          environment:
            MYSQL_ROOT_PASSWORD: hanami
     working_directory: ~/hanami-model

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "hanami-utils",    "~> 2.0.alpha"
   spec.add_runtime_dependency "rom",             "~> 4.2"
-  spec.add_runtime_dependency "rom-sql",         "~> 2.4"
+  spec.add_runtime_dependency "rom-sql",         "~> 2.5"
   spec.add_runtime_dependency "rom-repository",  "~> 2.0"
   spec.add_runtime_dependency "dry-types",       "~> 0.12"
   spec.add_runtime_dependency "dry-inflector",   "~> 0.1"

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -77,12 +77,6 @@ module Hanami
       @container
     end
 
-    # @since 0.1.0
-    def self.load!(&blk)
-      @container = configuration.load!(repositories, &blk)
-      @loaded    = true
-    end
-
     # Disconnect from the database
     #
     # This is useful for rebooting applications in production and to ensure that

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -179,8 +179,8 @@ module Hanami
         @container = ROM.container(rom)
         define_entities_mappings(@container, repositories)
         @container
-      # rescue => e
-      #   raise Hanami::Model::Error.for(e)
+      rescue => e
+        raise Hanami::Model::Error.for(e)
       end
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -34,9 +34,10 @@ module Hanami
 
       # @since 0.2.0
       # @api private
-      def initialize(configurator)
+      def initialize(configurator) # rubocop:disable Metrics/MethodLength
         @backend = configurator.backend
         @url = configurator.url
+        @container         = nil
         @migrations        = configurator._migrations
         @schema            = configurator._schema
         @gateway_config    = configurator._gateway
@@ -45,6 +46,10 @@ module Hanami
         @inflector         = configurator.inflector
         @mappings          = {}
         @entities          = {}
+      end
+
+      def container
+        @container or raise "not loaded"
       end
 
       # NOTE: This must be changed when we want to support several adapters at the time
@@ -170,9 +175,9 @@ module Hanami
         # FIXME: without "touching" the db, inferrer crashes on sqlite, wtf?
         gateway.connection.tables
 
-        container = ROM.container(rom)
-        define_entities_mappings(container, repositories)
-        container
+        @container = ROM.container(rom)
+        define_entities_mappings(@container, repositories)
+        @container
       rescue => e
         raise Hanami::Model::Error.for(e)
       end

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -2,6 +2,7 @@
 
 require "rom/configuration"
 require "hanami/utils/blank"
+require "hanami/model/repository_configurer"
 
 module Hanami
   module Model
@@ -169,7 +170,7 @@ module Hanami
         rom.setup.auto_registration(config.directory.to_s) unless config.directory.nil?
         rom.instance_eval(&blk)                            if     block_given?
         configure_gateway
-        repositories.each(&:load!)
+        configure_repositories(repositories)
         self.logger = logger
 
         # FIXME: without "touching" the db, inferrer crashes on sqlite, wtf?
@@ -183,6 +184,14 @@ module Hanami
       end
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize
+
+      # @since x.x.x
+      # @api private
+      def configure_repositories(repositories)
+        repositories.each do |repository|
+          RepositoryConfigurer.call(repository, self)
+        end
+      end
 
       # @since 1.0.0
       # @api private

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -179,8 +179,8 @@ module Hanami
         @container = ROM.container(rom)
         define_entities_mappings(@container, repositories)
         @container
-      rescue => e
-        raise Hanami::Model::Error.for(e)
+      # rescue => e
+      #   raise Hanami::Model::Error.for(e)
       end
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize

--- a/lib/hanami/model/repository_configurer.rb
+++ b/lib/hanami/model/repository_configurer.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Model
+    # Repository configurer
+    #
+    # @since x.x.x
+    # @api private
+    class RepositoryConfigurer
+      # Configure a repository
+      #
+      # @param [Hanami::Repository] the repository
+      # @param [Hanami::Model::Configuration] a configuration
+      #
+      # @since x.x.x
+      # @api private
+      def self.call(repository, configuration)
+        define_relation(repository, configuration)
+        define_mapping(repository, configuration)
+      end
+
+      # @since x.x.x
+      # @api private
+      #
+      # rubocop:disable Metrics/MethodLength
+      def self.define_relation(repository, configuration)
+        a = repository.associations
+        s = repository.schema
+
+        configuration.relation(repository.relation) do
+          if s.nil?
+            schema(infer: true) do
+              associations(&a) unless a.nil?
+            end
+          else
+            schema(&s)
+          end
+        end
+
+        repository.root(repository.relation)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # @since x.x.x
+      # @api private
+      #
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
+      def self.define_mapping(repository, configuration)
+        repository.entity = Utils::Class.load!(repository.entity_name)
+        e = repository.entity
+        m = repository.mapping
+
+        blk = lambda do |_|
+          model       e
+          register_as :entity
+          instance_exec(&m) unless m.nil?
+        end
+
+        root = repository.root
+        configuration.mappers { define(root, &blk) }
+        configuration.define_mappings(root, &blk)
+        configuration.register_entity(repository.relation, repository.entity_name.underscore, e)
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
+  end
+end

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -221,7 +221,7 @@ module Hanami
       Class.new(Hanami::Repository) do
         root relation_name
         def self.inherited(klass)
-          klass.class_eval <<~CODE
+          klass.class_eval <<~CODE, __FILE__, __LINE__ + 1
             include Utils::ClassAttribute
 
             auto_struct false

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -108,7 +108,7 @@ module Hanami
   # @see Hanami::Entity
   # @see http://martinfowler.com/eaaCatalog/repository.html
   # @see http://en.wikipedia.org/wiki/Dependency_inversion_principle
-  class Repository < ROM::Repository::Root # rubocop:disable Metrics/ClassLength
+  class Repository < ROM::Repository::Root
     # Plugins for database commands
     #
     # @since 0.7.0
@@ -123,14 +123,6 @@ module Hanami
     # @api private
     def self.configuration
       Hanami::Model.configuration
-    end
-
-    # Container
-    #
-    # @since 0.7.0
-    # @api private
-    def self.container
-      Hanami::Model.container
     end
 
     # Define a new ROM::Command while preserving the defaults used by Hanami itself.
@@ -396,8 +388,8 @@ module Hanami
     # @return [Hanami::Repository] the new instance
     #
     # @since 0.7.0
-    def self.new(container = self.container, options = {})
-      super
+    def self.new(configuration = self.configuration, options = {})
+      super(configuration.container, options)
     end
 
     # Find by primary key

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -230,7 +230,6 @@ module Hanami
 
         class_attribute :entity
         class_attribute :entity_name
-        class_attribute :relation
 
         Hanami::Utils::IO.silence_warnings do
           def self.relation=(name)
@@ -240,6 +239,7 @@ module Hanami
 
         self.entity_name = Model::EntityName.new(name)
         self.relation    = Model::RelationName.new(name)
+
 
         commands :create, update: :by_pk, delete: :by_pk, mapper: :entity, use: COMMAND_PLUGINS
         prepend Commands

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -388,7 +388,7 @@ module Hanami
     # @return [Hanami::Repository] the new instance
     #
     # @since 0.7.0
-    def self.new(configuration = self.configuration, options = {})
+    def self.new(configuration:, **options)
       super(configuration.container, options)
     end
 

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -217,10 +217,9 @@ module Hanami
     # @api private
     #
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def self.[](relation_name)
       Class.new(Hanami::Repository) do
-        self.root relation_name
+        root relation_name
         def self.inherited(klass)
           klass.class_eval <<~CODE
             include Utils::ClassAttribute
@@ -236,7 +235,7 @@ module Hanami
             class_attribute :relation
 
             self.entity_name = Model::EntityName.new(name)
-            self.relation = :#{self.root}
+            self.relation = :#{root}
 
 
             commands :create, update: :by_pk, delete: :by_pk, mapper: :entity, use: COMMAND_PLUGINS
@@ -248,7 +247,6 @@ module Hanami
       end
     end
 
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
     # Extend commands from ROM::Repository with error management

--- a/spec/integration/hanami/model/associations/belongs_to_spec.rb
+++ b/spec/integration/hanami/model/associations/belongs_to_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Associations (belongs_to)" do
   it "returns nil if association wasn't preloaded" do
-    repository = BookRepository.new
+    repository = BookRepository.new(configuration: configuration)
     book       = repository.create(name: "L")
     found      = repository.find(book.id)
 
@@ -10,8 +10,8 @@ RSpec.describe "Associations (belongs_to)" do
   end
 
   it "preloads the associated record" do
-    repository = BookRepository.new
-    author = AuthorRepository.new.create(name: "Michel Foucault")
+    repository = BookRepository.new(configuration: configuration)
+    author = AuthorRepository.new(configuration: configuration).create(name: "Michel Foucault")
     book   = repository.create(author_id: author.id, title: "Surveiller et punir")
     found = repository.find_with_author(book.id)
 
@@ -20,8 +20,8 @@ RSpec.describe "Associations (belongs_to)" do
   end
 
   it "returns an author" do
-    repository = BookRepository.new
-    author = AuthorRepository.new.create(name: "Maurice Leblanc")
+    repository = BookRepository.new(configuration: configuration)
+    author = AuthorRepository.new(configuration: configuration).create(name: "Maurice Leblanc")
     book   = repository.create(author_id: author.id, title: "L'Aguille Creuse")
     found = repository.author_for(book)
 
@@ -29,7 +29,7 @@ RSpec.describe "Associations (belongs_to)" do
   end
 
   it "returns nil if there's no associated record" do
-    repository = BookRepository.new
+    repository = BookRepository.new(configuration: configuration)
     book = repository.create(title: "The no author book")
 
     expect { repository.find_with_author(book.id) }.to_not raise_error

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe "Associations (has_many)" do
-  let(:authors) { AuthorRepository.new }
-  let(:books) { BookRepository.new }
+  let(:authors) { AuthorRepository.new(configuration: configuration) }
+  let(:books) { BookRepository.new(configuration: configuration) }
 
   it "returns nil if association wasn't preloaded" do
     author = authors.create(name: "L")
@@ -70,8 +70,8 @@ RSpec.describe "Associations (has_many)" do
   # REMOVE
   #
   it "removes an object from the collection" do
-    authors = AuthorRepository.new
-    books = BookRepository.new
+    authors = AuthorRepository.new(configuration: configuration)
+    books = BookRepository.new(configuration: configuration)
 
     # Book under test
     author = authors.create(name: "Douglas Adams")

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.describe "Associations (has_one)" do
   extend PlatformHelpers
 
-  let(:users) { UserRepository.new }
-  let(:avatars) { AvatarRepository.new }
+  let(:users) { UserRepository.new(configuration: configuration) }
+  let(:avatars) { AvatarRepository.new(configuration: configuration) }
 
   it "returns nil if the association wasn't preloaded" do
     user       = users.create(name: "John Doe")

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe "Associations (has_many :through)" do
   #### REPOS
-  let(:books) { BookRepository.new }
-  let(:categories) { CategoryRepository.new }
-  let(:ontologies) { BookOntologyRepository.new }
+  let(:books) { BookRepository.new(configuration: configuration) }
+  let(:categories) { CategoryRepository.new(configuration: configuration) }
+  let(:ontologies) { BookOntologyRepository.new(configuration: configuration) }
 
   ### ENTITIES
   let(:book) { books.create(title: "Ontology: Encyclopedia of Database Systems") }

--- a/spec/integration/hanami/model/associations/relation_alias_spec.rb
+++ b/spec/integration/hanami/model/associations/relation_alias_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe "Alias (:as)  support for associations" do
-  let(:users) { UserRepository.new }
-  let(:posts) { PostRepository.new }
-  let(:comments) { CommentRepository.new }
+  let(:users) { UserRepository.new(configuration: configuration) }
+  let(:posts) { PostRepository.new(configuration: configuration) }
+  let(:comments) { CommentRepository.new(configuration: configuration) }
 
   it "the attribute is named after the association" do
     user = users.create(name: "Jules Verne")

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#find" do
     it "finds record by primary key" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       found = repository.find(user.id)
 
@@ -15,7 +15,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "returns nil when nil is given" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.create(name: "L")
       found = repository.find(nil)
 
@@ -23,7 +23,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "returns nil for missing record" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       found = repository.find("9999999")
 
       expect(found).to be_nil
@@ -35,7 +35,7 @@ RSpec.describe "Repository (base)" do
         repository.clear
       end
 
-      let(:repository) { LabelRepository.new }
+      let(:repository) { LabelRepository.new(configuration: configuration) }
       let(:id)         { 1 }
 
       it "raises error" do
@@ -49,7 +49,7 @@ RSpec.describe "Repository (base)" do
     # See https://github.com/hanami/model/issues/399
     describe "with custom relation" do
       it "finds record by primary key" do
-        repository = AccessTokenRepository.new
+        repository = AccessTokenRepository.new(configuration: configuration)
         access_token = repository.create(token: "123")
         found        = repository.find(access_token.id)
 
@@ -60,7 +60,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#all" do
     it "returns all the records" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
 
       expect(repository.all).to be_an_instance_of(Array)
@@ -70,7 +70,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#first" do
     it "returns first record from table" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.clear
 
       user = repository.create(name: "James Hetfield")
@@ -82,7 +82,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#last" do
     it "returns last record from table" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.clear
 
       repository.create(name: "Tom")
@@ -95,7 +95,7 @@ RSpec.describe "Repository (base)" do
   # https://github.com/hanami/model/issues/473
   describe "querying" do
     it "allows to access relation attributes via square bracket syntax" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.clear
 
       expected = [repository.create(name: "Ella"),
@@ -109,7 +109,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#clear" do
     it "clears all the records" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.create(name: "L")
 
       repository.clear
@@ -120,7 +120,7 @@ RSpec.describe "Repository (base)" do
   describe "relation" do
     describe "read" do
       it "reads records from the database given a raw query string" do
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         repository.create(name: "L")
 
         users = repository.find_all_by_manual_query
@@ -134,7 +134,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#create" do
     it "creates record from data" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
 
       expect(user).to be_an_instance_of(User)
@@ -144,7 +144,7 @@ RSpec.describe "Repository (base)" do
 
     it "creates record from entity" do
       entity = User.new(name: "L")
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(entity)
 
       # It doesn't mutate original entity
@@ -161,7 +161,7 @@ RSpec.describe "Repository (base)" do
 
     unless_platform(engine: :jruby, db: :sqlite) do
       it "automatically touches timestamps" do
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         user = repository.create(name: "L")
 
         expect(user.created_at).to be_within(2).of(Time.now.utc)
@@ -169,7 +169,7 @@ RSpec.describe "Repository (base)" do
       end
 
       it "respects given timestamps" do
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         given_time = Time.new(2010, 1, 1, 12, 0, 0, "+00:00")
 
         user = repository.create(name: "L", created_at: given_time, updated_at: given_time)
@@ -179,7 +179,7 @@ RSpec.describe "Repository (base)" do
       end
 
       it "can update timestamps" do
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         user = repository.create(name: "L")
         expect(user.created_at).to be_within(2).of(Time.now.utc)
         expect(user.updated_at).to be_within(2).of(Time.now.utc)
@@ -198,8 +198,8 @@ RSpec.describe "Repository (base)" do
 
       # Bug: https://github.com/hanami/model/issues/412
       it "can have only creation timestamp" do
-        user = UserRepository.new.create(name: "L")
-        repository = AvatarRepository.new
+        user = UserRepository.new(configuration: configuration).create(name: "L")
+        repository = AvatarRepository.new(configuration: configuration)
         account = repository.create(url: "http://foo.com", user_id: user.id)
         expect(account.created_at).to be_within(2).of(Time.now.utc)
       end
@@ -207,7 +207,7 @@ RSpec.describe "Repository (base)" do
 
     # Bug: https://github.com/hanami/model/issues/237
     it "respects database defaults" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
 
       expect(user.comments_count).to eq(0)
@@ -215,7 +215,7 @@ RSpec.describe "Repository (base)" do
 
     # Bug: https://github.com/hanami/model/issues/272
     it "accepts booleans as attributes" do
-      user = UserRepository.new.create(name: "L", active: false)
+      user = UserRepository.new(configuration: configuration).create(name: "L", active: false)
       expect(user.active).to eq(false)
     end
 
@@ -233,7 +233,7 @@ RSpec.describe "Repository (base)" do
     #     engine(:jruby).db(:mysql) { 'bogus' }
     #   end
 
-    #   expect { UserRepository.new.create(name: 'L', bogus: 23) }.to raise_error do |error|
+    #   expect { UserRepository.new(configuration: configuration).create(name: 'L', bogus: 23) }.to raise_error do |error|
     #     expect(error).to be_a(expected_error)
     #     expect(error.message).to include(message)
     #   end
@@ -252,7 +252,7 @@ RSpec.describe "Repository (base)" do
         engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Column 'active' cannot be null" }
       end
 
-      expect { UserRepository.new.create(name: "L", active: nil) }.to raise_error do |error|
+      expect { UserRepository.new(configuration: configuration).create(name: "L", active: nil) }.to raise_error do |error|
         expect(error).to be_a(expected_error)
         expect(error.message).to include(message)
       end
@@ -273,7 +273,7 @@ RSpec.describe "Repository (base)" do
         engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Duplicate entry '#{email}' for key 'users_email_index'" }
       end
 
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.create(name: "Test", email: email)
 
       expect { repository.create(name: "L", email: email) }.to raise_error do |error|
@@ -295,7 +295,7 @@ RSpec.describe "Repository (base)" do
         engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)" }
       end
 
-      expect { AvatarRepository.new.create(user_id: 999_999_999, url: "url") }.to raise_error do |error|
+      expect { AvatarRepository.new(configuration: configuration).create(user_id: 999_999_999, url: "url") }.to raise_error do |error|
         expect(error).to be_a(expected_error)
         expect(error.message).to include(message)
       end
@@ -315,7 +315,7 @@ RSpec.describe "Repository (base)" do
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "users_age_check"' }
         end
 
-        expect { UserRepository.new.create(name: "L", age: 1) }.to raise_error do |error|
+        expect { UserRepository.new(configuration: configuration).create(name: "L", age: 1) }.to raise_error do |error|
           expect(error).to         be_a(expected)
           expect(error.message).to include(message)
         end
@@ -332,7 +332,7 @@ RSpec.describe "Repository (base)" do
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "comments_count_constraint"' }
         end
 
-        expect { UserRepository.new.create(name: "L", comments_count: -1) }.to raise_error do |error|
+        expect { UserRepository.new(configuration: configuration).create(name: "L", comments_count: -1) }.to raise_error do |error|
           expect(error).to         be_a(expected)
           expect(error.message).to include(message)
         end
@@ -342,7 +342,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#update" do
     it "updates record from data" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       updated = repository.update(user.id, name: "Luca")
 
@@ -353,7 +353,7 @@ RSpec.describe "Repository (base)" do
 
     it "updates record from entity" do
       entity = User.new(name: "Luca")
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       updated = repository.update(user.id, entity)
 
@@ -366,7 +366,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "returns nil when record cannot be found" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       updated = repository.update("9999999", name: "Luca")
 
       expect(updated).to be_nil
@@ -378,7 +378,7 @@ RSpec.describe "Repository (base)" do
 
     unless_platform(engine: :jruby, db: :sqlite) do
       it "automatically touches timestamps" do
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         user = repository.create(name: "L")
         sleep 0.1
         updated = repository.update(user.id, name: "Luca")
@@ -402,7 +402,7 @@ RSpec.describe "Repository (base)" do
     #     engine(:jruby).db(:mysql) { 'bogus' }
     #   end
 
-    #   repository = UserRepository.new
+    #   repository = UserRepository.new(configuration: configuration)
     #   user = repository.create(name: 'L')
 
     #   expect { repository.update(user.id, bogus: 23) }.to raise_error do |error|
@@ -426,7 +426,7 @@ RSpec.describe "Repository (base)" do
           engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Column 'active' cannot be null" }
         end
 
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         user = repository.create(name: "L")
 
         expect { repository.update(user.id, active: nil) }.to raise_error do |error|
@@ -451,7 +451,7 @@ RSpec.describe "Repository (base)" do
         engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Duplicate entry '#{email}' for key 'users_email_index'" }
       end
 
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       repository.create(name: "UpdateTest", email: email)
 
@@ -474,8 +474,8 @@ RSpec.describe "Repository (base)" do
         engine(:jruby).db(:mysql) { "Java::ComMysqlJdbcExceptionsJdbc4::MySQLIntegrityConstraintViolationException: Cannot add or update a child row: a foreign key constraint fails (`hanami_model`.`avatars`, CONSTRAINT `avatars_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE)" }
       end
 
-      user = UserRepository.new.create(name: "L")
-      repository = AvatarRepository.new
+      user = UserRepository.new(configuration: configuration).create(name: "L")
+      repository = AvatarRepository.new(configuration: configuration)
       avatar = repository.create(user_id: user.id, url: "a valid url")
 
       expect { repository.update(avatar.id, user_id: 999_999_999) }.to raise_error do |error|
@@ -498,7 +498,7 @@ RSpec.describe "Repository (base)" do
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "users_age_check"' }
         end
 
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         user = repository.create(name: "L")
 
         expect { repository.update(user.id, age: 17) }.to raise_error do |error|
@@ -518,7 +518,7 @@ RSpec.describe "Repository (base)" do
           engine(:jruby).db(:postgresql) { 'Java::OrgPostgresqlUtil::PSQLException: ERROR: new row for relation "users" violates check constraint "comments_count_constraint"' }
         end
 
-        repository = UserRepository.new
+        repository = UserRepository.new(configuration: configuration)
         user = repository.create(name: "L")
 
         expect { repository.update(user.id, comments_count: -2) }.to raise_error do |error|
@@ -531,7 +531,7 @@ RSpec.describe "Repository (base)" do
 
   describe "#delete" do
     it "deletes record" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       deleted = repository.delete(user.id)
 
@@ -544,7 +544,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "returns nil when record cannot be found" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       deleted = repository.delete("9999999")
 
       expect(deleted).to be_nil
@@ -556,7 +556,7 @@ RSpec.describe "Repository (base)" do
 
   describe "custom finder" do
     it "returns records" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       found = repository.by_name("L")
 
@@ -564,7 +564,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "uses root relation" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       found = repository.by_name_with_root("L")
 
@@ -572,7 +572,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "selects only a single column" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.clear
 
       repository.create([{ name: "L", age: 35 }, { name: "MG", age: 34 }])
@@ -588,7 +588,7 @@ RSpec.describe "Repository (base)" do
     end
 
     it "selects multiple columns" do
-      repository = UserRepository.new
+      repository = UserRepository.new(configuration: configuration)
       repository.clear
 
       repository.create([{ name: "L", age: 35 }, { name: "MG", age: 34 }])
@@ -607,7 +607,7 @@ RSpec.describe "Repository (base)" do
   with_platform(db: :postgresql) do
     describe "PostgreSQL" do
       it "finds record by primary key (UUID)" do
-        repository = SourceFileRepository.new
+        repository = SourceFileRepository.new(configuration: configuration)
         file = repository.create(name: "path/to/file.rb", languages: ["ruby"], metadata: { coverage: 100.0 }, content: "class Foo; end")
         found = repository.find(file.id)
 
@@ -618,7 +618,7 @@ RSpec.describe "Repository (base)" do
       end
 
       it "returns nil for nil primary key (UUID)" do
-        repository = SourceFileRepository.new
+        repository = SourceFileRepository.new(configuration: configuration)
 
         found = repository.find(nil)
         expect(found).to be_nil
@@ -630,7 +630,7 @@ RSpec.describe "Repository (base)" do
       #   LINE 1: ...", "updated_at" FROM "source_files" WHERE ("id" = '9999999')...
       it "returns nil for missing record (UUID)"
       # it 'returns nil for missing record (UUID)' do
-      #   repository = SourceFileRepository.new
+      #   repository = SourceFileRepository.new(configuration: configuration)
 
       #   found = repository.find('9999999')
       #   expect(found).to be_nil
@@ -639,7 +639,7 @@ RSpec.describe "Repository (base)" do
       describe "JSON types" do
         it "writes hashes" do
           hash = { first_name: "John", age: 53, married: true, car: nil }
-          repository = SourceFileRepository.new
+          repository = SourceFileRepository.new(configuration: configuration)
           column_type = repository.create(metadata: hash, name: "test", content: "test", json_info: hash)
           found = repository.find(column_type.id)
 
@@ -649,7 +649,7 @@ RSpec.describe "Repository (base)" do
 
         it "writes arrays" do
           array = ["abc", 1, true, nil]
-          repository = SourceFileRepository.new
+          repository = SourceFileRepository.new(configuration: configuration)
           column_type = repository.create(metadata: array, name: "test", content: "test", json_info: array)
           found = repository.find(column_type.id)
 
@@ -660,7 +660,7 @@ RSpec.describe "Repository (base)" do
 
       describe "when timestamps aren't enabled" do
         it "writes the proper PG types" do
-          repository = ProductRepository.new
+          repository = ProductRepository.new(configuration: configuration)
 
           product = repository.create(name: "NeoVim", categories: ["software"])
           found = repository.find(product.id)
@@ -671,7 +671,7 @@ RSpec.describe "Repository (base)" do
         end
 
         it "succeeds even if timestamps is the only plugin" do
-          repository = ProductRepository.new
+          repository = ProductRepository.new(configuration: configuration)
 
           product = repository
                     .command(:create, use: %i[timestamps])
@@ -688,7 +688,7 @@ RSpec.describe "Repository (base)" do
 
     describe "enum database type" do
       it "allows to write data" do
-        repository = ColorRepository.new
+        repository = ColorRepository.new(configuration: configuration)
         color = repository.create(name: "red")
 
         expect(color).to be_a_kind_of(Color)
@@ -696,7 +696,7 @@ RSpec.describe "Repository (base)" do
       end
 
       it "raises error if the value is not included in the enum" do
-        repository = ColorRepository.new
+        repository = ColorRepository.new(configuration: configuration)
         message = Platform.match do
           engine(:ruby)  { %(PG::InvalidTextRepresentation: ERROR:  invalid input value for enum rainbow: "grey") }
           engine(:jruby) { %(Java::OrgPostgresqlUtil::PSQLException: ERROR: invalid input value for enum rainbow: "grey") }

--- a/spec/integration/hanami/model/repository/command_spec.rb
+++ b/spec/integration/hanami/model/repository/command_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Customized commands" do
-  subject(:authors) { AuthorRepository.new }
+  subject(:authors) { AuthorRepository.new(configuration: configuration) }
 
   let(:data) do
     [{ name: "Arthur C. Clarke" }, { name: "Phillip K. Dick" }]

--- a/spec/integration/hanami/model/repository/legacy_spec.rb
+++ b/spec/integration/hanami/model/repository/legacy_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe "Repository (legacy)" do
+  let(:repository) { OperatorRepository.new(configuration: configuration) }
+
   describe "#find" do
     it "finds record by primary key" do
-      repository = OperatorRepository.new
       operator = repository.create(name: "F")
       found = repository.find(operator.id)
 
@@ -11,7 +12,6 @@ RSpec.describe "Repository (legacy)" do
     end
 
     it "returns nil for missing record" do
-      repository = OperatorRepository.new
       found = repository.find("9999999")
 
       expect(found).to be_nil
@@ -20,7 +20,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#all" do
     it "returns all the records" do
-      repository = OperatorRepository.new
       operator = repository.create(name: "F")
 
       expect(repository.all).to be_an_instance_of(Array)
@@ -30,7 +29,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#first" do
     it "returns first record from table" do
-      repository = OperatorRepository.new
       repository.clear
 
       operator = repository.create(name: "Janis Joplin")
@@ -42,7 +40,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#last" do
     it "returns last record from table" do
-      repository = OperatorRepository.new
       repository.clear
 
       repository.create(name: "Rob")
@@ -54,7 +51,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#clear" do
     it "clears all the records" do
-      repository = OperatorRepository.new
       repository.create(name: "F")
 
       repository.clear
@@ -70,7 +66,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#create" do
     it "creates record" do
-      repository = OperatorRepository.new
       operator = repository.create(name: "F")
 
       expect(operator).to be_an_instance_of(Operator)
@@ -81,7 +76,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#update" do
     it "updates record" do
-      repository = OperatorRepository.new
       operator = repository.create(name: "F")
       updated = repository.update(operator.id, name: "Flo")
 
@@ -91,7 +85,6 @@ RSpec.describe "Repository (legacy)" do
     end
 
     it "returns nil when record cannot be found" do
-      repository = OperatorRepository.new
       updated = repository.update("9999999", name: "Flo")
 
       expect(updated).to be_nil
@@ -100,7 +93,6 @@ RSpec.describe "Repository (legacy)" do
 
   describe "#delete" do
     it "deletes record" do
-      repository = OperatorRepository.new
       operator = repository.create(name: "F")
       deleted = repository.delete(operator.id)
 
@@ -113,7 +105,6 @@ RSpec.describe "Repository (legacy)" do
     end
 
     it "returns nil when record cannot be found" do
-      repository = OperatorRepository.new
       deleted = repository.delete("9999999")
 
       expect(deleted).to be_nil

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -50,4 +50,22 @@ module Database
   end
 end
 
-Database::Setup.new.run
+# rubocop:disable Style/GlobalVars
+$config = Database::Setup.new.run
+
+module RSpec
+  module Support
+    module Context
+      def self.included(base)
+        base.class_eval do
+          let(:configuration) { $config }
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Style/GlobalVars
+
+RSpec.configure do |config|
+  config.include(RSpec::Support::Context)
+end

--- a/spec/support/database/strategies/abstract.rb
+++ b/spec/support/database/strategies/abstract.rb
@@ -12,9 +12,11 @@ module Database
         load_dependencies
         export_env
         create_database
-        configure
+        configuration = configure
         after
         sleep 1
+
+        configuration
       end
 
       protected
@@ -40,11 +42,12 @@ module Database
       end
 
       def configure
-        returing = Hanami::Model.configure do
+        returning = Hanami::Model.configure do
           adapter ENV["HANAMI_DATABASE_ADAPTER"].to_sym, ENV["HANAMI_DATABASE_URL"]
         end
 
-        returing == Hanami::Model or raise "Hanami::Model.configure should return Hanami::Model"
+        returning == Hanami::Model or raise "Hanami::Model.configure should return Hanami::Model"
+        returning.configuration
       end
 
       def after

--- a/spec/support/database/strategies/sql.rb
+++ b/spec/support/database/strategies/sql.rb
@@ -38,7 +38,7 @@ module Database
           gateway do |g|
             g.connection.extension(:pg_enum) if Database.engine?(:postgresql)
           end
-        end
+        end.configuration
       end
 
       def after

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -91,7 +91,7 @@ end
 class Label < Hanami::Entity
 end
 
-class PostRepository < Hanami::Repository
+class PostRepository < Hanami::Repository[:posts]
   associations do
     belongs_to :user, as: :author
     has_many :comments
@@ -119,7 +119,7 @@ class PostRepository < Hanami::Repository
   end
 end
 
-class CommentRepository < Hanami::Repository
+class CommentRepository < Hanami::Repository[:comments]
   associations do
     belongs_to :post
     belongs_to :user
@@ -130,7 +130,7 @@ class CommentRepository < Hanami::Repository
   end
 end
 
-class AvatarRepository < Hanami::Repository
+class AvatarRepository < Hanami::Repository[:avatars]
   associations do
     belongs_to :user
   end
@@ -140,7 +140,7 @@ class AvatarRepository < Hanami::Repository
   end
 end
 
-class UserRepository < Hanami::Repository
+class UserRepository < Hanami::Repository[:users]
   associations do
     has_one :avatar
     has_many :posts, as: :threads
@@ -208,10 +208,7 @@ class UserRepository < Hanami::Repository
   end
 end
 
-class AvatarRepository < Hanami::Repository
-end
-
-class AuthorRepository < Hanami::Repository
+class AuthorRepository < Hanami::Repository[:authors]
   associations do
     has_many :books
   end
@@ -271,14 +268,14 @@ class AuthorRepository < Hanami::Repository
   end
 end
 
-class BookOntologyRepository < Hanami::Repository
+class BookOntologyRepository < Hanami::Repository[:book_ontologies]
   associations do
     belongs_to :books
     belongs_to :categories
   end
 end
 
-class CategoryRepository < Hanami::Repository
+class CategoryRepository < Hanami::Repository[:categories]
   associations do
     has_many :books, through: :book_ontologies
   end
@@ -308,7 +305,7 @@ class CategoryRepository < Hanami::Repository
   end
 end
 
-class BookRepository < Hanami::Repository
+class BookRepository < Hanami::Repository[:books]
   associations do
     belongs_to :author
     has_many :categories, through: :book_ontologies
@@ -339,29 +336,26 @@ class BookRepository < Hanami::Repository
   end
 end
 
-class OperatorRepository < Hanami::Repository
-  self.relation = :t_operator
-
+class OperatorRepository < Hanami::Repository[:t_operator]
   mapping do
     attribute :id,   from: :operator_id
     attribute :name, from: :s_name
   end
 end
 
-class AccessTokenRepository < Hanami::Repository
-  self.relation = "tokens"
+class AccessTokenRepository < Hanami::Repository[:tokens]
 end
 
-class SourceFileRepository < Hanami::Repository
+class SourceFileRepository < Hanami::Repository[:source_files]
 end
 
-class WarehouseRepository < Hanami::Repository
+class WarehouseRepository < Hanami::Repository[:warehouses]
 end
 
-class ProductRepository < Hanami::Repository
+class ProductRepository < Hanami::Repository[:products]
 end
 
-class ColorRepository < Hanami::Repository
+class ColorRepository < Hanami::Repository[:colors]
   schema do
     attribute :id,         Hanami::Model::Sql::Types::Int
     attribute :name,       Hanami::Model::Sql::Types::String
@@ -370,7 +364,7 @@ class ColorRepository < Hanami::Repository
   end
 end
 
-class LabelRepository < Hanami::Repository
+class LabelRepository < Hanami::Repository[:labels]
 end
 
 Hanami::Model.load!

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -367,4 +367,4 @@ end
 class LabelRepository < Hanami::Repository[:labels]
 end
 
-Hanami::Model.load!
+Hanami::Model.configuration.load!(Hanami::Model.repositories)

--- a/spec/unit/hanami/model/load_spec.rb
+++ b/spec/unit/hanami/model/load_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Hanami::Model.load!" do
+RSpec.describe "Hanami::Model.configuration.load!" do
   let(:message) { "Cannot find corresponding type for form" }
 
   before do
@@ -8,6 +8,6 @@ RSpec.describe "Hanami::Model.load!" do
   end
 
   it "raises unknown database error when repository automapping spots an unknown type" do
-    expect { Hanami::Model.load! }.to raise_error(Hanami::Model::UnknownDatabaseTypeError, message)
+    expect { Hanami::Model.configuration.load!(Hanami::Model.repositories) }.to raise_error(Hanami::Model::UnknownDatabaseTypeError, message)
   end
 end

--- a/spec/unit/hanami/model/mapped_relation_spec.rb
+++ b/spec/unit/hanami/model/mapped_relation_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Hanami::Model::MappedRelation do
   subject { described_class.new(relation) }
-  let(:relation) { UserRepository.new.users }
+  let(:relation) { UserRepository.new(configuration: configuration).users }
 
   describe "#[]" do
     it "returns attribute" do


### PR DESCRIPTION
Alter the Repository class declaration so we can start to remove `Hanami::Model.configuration`.

Right now the obstacle to doing this is migrations.