### PR TITLE
Updates the README with requiring sql documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This class provides a DSL to configure the connection.
 
 ```ruby
 require 'hanami/model'
+require 'hanami/model/sql'
 
 class User < Hanami::Entity
 end
@@ -192,6 +193,8 @@ This is a **huge improvement**, because:
 
 Hanami::Model can **_automap_** columns from relations and entities attributes.
 
+When using a `sql` adapter, you must require `hanami/model/sql` before `Hanami::Model.load!` is called so the relations are loaded correctly.
+
 However, there are cases where columns and attribute names do not match (mainly **legacy databases**).
 
 ```ruby
@@ -234,6 +237,7 @@ If an entity has the following accessors: `:created_at` and `:updated_at`, they 
 
 ```ruby
 require 'hanami/model'
+require 'hanami/model/sql'
 
 class User < Hanami::Entity
 end


### PR DESCRIPTION
I was recently integrating Hanami::Model into a "plain" (non-Hanami) application and I was getting obscure errors when creating a record via a repository.

These were hard to track down because Hanami wraps them in an `Hanami::Model::Error` and ROM creates the commands (like `create`) dynamically using reflection and the call stack does not reflect the dynamic method.

I tracked the issue down to [this line of code](https://github.com/hanami/model/blob/31566f1449a84c156b00188b785dc6aafd76416d/lib/hanami/model/configuration.rb#L108).

Since I was not requiring `hanami/model/sql`, the relations were not being built for the entities and it would fail [here](https://github.com/rom-rb/rom-repository/blob/d5bce87cde9801da937dad1d9f9e1a8b49c1b33a/lib/rom/repository.rb#L361) in ROM Repository because the `relation` was not set on the entity.

My hope is that these small updates to the `README` with a special callout to the require will help others not run into this issue.