### PR TITLE
Target Updated Default Travis CI Build Environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
   - DB=postgresql
   - DB=mysql
 
+services:
+  - mysql
+
 addons:
   postgresql: '10'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - DB=mysql
 
 addons:
-  postgresql: '9.4'
+  postgresql: '10'
 
 matrix:
   allow_failures:

--- a/spec/integration/hanami/model/migration/mysql.rb
+++ b/spec/integration/hanami/model/migration/mysql.rb
@@ -392,8 +392,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
 
       expected = Platform.match do
-        ci(:travis) { '0' }
-        default     { nil }
+        default { nil }
       end
 
       expect(options.fetch(:default)).to eq(expected)
@@ -409,8 +408,7 @@ RSpec.shared_examples 'migration_integration_mysql' do
       expect(options.fetch(:allow_null)).to eq(false)
 
       expected = Platform.match do
-        ci(:travis) { '0' }
-        default     { nil }
+        default { nil }
       end
 
       expect(options.fetch(:default)).to eq(expected)

--- a/spec/integration/hanami/model/migration/postgresql.rb
+++ b/spec/integration/hanami/model/migration/postgresql.rb
@@ -420,8 +420,7 @@ RSpec.shared_examples 'migration_integration_postgresql' do
       expect(options.fetch(:allow_null)).to eq(true)
 
       expected = Platform.match do
-        ci(:travis) { '(-1)' }
-        default     { "'-1'::integer" }
+        default { "'-1'::integer" }
       end
 
       expect(options.fetch(:default)).to eq(expected)


### PR DESCRIPTION
Certain (Postgres-specific) specs are expecting syntax specific to newer versions of PostgreSQL (10 and up). hanami/model is currently relying on Travis CI. In April this year, [Travis CI updated its default build environment to Ubuntu Xenial 16.04](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment#1-services-support). Xenial allows Travis CI to run PostgreSQL 10, but it uses a pre-10 version out-of-the-box.

An example of a failure that occurred when running the PostgreSQL 10+ dependent code on a pre-10 version:

```bash
  1) Hanami::Model::Migrator PostgreSQL apply dumps database schema.sql
     Failure/Error:
       expect(actual).to include <<~SQL
         CREATE SEQUENCE public.reviews_id_seq
             AS integer
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
       SQL
```

I also found that MySQL was not running, resulting in builds failing when attempting to use the database. Per previously-linked blog post, "Services like MySQL or PostgreSQL are not started by default."

This pull request configures hanami/model's CI build to run in the updated Travis CI environment. It also removes no-longer-needed workarounds that were in place to run tests using the old Travis CI environment.

I see the value in not squashing these commits as I documented the reasons for these changes in database-specific commit messages. I will understand if that's not in line with the organization's standards.