### PR TITLE
Update dry-types & ROM

### DIFF
--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_runtime_dependency "hanami-utils",    "~> 2.0.alpha"
-  spec.add_runtime_dependency "rom",             "~> 5.1"
-  spec.add_runtime_dependency "rom-repository",  "~> 5.1"
-  spec.add_runtime_dependency "rom-sql",         "~> 3.0"
+  spec.add_runtime_dependency "rom",             "~> 5.2"
+  spec.add_runtime_dependency "rom-repository",  "~> 5.2"
+  spec.add_runtime_dependency "rom-sql",         "~> 3.2"
   spec.add_runtime_dependency "dry-types",       "~> 1.3"
   spec.add_runtime_dependency "dry-inflector",   "~> 0.1"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"

--- a/hanami-model.gemspec
+++ b/hanami-model.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rom",             "~> 5.1"
   spec.add_runtime_dependency "rom-repository",  "~> 5.1"
   spec.add_runtime_dependency "rom-sql",         "~> 3.0"
-  spec.add_runtime_dependency "dry-types",       "~> 1.2"
+  spec.add_runtime_dependency "dry-types",       "~> 1.3"
   spec.add_runtime_dependency "dry-inflector",   "~> 0.1"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
 

--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -113,7 +113,7 @@ module Hanami
       end
     end
 
-    def self.attribute(name, type = nil, &blk)
+    def self.attribute(name, type = Undefined, &blk)
       @_mutex.synchronize do
         @_schema = true
       end

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -38,11 +38,11 @@ module Hanami
       def initialize(configurator) # rubocop:disable Metrics/MethodLength
         @backend = configurator.backend
         @url = configurator.url
-        @container         = nil
-        @migrations        = configurator._migrations
-        @schema            = configurator._schema
-        @gateway_config    = configurator._gateway
-        @logger            = configurator._logger
+        @container = nil
+        @migrations = configurator._migrations
+        @schema = configurator._schema
+        @gateway_config = configurator._gateway
+        @logger = configurator._logger
         @migrations_logger = configurator.migrations_logger
         @inflector         = configurator.inflector
         @mappings          = {}

--- a/lib/hanami/model/migrator.rb
+++ b/lib/hanami/model/migrator.rb
@@ -329,7 +329,7 @@ module Hanami
       # @see Hanami::Model::Migrator.prepare
       def prepare
         drop
-      rescue # rubocop:disable Lint/HandleExceptions
+      rescue # rubocop:disable Lint/SuppressedException
       ensure
         create
         adapter.load

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe "Associations (has_one)" do
   extend PlatformHelpers
 

--- a/spec/support/platform/matcher.rb
+++ b/spec/support/platform/matcher.rb
@@ -6,7 +6,7 @@ module Platform
   class Matcher
     class Nope < Hanami::Utils::BasicObject
       def or(other, &blk)
-        blk.nil? ? other : blk.call
+        blk.nil? ? other : yield
       end
 
       # rubocop:disable Style/MethodMissingSuper

--- a/spec/support/platform/matcher.rb
+++ b/spec/support/platform/matcher.rb
@@ -24,11 +24,13 @@ module Platform
       end
     end
 
-    def self.match?(os: Os.current, ci: Ci.current, engine: Engine.current, db: Db.current) # rubocop:disable Naming/UncommunicativeMethodParamName
+    # rubocop:disable Naming/MethodParameterName
+    def self.match?(os: Os.current, ci: Ci.current, engine: Engine.current, db: Db.current)
       catch :match do
         new.os(os).ci(ci).engine(engine).db(db) { true }.or(false)
       end
     end
+    # rubocop:enable Naming/MethodParameterName
 
     def initialize
       freeze

--- a/spec/unit/hanami/model/sql/console/mysql.rb
+++ b/spec/unit/hanami/model/sql/console/mysql.rb
@@ -3,13 +3,13 @@
 require "hanami/model/sql/consoles/mysql"
 
 RSpec.shared_examples "sql_console_mysql" do
-  let(:console) { Hanami::Model::Sql::Consoles::Mysql.new(uri) }
+  let(:db_console) { Hanami::Model::Sql::Consoles::Mysql.new(uri) }
 
   describe "#connection_string" do
     let(:uri) { URI.parse("mysql://username:password@localhost:1234/foo_development") }
 
     it "returns a connection string" do
-      expect(console.connection_string).to eq("mysql -h localhost -D foo_development -P 1234 -u username -p password")
+      expect(db_console.connection_string).to eq("mysql -h localhost -D foo_development -P 1234 -u username -p password")
     end
   end
 end

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -3,17 +3,17 @@
 require "hanami/model/sql/consoles/postgresql"
 
 RSpec.shared_examples "sql_console_postgresql" do
-  let(:console) { Hanami::Model::Sql::Consoles::Postgresql.new(uri) }
+  let(:db_console) { Hanami::Model::Sql::Consoles::Postgresql.new(uri) }
 
   describe "#connection_string" do
     let(:uri) { URI.parse("postgres://username:password@localhost:1234/foo_development") }
 
     it "returns a connection string" do
