### PR TITLE
Use BigDecimal v1.4

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-types',       '~> 0.11.0'
   spec.add_runtime_dependency 'dry-logic',       '~> 0.4.2', '< 0.5'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_runtime_dependency 'bigdecimal',      '~> 1.4'
 
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',  '~> 12'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,14 +2,6 @@ $LOAD_PATH.unshift 'lib'
 require 'hanami/devtools/unit'
 require 'hanami/model'
 
-require "bigdecimal"
-
-unless BigDecimal.respond_to?(:new)
-  def BigDecimal.new(*args)
-    ::Kernel.BigDecimal(*args)
-  end
-end
-
 require_relative './support/rspec'
 require_relative './support/test_io'
 require_relative './support/platform'


### PR DESCRIPTION
BigDecimal v2.0, included in Ruby 2.7, [removed BigDecimal.new()](https://github.com/ruby/bigdecimal#which-version-should-you-select) which is used in sequel 4.49, the last release of 4.x for sequel, which we're stuck on through rom-sql requiring that version. It's also an old version (1.3.5) of rom-sql, so it seems better that we just handle this here for Hanami 1.3. 

Another option is to ask the rom-rb team to release 1.3.6 with a change allowing using Sequel 5, but it hasn't been updated in 2 years, and there might be incompatibilities.

It won't be fixed in sequel, since version 4 hasn't been updated in over 2 years as well: https://github.com/jeremyevans/sequel/issues/1666

Closes #570

