### PR TITLE
Remove #find_book from (has_many) AuthorRepository

### DIFF
--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -254,10 +254,6 @@ class AuthorRepository < Hanami::Repository
     assoc(:books, author).where(on_sale: true).count
   end
 
-  def find_book(author, id)
-    book_for(author, id).one
-  end
-
   def book_exists?(author, id)
     book_for(author, id).exists?
   end


### PR DESCRIPTION
Per #550, #one is not implemented on on HasMany.

**Note:** This is one of two solutions to the linked issue, the other being #553. If either is accepted, the other PR should be closed.
**Note:** This should be closed or merged alongside https://github.com/hanami/guides/pull/52.

Closes #550 