### PR TITLE
Use original error in case role is missing for Postgres

### DIFF
--- a/lib/hanami/model/migrator/postgres_adapter.rb
+++ b/lib/hanami/model/migrator/postgres_adapter.rb
@@ -109,7 +109,7 @@ module Hanami
           case original_message
           when /already exists/
             DB_CREATION_ERROR
-          when /does not exist/
+          when /database ".+" does not exist/
             "Cannot find database: #{database}"
           when /No such file or directory/
             "Could not find executable in your PATH: `#{original_message.split.last}`"


### PR DESCRIPTION
When creating database without role setup first, `hanami db create` emits error:

```
Cannot find database: guardhouse_development
/Users/hieunguyen/.rvm/gems/ruby-2.6.3@guardhouse/gems/hanami-model-1.3.2/lib/hanami/model/migrator/postgres_adapter.rb:99:in `block in call_db_command'
        /Users/hieunguyen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/open3.rb:219:in `popen_run'
        /Users/hieunguyen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/open3.rb:101:in `popen3
...
```

This is quite misleading, and it took me a while to figure out the error. This fix returns the original error to make the issue clearer:

```
createdb: could not connect to database template1: FATAL:  role "postgres" does not exist
/Users/hieunguyen/.rvm/gems/ruby-2.6.3@guardhouse/gems/hanami-model-1.3.2/lib/hanami/model/migrator/postgres_adapter.rb:98:in `block in call_db_command'
        /Users/hieunguyen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/open3.rb:219:in `popen_run'
        /Users/hieunguyen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/open3.rb:101:in `popen3'
```

I don't see any tests for `#create` method, so I'm not sure how I should setup the test for this fix. If you could show me some directions, it would be very helpful. 