-      expect(console.connection_string).to eq("psql -h localhost -d foo_development -p 1234 -U username")
+      expect(db_console.connection_string).to eq("psql -h localhost -d foo_development -p 1234 -U username")
     end
 
     it "sets the PGPASSWORD environment variable" do
-      console.connection_string
+      db_console.connection_string
       expect(ENV["PGPASSWORD"]).to eq("password")
       ENV.delete("PGPASSWORD")
     end
@@ -22,7 +22,7 @@ RSpec.shared_examples "sql_console_postgresql" do
       let(:uri) { URI.parse("postgres://username:p%40ss@localhost:1234/foo_development") }
 
       it "sets the PGPASSWORD environment variable decoding special characters" do
-        console.connection_string
+        db_console.connection_string
         expect(ENV["PGPASSWORD"]).to eq("p@ss")
         ENV.delete("PGPASSWORD")
       end
@@ -32,11 +32,11 @@ RSpec.shared_examples "sql_console_postgresql" do
       let(:uri) { URI.parse("postgres:///foo_development?user=username&password=password&host=localhost&port=1234") }
 
       it "returns a connection string" do
-        expect(console.connection_string).to eq("psql -h localhost -d foo_development -p 1234 -U username")
+        expect(db_console.connection_string).to eq("psql -h localhost -d foo_development -p 1234 -U username")
       end
 
       it "sets the PGPASSWORD environment variable" do
-        console.connection_string
+        db_console.connection_string
         expect(ENV["PGPASSWORD"]).to eq("password")
         ENV.delete("PGPASSWORD")
       end

--- a/spec/unit/hanami/model/sql/console/sqlite.rb
+++ b/spec/unit/hanami/model/sql/console/sqlite.rb
@@ -3,20 +3,20 @@
 require "hanami/model/sql/consoles/sqlite"
 
 RSpec.shared_examples "sql_console_sqlite" do
-  let(:console) { Hanami::Model::Sql::Consoles::Sqlite.new(uri) }
+  let(:db_console) { Hanami::Model::Sql::Consoles::Sqlite.new(uri) }
 
   describe "#connection_string" do
     describe "with shell ok database uri" do
       let(:uri) { URI.parse("sqlite://foo/bar.db") }
       it "returns a connection string for Sqlite3" do
-        expect(console.connection_string).to eq("sqlite3 foo/bar.db")
+        expect(db_console.connection_string).to eq("sqlite3 foo/bar.db")
       end
     end
 
     describe "with non shell ok database uri" do
       let(:uri) { URI.parse("sqlite://foo/%20bar.db") }
       it "returns an escaped connection string for Sqlite3" do
-        expect(console.connection_string).to eq('sqlite3 foo/\\%20bar.db')
+        expect(db_console.connection_string).to eq('sqlite3 foo/\\%20bar.db')
       end
     end
   end

--- a/spec/unit/hanami/model/sql/console_spec.rb
+++ b/spec/unit/hanami/model/sql/console_spec.rb
@@ -9,28 +9,28 @@ RSpec.describe Hanami::Model::Sql::Console do
     case Database.engine
     when :sqlite
       it "sqlite:// uri returns an instance of Console::Sqlite" do
-        console = Hanami::Model::Sql::Console.new("sqlite://#{uri}").send(:console)
-        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Sqlite)
+        db_console = Hanami::Model::Sql::Console.new("sqlite://#{uri}").send(:console)
+        expect(db_console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Sqlite)
       end
     when :postgresql
       it "postgres:// uri returns an instance of Console::Postgresql" do
-        console = Hanami::Model::Sql::Console.new("postgres://#{uri}").send(:console)
-        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
+        db_console = Hanami::Model::Sql::Console.new("postgres://#{uri}").send(:console)
+        expect(db_console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
       end
 
       it "postgresql:// uri returns an instance of Console::Postgresql" do
-        console = Hanami::Model::Sql::Console.new("postgresql://#{uri}").send(:console)
-        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
+        db_console = Hanami::Model::Sql::Console.new("postgresql://#{uri}").send(:console)
+        expect(db_console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Postgresql)
       end
     when :mysql
       it "mysql:// uri returns an instance of Console::Mysql" do
-        console = Hanami::Model::Sql::Console.new("mysql://#{uri}").send(:console)
-        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
+        db_console = Hanami::Model::Sql::Console.new("mysql://#{uri}").send(:console)
+        expect(db_console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
       end
 
       it "mysql2:// uri returns an instance of Console::Mysql" do
-        console = Hanami::Model::Sql::Console.new("mysql2://#{uri}").send(:console)
-        expect(console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
+        db_console = Hanami::Model::Sql::Console.new("mysql2://#{uri}").send(:console)
+        expect(db_console).to be_a_kind_of(Hanami::Model::Sql::Consoles::Mysql)
       end
     end
   end


### PR DESCRIPTION
Updates: 

1. Dry Types
`Struct.attribute` has a new signature, using `Undefined` as the default type.
Making `Entity.attribute` match the signature fixes the issue.

2. ROM, ROM Repository, ROM Sql