### PR TITLE
Add #one to HasMany (#550)

### DIFF
--- a/lib/hanami/model/associations/has_many.rb
+++ b/lib/hanami/model/associations/has_many.rb
@@ -46,6 +46,16 @@ module Hanami
           freeze
         end
 
+        # @raise [MultipleResultsError] if more than one record is available
+        #
+        # @since 1.3.3
+        # @api private
+        def one
+          raise Hanami::Model::MultipleResultsError, "#{count} results returned" if count > 1
+
+          scope.one
+        end
+
         # @since 0.7.0
         # @api private
         def create(data)

--- a/lib/hanami/model/error.rb
+++ b/lib/hanami/model/error.rb
@@ -127,5 +127,8 @@ module Hanami
         super("Unknown database adapter for URL: #{url.inspect}. Please check your database configuration (hint: ENV['DATABASE_URL']).")
       end
     end
+
+    class MultipleResultsError < Error
+    end
   end
 end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -192,4 +192,33 @@ RSpec.describe 'Associations (has_many)' do
     # skipped spec
     it '#remove'
   end
+
+  describe '#one' do
+    it 'raises an error if more than one record exists' do
+      author = authors.create(name: 'Umberto Eco')
+      book = books.create(author_id: author.id, title: 'Foucault Pendulum')
+      book = books.create(author_id: author.id, title: 'Foucault Pendulum')
+
+      expect do
+        authors.find_book_by_title(author, book.title)
+      end.to raise_error(Hanami::Model::MultipleResultsError)
+    end
+
+    it 'returns an individual record if only one record exists' do
+      author = authors.create(name: 'Umberto Eco')
+      book = books.create(author_id: author.id, title: 'Foucault Pendulum')
+
+      found = authors.find_book(author, book.id)
+
+      expect(found).to eq(book)
+    end
+
+    it 'returns nil if no records exist' do
+      author = authors.create(name: 'Aspiring Author')
+
+      found = authors.find_book(author, nil)
+
+      expect(found).to eq(nil)
+    end
+  end
 end

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -195,9 +195,9 @@ RSpec.describe 'Associations (has_many)' do
 
   describe '#one' do
     it 'raises an error if more than one record exists' do
-      author = authors.create(name: 'Umberto Eco')
-      book = books.create(author_id: author.id, title: 'Foucault Pendulum')
-      book = books.create(author_id: author.id, title: 'Foucault Pendulum')
+      author = authors.create(name: 'Cormac McCarthy')
+      book = books.create(author_id: author.id, title: 'Blood Meridian')
+      book = books.create(author_id: author.id, title: 'Blood Meridian')
 
       expect do
         authors.find_book_by_title(author, book.title)
@@ -205,8 +205,8 @@ RSpec.describe 'Associations (has_many)' do
     end
 
     it 'returns an individual record if only one record exists' do
-      author = authors.create(name: 'Umberto Eco')
-      book = books.create(author_id: author.id, title: 'Foucault Pendulum')
+      author = authors.create(name: 'Toni Morrison')
+      book = books.create(author_id: author.id, title: 'Song of Solomon')
 
       found = authors.find_book(author, book.id)
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -258,11 +258,19 @@ class AuthorRepository < Hanami::Repository
     book_for(author, id).one
   end
 
+  def find_book_by_title(author, title)
+    book_by_title(author, title).one
+  end
+
   def book_exists?(author, id)
     book_for(author, id).exists?
   end
 
   private
+
+  def book_by_title(author, title)
+    assoc(:books, author).where(title: title)
+  end
 
   def book_for(author, id)
     assoc(:books, author).where(id: id)


### PR DESCRIPTION
Per https://github.com/hanami/model/issues/550, the HasMany interface
does not line up with Hanami's guides. Prior to this commit, the
following is invalid as HasMany does not implement #one.

```ruby
class AuthorRepository < Hanami::Repository
  associations do
    has_many :books
  end

  def find_book(author, id)
    book_for(author, id).one
  end

  private

  def book_for(author, id)
    assoc(:books, author).where(id: id)
  end
end
```

This implementation is based on a couple of others, notably [ROM's](https://github.com/rom-rb/rom/blob/2fec380aa07ceef1d46e125c4f5f23eab468e7bc/core/lib/rom/relation/loaded.rb#L59) and
[Ecto's](https://github.com/elixir-ecto/ecto/blob/f9e5b75e500da98451d57c32849e5403b5d9d139/lib/ecto/repo/queryable.ex#L100) (Elixir). I opted to name the raised error MultipleResultsError,
which is the exact name used by Ecto, because I feel it bears a semantic
relationship to the name of the method from which raises it.

**Note:** This is one of two solutions to the linked issue, the other being #554. If either is accepted, the other PR should be closed.

Closes #550 