### PR TITLE
Introduces Hanami::Relation

### DIFF
--- a/lib/hanami/entity.rb
+++ b/lib/hanami/entity.rb
@@ -52,7 +52,17 @@ module Hanami
   # @since 0.1.0
   #
   # @see Hanami::Repository
-  class Entity < Dry::Struct
+  class Entity < ROM::Struct
+    def hash
+      [self.class, id].hash
+    end
+
+    def ==(other)
+      self.class.to_s == other.class.to_s && id == other.id
+    end
+  end
+
+  class OldEntity < Dry::Struct
     require "hanami/entity/strict"
     require "hanami/entity/schemaless"
 

--- a/lib/hanami/entity/schemaless.rb
+++ b/lib/hanami/entity/schemaless.rb
@@ -4,7 +4,7 @@ require "dry/struct"
 require "hanami/utils/hash"
 
 module Hanami
-  class Entity < Dry::Struct
+  class OldEntity < Dry::Struct
     # Schemaless entity
     #
     # @since 2.0.0

--- a/lib/hanami/entity/strict.rb
+++ b/lib/hanami/entity/strict.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Hanami
-  class Entity < Dry::Struct
+  class OldEntity < Dry::Struct
     # Strict entity
     #
     # @since 2.0.0
-    class Strict < Entity
+    class Strict < OldEntity
       def self.schema_policy
         lambda do |entity|
           entity.class_eval do

--- a/lib/hanami/model.rb
+++ b/lib/hanami/model.rb
@@ -3,6 +3,7 @@
 require "rom"
 require "concurrent"
 require "hanami/entity"
+require "hanami/relation"
 require "hanami/repository"
 
 # Hanami

--- a/lib/hanami/model/configuration.rb
+++ b/lib/hanami/model/configuration.rb
@@ -47,6 +47,7 @@ module Hanami
         @inflector         = configurator.inflector
         @mappings          = {}
         @entities          = {}
+        @directory         = configurator.directory
       end
 
       def container
@@ -167,20 +168,21 @@ module Hanami
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
       def load!(repositories, &blk)
-        rom.setup.auto_registration(config.directory.to_s) unless config.directory.nil?
+        rom.auto_registration(@directory) unless @directory.nil?
         rom.instance_eval(&blk)                            if     block_given?
         configure_gateway
-        configure_repositories(repositories)
+        # configure_repositories(repositories)
         self.logger = logger
 
         # FIXME: without "touching" the db, inferrer crashes on sqlite, wtf?
         gateway.connection.tables
 
         @container = ROM.container(rom)
-        define_entities_mappings(@container, repositories)
+        # define_entities_mappings(@container, repositories)
+
         @container
-      rescue => exception
-        raise Hanami::Model::Error.for(exception)
+      # rescue => exception
+      #   raise Hanami::Model::Error.for(exception)
       end
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize

--- a/lib/hanami/model/configurator.rb
+++ b/lib/hanami/model/configurator.rb
@@ -92,7 +92,7 @@ module Hanami
         require "hanami/logger"
 
         opts = options.merge(stream: stream)
-        @_logger = Hanami::Logger.new("hanami.model", opts)
+        @_logger = Hanami::Logger.new("hanami.model", **opts)
       end
 
       # @since 1.0.0

--- a/lib/hanami/model/repository_configurer.rb
+++ b/lib/hanami/model/repository_configurer.rb
@@ -15,7 +15,7 @@ module Hanami
       # @since x.x.x
       # @api private
       def self.call(repository, configuration)
-        define_relation(repository, configuration)
+        # define_relation(repository, configuration)
         define_mapping(repository, configuration)
       end
 
@@ -54,7 +54,7 @@ module Hanami
         blk = lambda do |_|
           model       e
           register_as :entity
-          instance_exec(&m) unless m.nil?
+          # instance_exec(&m) unless m.nil?
         end
 
         root = repository.root

--- a/lib/hanami/relation.rb
+++ b/lib/hanami/relation.rb
@@ -1,0 +1,3 @@
+module Hanami
+  Relation = ROM::Relation
+end

--- a/lib/hanami/repository.rb
+++ b/lib/hanami/repository.rb
@@ -139,106 +139,8 @@ module Hanami
     # @since 1.2.0
     def command(type, relation: root, **opts, &block)
       opts[:use] = COMMAND_PLUGINS | Array(opts[:use])
-      # opts[:mapper] = opts.fetch(:mapper, Model::MappedRelation.mapper_name)
-
       relation.command(type, **opts, &block)
     end
-
-    # Declare associations for the repository
-    #
-    # NOTE: This is an experimental feature
-    #
-    # @since 0.7.0
-    # @api private
-    #
-    # @example
-    #   class BookRepository < Hanami::Repository
-    #     associations do
-    #       has_many :books
-    #     end
-    #   end
-    # def self.associations(&blk)
-    #   if block_given?
-    #     @associations = blk
-    #   else
-    #     @associations
-    #   end
-    # end
-
-    # Declare database schema
-    #
-    # NOTE: This should be used **only** when Hanami can't find a corresponding Ruby type for your column.
-    #
-    # @since 1.0.0
-    #
-    # @example
-    #   # In this example `name` is a PostgreSQL Enum type that we want to treat like a string.
-    #
-    #   class ColorRepository < Hanami::Repository
-    #     schema do
-    #       attribute :id,         Hanami::Model::Sql::Types::Integer
-    #       attribute :name,       Hanami::Model::Sql::Types::String
-    #       attribute :created_at, Hanami::Model::Sql::Types::DateTime
-    #       attribute :updated_at, Hanami::Model::Sql::Types::DateTime
-    #     end
-    #   end
-    # def self.schema(&blk)
-    #   if block_given?
-    #     @schema = blk
-    #   else
-    #     @schema
-    #   end
-    # end
-
-    # Declare mapping between database columns and entity's attributes
-    #
-    # NOTE: This should be used **only** when there is a name mismatch (eg. in legacy databases).
-    #
-    # @since 0.7.0
-    #
-    # @example
-    #   class BookRepository < Hanami::Repository
-    #     self.relation = :t_operator
-    #
-    #     mapping do
-    #       attribute :id,   from: :operator_id
-    #       attribute :name, from: :s_name
-    #     end
-    #   end
-    # def self.mapping(&blk)
-    #   if block_given?
-    #     @mapping = blk
-    #   else
-    #     @mapping
-    #   end
-    # end
-
-    # @since 0.7.0
-    # @api private
-    #
-    # rubocop:disable Metrics/MethodLength
-    # def self.[](relation_name)
-    #   Class.new(Hanami::Repository) do
-    #     root relation_name
-    #     def self.inherited(klass)
-    #       klass.class_eval <<~CODE, __FILE__, __LINE__ + 1
-    #         include Utils::ClassAttribute
-    #
-    #         class_attribute :entity
-    #         class_attribute :entity_name
-    #         class_attribute :relation
-    #
-    #         self.root :#{root}
-    #
-    #
-    #         commands :create, update: :by_pk, delete: :by_pk, mapper: :entity, use: COMMAND_PLUGINS
-    #         prepend Commands
-    #       CODE
-    #
-    #       # Hanami::Model.repositories << klass
-    #     end
-    #   end
-    # end
 
     def [](name)
       fetch_or_store(name) do
@@ -252,8 +154,6 @@ module Hanami
       klass.commands :create, update: :by_pk, delete: :by_pk, use: COMMAND_PLUGINS
       klass.prepend Commands
     end
-
-    # rubocop:enable Metrics/MethodLength
 
     # Extend commands from ROM::Repository with error management
     #

--- a/spec/integration/hanami/model/associations/has_many_spec.rb
+++ b/spec/integration/hanami/model/associations/has_many_spec.rb
@@ -24,20 +24,20 @@ RSpec.describe "Associations (has_many)" do
   it "creates an object with a collection of associated objects" do
     author = authors.create_with_books(name: "Henry Thoreau", books: [{ title: "Walden" }])
 
-    expect(author).to be_an_instance_of(Author)
+    expect(author).to be_a(Project::Entities::Author)
     expect(author.name).to eq("Henry Thoreau")
-    expect(author.books).to be_an_instance_of(Array)
-    expect(author.books.first).to be_an_instance_of(Book)
+    expect(author.books).to be_an(Array)
+    expect(author.books.first).to be_a(Project::Entities::Book)
     expect(author.books.first.title).to eq("Walden")
   end
 
   it "creates associated records when it receives a collection of serializable data" do
     author = authors.create_with_books(name: "Sandi Metz", books: [BaseParams.new(title: "Practical Object-Oriented Design in Ruby")])
 
-    expect(author).to be_an_instance_of(Author)
+    expect(author).to be_a(Project::Entities::Author)
     expect(author.name).to eq("Sandi Metz")
-    expect(author.books).to be_an_instance_of(Array)
-    expect(author.books.first).to be_an_instance_of(Book)
+    expect(author.books).to be_an(Array)
+    expect(author.books.first).to be_a(Project::Entities::Book)
     expect(author.books.first.title).to eq("Practical Object-Oriented Design in Ruby")
   end
 
@@ -102,7 +102,7 @@ RSpec.describe "Associations (has_many)" do
   it "returns an array of books" do
     author = authors.create(name: "Nikolai Gogol")
     expected = books.create(author_id: author.id, title: "Dead Souls")
-    expect(expected).to be_an_instance_of(Book)
+    expect(expected).to be_a(Project::Entities::Book)
 
     actual = authors.books_for(author).to_a
     expect(actual).to eq([expected])
@@ -117,7 +117,7 @@ RSpec.describe "Associations (has_many)" do
 
     actual = []
     authors.books_for(author).each do |book|
-      expect(book).to be_an_instance_of(Book)
+      expect(book).to be_a(Project::Entities::Book)
       actual << book
     end
 
@@ -130,7 +130,7 @@ RSpec.describe "Associations (has_many)" do
   it "iterates through the books and returns an array" do
     author = authors.create(name: "José Saramago")
     expected = books.create(author_id: author.id, title: "The Cave")
-    expect(expected).to be_an_instance_of(Book)
+    expect(expected).to be_a(Project::Entities::Book)
 
     actual = authors.books_for(author).map { |book| book }
     expect(actual).to eq([expected])
@@ -150,6 +150,7 @@ RSpec.describe "Associations (has_many)" do
   it "returns the count of on sale associated books" do
     author = authors.create(name: "Steven Pinker")
     books.create(author_id: author.id, title: "The Sense of Style", on_sale: true)
+    books.create(author_id: author.id, title: "The Blank Slate", on_sale: false)
 
     expect(authors.on_sales_books_count(author)).to eq(1)
   end
@@ -190,8 +191,5 @@ RSpec.describe "Associations (has_many)" do
         authors.add_book(author, title: "O Alienista", on_sale: nil)
       end.to raise_error Hanami::Model::NotNullConstraintViolationError
     end
-
-    # skipped spec
-    it "#remove"
   end
 end

--- a/spec/integration/hanami/model/associations/has_one_spec.rb
+++ b/spec/integration/hanami/model/associations/has_one_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Associations (has_one)" do
       other_found = users.find_with_avatar(other.id)
 
       expect(found.avatar).to be_nil
-      expect(other_found.avatar).to be_an Avatar
+      expect(other_found.avatar).to be_an Project::Entities::Avatar
     end
   end
 

--- a/spec/integration/hanami/model/associations/many_to_many_spec.rb
+++ b/spec/integration/hanami/model/associations/many_to_many_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Associations (has_many :through)" do
       actual = []
 
       categories.books_for(category).each do |book|
-        expect(book).to be_an_instance_of(Book)
+        expect(book).to be_a(Project::Entities::Book)
         actual << book
       end
 

--- a/spec/integration/hanami/model/repository/base_spec.rb
+++ b/spec/integration/hanami/model/repository/base_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Repository (base)" do
       repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
 
-      expect(repository.all).to be_an_instance_of(Array)
+      expect(repository.all).to be_an(Array)
       expect(repository.all).to include(user)
     end
   end
@@ -127,7 +127,7 @@ RSpec.describe "Repository (base)" do
         expect(users).to be_a_kind_of(Array)
 
         user = users.first
-        expect(user).to be_a_kind_of(User)
+        expect(user).to be_a_kind_of(Project::Entities::User)
       end
     end
   end
@@ -137,20 +137,20 @@ RSpec.describe "Repository (base)" do
       repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
 
-      expect(user).to be_an_instance_of(User)
+      expect(user).to be_a(Project::Entities::User)
       expect(user.id).to_not be_nil
       expect(user.name).to eq("L")
     end
 
-    it "creates record from entity" do
-      entity = User.new(name: "L")
+    xit "creates record from entity" do
+      entity = Project::Entities::User.new(name: "L")
       repository = UserRepository.new(configuration: configuration)
       user = repository.create(entity)
 
       # It doesn't mutate original entity
       expect(entity.id).to be_nil
 
-      expect(user).to be_an_instance_of(User)
+      expect(user).to be_a(User)
       expect(user.id).to_not be_nil
       expect(user.name).to eq("L")
     end
@@ -346,13 +346,13 @@ RSpec.describe "Repository (base)" do
       user = repository.create(name: "L")
       updated = repository.update(user.id, name: "Luca")
 
-      expect(updated).to be_an_instance_of(User)
+      expect(updated).to be_a(Project::Entities::User)
       expect(updated.id).to eq(user.id)
       expect(updated.name).to eq("Luca")
     end
 
-    it "updates record from entity" do
-      entity = User.new(name: "Luca")
+    xit "updates record from entity" do
+      entity = Project::Entities::User.new(name: "Luca")
       repository = UserRepository.new(configuration: configuration)
       user = repository.create(name: "L")
       updated = repository.update(user.id, entity)
@@ -360,7 +360,7 @@ RSpec.describe "Repository (base)" do
       # It doesn't mutate original entity
       expect(entity.id).to be_nil
 
-      expect(updated).to be_an_instance_of(User)
+      expect(updated).to be_a(User)
       expect(updated.id).to eq(user.id)
       expect(updated.name).to eq("Luca")
     end
@@ -535,7 +535,7 @@ RSpec.describe "Repository (base)" do
       user = repository.create(name: "L")
       deleted = repository.delete(user.id)
 
-      expect(deleted).to be_an_instance_of(User)
+      expect(deleted).to be_a(Project::Entities::User)
       expect(deleted.id).to eq(user.id)
       expect(deleted.name).to eq("L")
 
@@ -580,10 +580,10 @@ RSpec.describe "Repository (base)" do
 
       expect(found.size).to be(2)
       found.each do |user|
-        expect(user).to be_a_kind_of(User)
+        expect(user).to be_a_kind_of(Project::Entities::User)
         expect(user.id).to_not be(nil)
-        expect(user.name).to be(nil)
-        expect(user.age).to be(nil)
+        expect { user.name }.to raise_error ROM::Struct::MissingAttribute
+        expect { user.age }.to raise_error ROM::Struct::MissingAttribute
       end
     end
 
@@ -596,10 +596,10 @@ RSpec.describe "Repository (base)" do
 
       expect(found.size).to be(2)
       found.each do |user|
-        expect(user).to be_a_kind_of(User)
+        expect(user).to be_a(Project::Entities::User)
         expect(user.id).to_not be(nil)
         expect(user.name).to_not be(nil)
-        expect(user.age).to be(nil)
+        expect { user.age }.to raise_error ROM::Struct::MissingAttribute
       end
     end
   end
@@ -691,7 +691,7 @@ RSpec.describe "Repository (base)" do
         repository = ColorRepository.new(configuration: configuration)
         color = repository.create(name: "red")
 
-        expect(color).to be_a_kind_of(Color)
+        expect(color).to be_a_kind_of(Project::Entities::Color)
         expect(color.name).to eq("red")
       end
 

--- a/spec/support/database/strategies/sql.rb
+++ b/spec/support/database/strategies/sql.rb
@@ -32,8 +32,10 @@ module Database
           logger     ENV["HANAMI_DATABASE_LOGGER"], level: :debug
           migrations Dir.pwd + "/spec/support/fixtures/database_migrations"
           schema     Dir.pwd + "/tmp/schema.sql"
+          path       Dir.pwd + "/spec/support/fixtures/project/"
 
           migrations_logger ENV["HANAMI_DATABASE_LOGGER"]
+
 
           gateway do |g|
             g.connection.extension(:pg_enum) if Database.engine?(:postgresql)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -8,50 +8,33 @@ class BaseParams < OpenStruct
   end
 end
 
-module Hanami
-  class Entity2 < ROM::Struct
-    # def id
-    #   attributes.fetch(:id, nil)
-    # end
-
-    def hash
-      [self.class, id].hash
-    end
-
-    def ==(other)
-      self.class.to_s == other.class.to_s &&
-        id == other.id
-    end
-  end
-end
-
 module Project
   module Entities
-    class AccessToken < Hanami::Entity2
+    class AccessToken < Hanami::Entity
     end
 
-    class Author < Hanami::Entity2
+    class Author < Hanami::Entity
     end
 
-    class Avatar < Hanami::Entity2
+    class Avatar < Hanami::Entity
     end
 
-    class Book < Hanami::Entity2
+    class Book < Hanami::Entity
     end
 
-    class BookOntology < Hanami::Entity2
+    class BookOntology < Hanami::Entity
     end
 
-    class Category < Hanami::Entity2
+    class Category < Hanami::Entity
     end
 
-    class Color < Hanami::Entity2
+    class Color < Hanami::Entity
     end
 
-    class Label < Hanami::Entity2
+    class Label < Hanami::Entity
     end
 
-    class User < Hanami::Entity2
+    class User < Hanami::Entity
     end
   end
 end
@@ -254,21 +237,9 @@ class UserRepository < Hanami::Repository[:users]
   end
 end
 
-# class Avatar < Hanami::Entity
-# end
-#
-# class Author < Hanami::Entity
-# end
-#
-# class Book < Hanami::Entity
-# end
-#
-# class Category < Hanami::Entity
-# end
-#
-# class BookOntology < Hanami::Entity
-# end
-#
+class Author < Hanami::OldEntity
+end
+
 # class Operator < Hanami::Entity
 # end
 
@@ -287,15 +258,20 @@ end
 #   attribute :code, Types::String.constrained(format: /\Awh\-/)
 # end
 #
-# class Account < Hanami::Entity
-#   attribute :id,         Types::Strict::Integer
-#   attribute :name,       Types::String
-#   attribute :codes,      Types::Collection(Types::Coercible::Integer)
-#   attribute :owner,      Types::Entity(User)
-#   attribute :users,      Types::Collection(User)
-#   attribute :email,      Types::String.constrained(format: /@/)
-#   attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })
-# end
+
+class User < Hanami::OldEntity
+end
+
+class Account < Hanami::OldEntity
+  attribute :id,         Types::Strict::Integer
+  attribute :name,       Types::String
+  attribute :codes,      Types::Collection(Types::Coercible::Integer)
+  attribute :owner,      Types::Entity(User)
+  attribute :users,      Types::Collection(User)
+  attribute :email,      Types::String.constrained(format: /@/)
+  attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })
+end
+
 #
 # class PageVisit < Hanami::Entity
 #   attribute :id,        Types::Strict::Integer
@@ -309,10 +285,10 @@ end
 #   end
 # end
 #
-# class Person < Hanami::Entity[:strict]
-#   attribute :id,   Types::Strict::Integer
-#   attribute :name, Types::Strict::String
-# end
+class Person < Hanami::OldEntity[:strict]
+  attribute :id,   Types::Strict::Integer
+  attribute :name, Types::Strict::String
+end
 
 # class Product < Hanami::Entity
 # end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -3,360 +3,457 @@
 require "ostruct"
 
 class BaseParams < OpenStruct
-  def to_hash
-    to_h
+  def merge(other)
+    other.merge(to_h)
   end
 end
 
-class User < Hanami::Entity
-end
+module Hanami
+  class Entity2 < ROM::Struct
+    # def id
+    #   attributes.fetch(:id, nil)
+    # end
 
-class Avatar < Hanami::Entity
-end
+    def hash
+      [self.class, id].hash
+    end
 
-class Author < Hanami::Entity
-end
-
-class Book < Hanami::Entity
-end
-
-class Category < Hanami::Entity
-end
-
-class BookOntology < Hanami::Entity
-end
-
-class Operator < Hanami::Entity
-end
-
-class AccessToken < Hanami::Entity
-end
-
-class SourceFile < Hanami::Entity
-end
-
-class Post < Hanami::Entity
-end
-
-class Comment < Hanami::Entity
-end
-
-class Warehouse < Hanami::Entity
-  attribute :id,   Types::Integer
-  attribute :name, Types::String
-  attribute :code, Types::String.constrained(format: /\Awh\-/)
-end
-
-class Account < Hanami::Entity
-  attribute :id,         Types::Strict::Integer
-  attribute :name,       Types::String
-  attribute :codes,      Types::Collection(Types::Coercible::Integer)
-  attribute :owner,      Types::Entity(User)
-  attribute :users,      Types::Collection(User)
-  attribute :email,      Types::String.constrained(format: /@/)
-  attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })
-end
-
-class PageVisit < Hanami::Entity
-  attribute :id,        Types::Strict::Integer
-  attribute :start,     Types::DateTime
-  attribute :end,       Types::DateTime
-  attribute :visitor,   Types::Hash
-  attribute :page_info do
-    attribute :name, Types::Coercible::String
-    attribute :scroll_depth, Types::Coercible::Float
-    attribute :meta, Types::Hash
+    def ==(other)
+      self.class.to_s == other.class.to_s &&
+        id == other.id
+    end
   end
 end
 
-class Person < Hanami::Entity[:strict]
-  attribute :id,   Types::Strict::Integer
-  attribute :name, Types::Strict::String
-end
+module Project
+  module Entities
+    class AccessToken < Hanami::Entity2
+    end
 
-class Product < Hanami::Entity
-end
+    class Author < Hanami::Entity2
+    end
 
-class Color < Hanami::Entity
-end
+    class Avatar < Hanami::Entity2
+    end
 
-class Label < Hanami::Entity
-end
+    class Book < Hanami::Entity2
+    end
 
-class PostRepository < Hanami::Repository[:posts]
-  associations do
-    belongs_to :user, as: :author
-    has_many :comments
-    has_many :users, through: :comments, as: :commenters
-  end
+    class Color < Hanami::Entity2
+    end
 
-  def find_with_commenters(id)
-    combine(:commenters).where(id: id).map_to(Post).to_a
-  end
+    class Label < Hanami::Entity2
+    end
 
-  def commenters_for(post)
-    assoc(:commenters, post).to_a
-  end
-
-  def find_with_author(id)
-    posts.combine(:author).where(id: id).map_to(Post).one
-  end
-
-  def feed_for(id)
-    posts.combine(:author, comments: :user).where(id: id).map_to(Post).one
-  end
-
-  def author_for(post)
-    assoc(:author, post).one
-  end
-end
-
-class CommentRepository < Hanami::Repository[:comments]
-  associations do
-    belongs_to :post
-    belongs_to :user
-  end
-
-  def commenter_for(comment)
-    assoc(:user, comment).one
-  end
-end
-
-class AvatarRepository < Hanami::Repository[:avatars]
-  associations do
-    belongs_to :user
-  end
-
-  def by_user(id)
-    avatars.where(user_id: id).to_a
-  end
-end
-
-class UserRepository < Hanami::Repository[:users]
-  associations do
-    has_one :avatar
-    has_many :posts, as: :threads
-    has_many :comments
-  end
-
-  def find_with_threads(id)
-    users.combine(:threads).where(id: id).map_to(User).one
-  end
-
-  def threads_for(user)
-    assoc(:threads, user).to_a
-  end
-
-  def find_with_avatar(id)
-    users.combine(:avatar).where(id: id).map_to(User).one
-  end
-
-  def create_with_avatar(data)
-    assoc(:avatar).create(data)
-  end
-
-  def remove_avatar(user)
-    assoc(:avatar, user).delete
-  end
-
-  def add_avatar(user, data)
-    assoc(:avatar, user).add(data)
-  end
-
-  def update_avatar(user, data)
-    assoc(:avatar, user).update(data)
-  end
-
-  def replace_avatar(user, data)
-    assoc(:avatar, user).replace(data)
-  end
-
-  def avatar_for(user)
-    assoc(:avatar, user).one
-  end
-
-  def by_name(name)
-    users.where(name: name).map_to(User)
-  end
-
-  def by_matching_name(name)
-    users.where(users[:name].ilike(name)).map_to(User).to_a
-  end
-
-  def by_name_with_root(name)
-    root.where(name: name).map_to(User)
-  end
-
-  def find_all_by_manual_query
-    users.read("select * from users").map_to(User).to_a
-  end
-
-  def ids
-    users.select(:id).map_to(User).to_a
-  end
-
-  def select_id_and_name
-    users.select(:id, :name).map_to(User).to_a
-  end
-end
-
-class AuthorRepository < Hanami::Repository[:authors]
-  associations do
-    has_many :books
-  end
-
-  def create_many(data, opts: {})
-    command(:create, result: :many, **opts).call(data)
-  end
-
-  def create_with_books(data)
-    assoc(:books).create(data)
-  end
-
-  def find_with_books(id)
-    authors.combine(:books).by_pk(id).map_to(Author).one
-  end
-
-  def books_for(author)
-    assoc(:books, author)
-  end
-
-  def add_book(author, data)
-    assoc(:books, author).add(data)
-  end
-
-  def remove_book(author, id)
-    assoc(:books, author).remove(id)
-  end
-
-  def delete_books(author)
-    assoc(:books, author).delete
-  end
-
-  def delete_on_sales_books(author)
-    assoc(:books, author).where(on_sale: true).delete
-  end
-
-  def books_count(author)
-    assoc(:books, author).count
-  end
-
-  def on_sales_books_count(author)
-    assoc(:books, author).where(on_sale: true).count
-  end
-
-  def find_book(author, id)
-    book_for(author, id).one
-  end
-
-  def book_exists?(author, id)
-    book_for(author, id).exists?
-  end
-
-  private
-
-  def book_for(author, id)
-    assoc(:books, author).where(id: id)
-  end
-end
-
-class BookOntologyRepository < Hanami::Repository[:book_ontologies]
-  associations do
-    belongs_to :books
-    belongs_to :categories
-  end
-end
-
-class CategoryRepository < Hanami::Repository[:categories]
-  associations do
-    has_many :books, through: :book_ontologies
-  end
-
-  def books_for(category)
-    assoc(:books, category)
-  end
-
-  def on_sales_books_count(category)
-    assoc(:books, category).where(on_sale: true).count
-  end
-
-  def books_count(category)
-    assoc(:books, category).count
-  end
-
-  def find_with_books(id)
-    categories.combine(:books).where(id: id).map_to(Category).one
-  end
-
-  def add_books(category, *books)
-    assoc(:books, category).add(*books)
-  end
-
-  def remove_book(category, book_id)
-    assoc(:books, category).remove(book_id)
-  end
-end
-
-class BookRepository < Hanami::Repository[:books]
-  associations do
-    belongs_to :author
-    has_many :categories, through: :book_ontologies
-  end
-
-  def add_category(book, category)
-    assoc(:categories, book).add(category)
-  end
-
-  def clear_categories(book)
-    assoc(:categories, book).delete
-  end
-
-  def categories_for(book)
-    assoc(:categories, book).to_a
-  end
-
-  def find_with_categories(id)
-    books.combine(:categories).where(id: id).map_to(Book).one
-  end
-
-  def find_with_author(id)
-    books.combine(:author).where(id: id).map_to(Book).one
-  end
-
-  def author_for(book)
-    assoc(:author, book).one
-  end
-end
-
-class OperatorRepository < Hanami::Repository[:t_operator]
-  mapping do
-    attribute :id,   from: :operator_id
-    attribute :name, from: :s_name
+    class User < Hanami::Entity2
+    end
   end
 end
 
 class AccessTokenRepository < Hanami::Repository[:tokens]
+  struct_namespace Project::Entities
 end
 
-class SourceFileRepository < Hanami::Repository[:source_files]
+class AuthorRepository < Hanami::Repository[:authors]
+  struct_namespace Project::Entities
+
+  def find_with_books(id)
+    root.combine(:books).by_pk(id).one
+  end
+
+  # There must be a better way to do this - MRP - 2020-04-25
+  def books_for(author)
+    root.assoc(:books).where(root[:id] => author.id).map_to(Project::Entities::Book).to_a
+  end
+
+  def books_count(author)
+    root.assoc(:books).where(root[:id] => author.id).count
+  end
+
+  def on_sales_books_count(author)
+    root.assoc(:books).where(root[:id] => author.id, on_sale: true).count
+  end
+
+  def add_book(author, data)
+    associated = root.associations[:books].associate(data, author)
+    command(:create, relation: books).call(associated)
+  end
+
+  def create_with_books(data)
+    command(:create, relation: root.combine(:books)).call(data)
+  end
+
+  # There's no simple way to delete from the has_many association it seems.
+  # One could argue that this is better done directly on the BookRepository
+  # and that we are only mirroring AR behaviour. - MRP - 2020-04-25
+  def delete_books(author)
+    books.where(author_id: author.id).delete
+  end
+
+  def delete_on_sales_books(author)
+    books.where(author_id: author.id, on_sale: true).delete
+  end
+
+  def remove_book(_author, id)
+    command(:update, relation: books).by_pk(id).call(author_id: nil)
+  end
+
+  #   def find_book(author, id)
+  #     book_for(author, id).one
+  #   end
+  #
+  #   def book_exists?(author, id)
+  #     book_for(author, id).exists?
+  #   end
 end
 
-class WarehouseRepository < Hanami::Repository[:warehouses]
-end
+class AvatarRepository < Hanami::Repository[:avatars]
+  struct_namespace Project::Entities
 
-class ProductRepository < Hanami::Repository[:products]
-end
-
-class ColorRepository < Hanami::Repository[:colors]
-  schema do
-    attribute :id,         Hanami::Model::Sql::Types::Integer
-    attribute :name,       Hanami::Model::Sql::Types::String
-    attribute :created_at, Hanami::Model::Sql::Types::DateTime
-    attribute :updated_at, Hanami::Model::Sql::Types::DateTime
+  def by_user(id)
+    root.where(user_id: id).to_a
   end
 end
 
-class LabelRepository < Hanami::Repository[:labels]
+class BookRepository < Hanami::Repository[:books]
+  struct_namespace Project::Entities
+
+  def author_for(book)
+    root.by_pk(book.id).combine(:author).one.author
+  end
+
+  def find_with_author(id)
+    books.combine(:author).by_pk(id).one
+  end
 end
 
-Hanami::Model.configuration.load!(Hanami::Model.repositories)
+class ColorRepository < Hanami::Repository[:colors]
+  struct_namespace Project::Entities
+end
+
+class LabelRepository < Hanami::Repository[:labels]
+  struct_namespace Project::Entities
+end
+
+class UserRepository < Hanami::Repository[:users]
+  struct_namespace Project::Entities
+
+  def by_name(name)
+    root.where(name: name)
+  end
+
+  def by_matching_name(name)
+    root.where(users[:name].ilike(name)).to_a
+  end
+
+  def by_name_with_root(name)
+    root.where(name: name)
+  end
+
+  def find_all_by_manual_query
+    users.read("select * from users").map_to(Project::Entities::User).to_a
+  end
+
+  def ids
+    root.select(:id).to_a
+  end
+
+  def select_id_and_name
+    root.select(:id, :name).to_a
+  end
+
+  #   associations do
+  #     has_one :avatar
+  #     has_many :posts, as: :threads
+  #     has_many :comments
+  #   end
+  #
+  #   def find_with_threads(id)
+  #     users.combine(:threads).where(id: id).map_to(User).one
+  #   end
+  #
+  #   def threads_for(user)
+  #     assoc(:threads, user).to_a
+  #   end
+  #
+  #   def find_with_avatar(id)
+  #     users.combine(:avatar).where(id: id).map_to(User).one
+  #   end
+  #
+  #   def create_with_avatar(data)
+  #     assoc(:avatar).create(data)
+  #   end
+  #
+  #   def remove_avatar(user)
+  #     assoc(:avatar, user).delete
+  #   end
+  #
+  #   def add_avatar(user, data)
+  #     assoc(:avatar, user).add(data)
+  #   end
+  #
+  #   def update_avatar(user, data)
+  #     assoc(:avatar, user).update(data)
+  #   end
+  #
+  #   def replace_avatar(user, data)
+  #     assoc(:avatar, user).replace(data)
+  #   end
+  #
+  #   def avatar_for(user)
+  #     assoc(:avatar, user).one
+  #   end
+end
+
+# class Avatar < Hanami::Entity
+# end
+#
+# class Author < Hanami::Entity
+# end
+#
+# class Book < Hanami::Entity
+# end
+#
+# class Category < Hanami::Entity
+# end
+#
+# class BookOntology < Hanami::Entity
+# end
+#
+# class Operator < Hanami::Entity
+# end
+
+# class SourceFile < Hanami::Entity
+# end
+#
+# class Post < Hanami::Entity
+# end
+#
+# class Comment < Hanami::Entity
+# end
+#
+# class Warehouse < Hanami::Entity
+#   attribute :id,   Types::Integer
+#   attribute :name, Types::String
+#   attribute :code, Types::String.constrained(format: /\Awh\-/)
+# end
+#
+# class Account < Hanami::Entity
+#   attribute :id,         Types::Strict::Integer
+#   attribute :name,       Types::String
+#   attribute :codes,      Types::Collection(Types::Coercible::Integer)
+#   attribute :owner,      Types::Entity(User)
+#   attribute :users,      Types::Collection(User)
+#   attribute :email,      Types::String.constrained(format: /@/)
+#   attribute :created_at, Types::DateTime.constructor(->(dt) { ::DateTime.parse(dt.to_s) })
+# end
+#
+# class PageVisit < Hanami::Entity
+#   attribute :id,        Types::Strict::Integer
+#   attribute :start,     Types::DateTime
+#   attribute :end,       Types::DateTime
+#   attribute :visitor,   Types::Hash
+#   attribute :page_info do
+#     attribute :name, Types::Coercible::String
+#     attribute :scroll_depth, Types::Coercible::Float
+#     attribute :meta, Types::Hash
+#   end
+# end
+#
+# class Person < Hanami::Entity[:strict]
+#   attribute :id,   Types::Strict::Integer
+#   attribute :name, Types::Strict::String
+# end
+
+# class Product < Hanami::Entity
+# end
+
+# class Color < Hanami::Entity
+# end
+
+# class PostRepository < Hanami::Repository[:posts]
+#   associations do
+#     belongs_to :user, as: :author
+#     has_many :comments
+#     has_many :users, through: :comments, as: :commenters
+#   end
+#
+#   def find_with_commenters(id)
+#     combine(:commenters).where(id: id).map_to(Post).to_a
+#   end
+#
+#   def commenters_for(post)
+#     assoc(:commenters, post).to_a
+#   end
+#
+#   def find_with_author(id)
+#     posts.combine(:author).where(id: id).map_to(Post).one
+#   end
+#
+#   def feed_for(id)
+#     posts.combine(:author, comments: :user).where(id: id).map_to(Post).one
+#   end
+#
+#   def author_for(post)
+#     assoc(:author, post).one
+#   end
+# end
+#
+# class CommentRepository < Hanami::Repository[:comments]
+#   associations do
+#     belongs_to :post
+#     belongs_to :user
+#   end
+#
+#   def commenter_for(comment)
+#     assoc(:user, comment).one
+#   end
+# end
+#
+
+#
+# class AuthorRepository < Hanami::Repository[:authors]
+#   associations do
+#     has_many :books
+#   end
+#
+#   def create_many(data, opts: {})
+#     command(:create, result: :many, **opts).call(data)
+#   end
+#
+#   def create_with_books(data)
+#     assoc(:books).create(data)
+#   end
+#
+#   def find_with_books(id)
+#     authors.combine(:books).by_pk(id).map_to(Author).one
+#   end
+#
+#   def books_for(author)
+#     assoc(:books, author)
+#   end
+#
+#   def add_book(author, data)
+#     assoc(:books, author).add(data)
+#   end
+#
+#   def remove_book(author, id)
+#     assoc(:books, author).remove(id)
+#   end
+#
+#   def delete_books(author)
+#     assoc(:books, author).delete
+#   end
+#
+#   def delete_on_sales_books(author)
+#     assoc(:books, author).where(on_sale: true).delete
+#   end
+#
+#   def books_count(author)
+#     assoc(:books, author).count
+#   end
+#
+#   def on_sales_books_count(author)
+#     assoc(:books, author).where(on_sale: true).count
+#   end
+#
+#   def find_book(author, id)
+#     book_for(author, id).one
+#   end
+#
+#   def book_exists?(author, id)
+#     book_for(author, id).exists?
+#   end
+#
+#   private
+#
+#   def book_for(author, id)
+#     assoc(:books, author).where(id: id)
+#   end
+# end
+#
+# class BookOntologyRepository < Hanami::Repository[:book_ontologies]
+#   associations do
+#     belongs_to :books
+#     belongs_to :categories
+#   end
+# end
+#
+# class CategoryRepository < Hanami::Repository[:categories]
+#   associations do
+#     has_many :books, through: :book_ontologies
+#   end
+#
+#   def books_for(category)
+#     assoc(:books, category)
+#   end
+#
+#   def on_sales_books_count(category)
+#     assoc(:books, category).where(on_sale: true).count
+#   end
+#
+#   def books_count(category)
+#     assoc(:books, category).count
+#   end
+#
+#   def find_with_books(id)
+#     categories.combine(:books).where(id: id).map_to(Category).one
+#   end
+#
+#   def add_books(category, *books)
+#     assoc(:books, category).add(*books)
+#   end
+#
+#   def remove_book(category, book_id)
+#     assoc(:books, category).remove(book_id)
+#   end
+# end
+#
+# class BookRepository < Hanami::Repository[:books]
+#   associations do
+#     belongs_to :author
+#     has_many :categories, through: :book_ontologies
+#   end
+#
+#   def add_category(book, category)
+#     assoc(:categories, book).add(category)
+#   end
+#
+#   def clear_categories(book)
+#     assoc(:categories, book).delete
+#   end
+#
+#   def categories_for(book)
+#     assoc(:categories, book).to_a
+#   end
+#
+#   def find_with_categories(id)
+#     books.combine(:categories).where(id: id).map_to(Book).one
+#   end
+#
+#   def find_with_author(id)
+#     books.combine(:author).where(id: id).map_to(Book).one
+#   end
+#
+#   def author_for(book)
+#     assoc(:author, book).one
+#   end
+# end
+#
+# class OperatorRepository < Hanami::Repository[:t_operator]
+#   mapping do
+#     attribute :id,   from: :operator_id
+#     attribute :name, from: :s_name
+#   end
+# end
+
+# class SourceFileRepository < Hanami::Repository[:source_files]
+# end
+#
+# class WarehouseRepository < Hanami::Repository[:warehouses]
+# end
+
+# class ProductRepository < Hanami::Repository[:products]
+# end
+
+Hanami::Model.configuration.load!([]) # Hanami::Model.repositories)

--- a/spec/support/fixtures/project/relations/authors.rb
+++ b/spec/support/fixtures/project/relations/authors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Project
+  module Relations
+    class Authors < Hanami::Relation[:sql]
+      schema(:authors, infer: true) do
+        associations do
+          has_many :books
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/avatars.rb
+++ b/spec/support/fixtures/project/relations/avatars.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Project
+  module Relations
+    class Avatars < Hanami::Relation[:sql]
+      schema(:avatars, infer: true) do
+        associations do
+          belongs_to :users
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/book_ontologies.rb
+++ b/spec/support/fixtures/project/relations/book_ontologies.rb
@@ -1,0 +1,12 @@
+module Project
+  module Relations
+    class BookOntologies < Hanami::Relation[:sql]
+      schema(:book_ontologies, infer: true) do
+        associations do
+          belongs_to :books
+          belongs_to :categories
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/books.rb
+++ b/spec/support/fixtures/project/relations/books.rb
@@ -6,6 +6,8 @@ module Project
       schema(:books, infer: true) do
         associations do
           belongs_to :author
+          has_many :book_ontologies
+          has_many :categories, through: :book_ontologies
         end
       end
     end

--- a/spec/support/fixtures/project/relations/books.rb
+++ b/spec/support/fixtures/project/relations/books.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Project
+  module Relations
+    class Books < Hanami::Relation[:sql]
+      schema(:books, infer: true) do
+        associations do
+          belongs_to :author
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/categories.rb
+++ b/spec/support/fixtures/project/relations/categories.rb
@@ -1,0 +1,12 @@
+module Project
+  module Relations
+    class Categories < Hanami::Relation[:sql]
+      schema(:categories, infer: true) do
+        associations do
+          has_many :book_ontologies
+          has_many :books, through: :book_ontologies
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/colors.rb
+++ b/spec/support/fixtures/project/relations/colors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Project
+  module Relations
+    class Colors < Hanami::Relation[:sql]
+      schema(:colors) do
+        attribute :id,         Hanami::Model::Sql::Types::Integer
+        attribute :name,       Hanami::Model::Sql::Types::String
+        attribute :created_at, Hanami::Model::Sql::Types::DateTime
+        attribute :updated_at, Hanami::Model::Sql::Types::DateTime
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/labels.rb
+++ b/spec/support/fixtures/project/relations/labels.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Project
+  module Relations
+    class Labels < Hanami::Relation[:sql]
+      schema(:labels, infer: true)
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/tokens.rb
+++ b/spec/support/fixtures/project/relations/tokens.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Project
   module Relations
     class Tokens < Hanami::Relation[:sql]

--- a/spec/support/fixtures/project/relations/tokens.rb
+++ b/spec/support/fixtures/project/relations/tokens.rb
@@ -1,0 +1,7 @@
+module Project
+  module Relations
+    class Tokens < Hanami::Relation[:sql]
+      schema(:tokens, infer: true)
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/users.rb
+++ b/spec/support/fixtures/project/relations/users.rb
@@ -1,0 +1,7 @@
+module Project
+  module Relations
+    class Users < Hanami::Relation[:sql]
+      schema(:users, infer: true)
+    end
+  end
+end

--- a/spec/support/fixtures/project/relations/users.rb
+++ b/spec/support/fixtures/project/relations/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Project
   module Relations
     class Users < Hanami::Relation[:sql]

--- a/spec/support/fixtures/project/relations/users.rb
+++ b/spec/support/fixtures/project/relations/users.rb
@@ -3,7 +3,9 @@
 module Project
   module Relations
     class Users < Hanami::Relation[:sql]
-      schema(:users, infer: true)
+      schema(:users, infer: true) do
+        associations { has_one :avatar }
+      end
     end
   end
 end

--- a/spec/unit/hanami/entity/automatic_schema_spec.rb
+++ b/spec/unit/hanami/entity/automatic_schema_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Hanami::Entity do
   describe "automatic schema" do
-    let(:described_class) { Author }
+    let(:described_class) { Project::Entities::Author }
 
     let(:input) do
       Class.new do
@@ -65,8 +65,7 @@ RSpec.describe Hanami::Entity do
 
     describe "#id" do
       it "returns the value" do
-        entity = described_class.new(id: 1)
-
+        entity = described_class.new(id: 1, name: 'Bob')
         expect(entity.id).to eq(1)
       end
 
@@ -119,7 +118,7 @@ RSpec.describe Hanami::Entity do
       end
 
       it "prevents information escape" do
-        entity = described_class.new(books: books = [Book.new(id: 1), Book.new(id: 2)])
+        entity = described_class.new(books: books = [Project::Entities::Book.new(id: 1), Project::Entities::Book.new(id: 2)])
 
         entity.to_h[:books].reverse!
         expect(entity.books).to eq(books)

--- a/spec/unit/hanami/entity/manual_schema/base_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/base_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Entity do
+RSpec.describe Hanami::OldEntity do
   describe "manual schema (base)" do
     let(:described_class) { Account }
 

--- a/spec/unit/hanami/entity/manual_schema/strict_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/strict_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Entity do
+RSpec.describe Hanami::OldEntity do
   describe "manual schema (strict)" do
     let(:described_class) { Person }
 

--- a/spec/unit/hanami/entity/manual_schema/types_spec.rb
+++ b/spec/unit/hanami/entity/manual_schema/types_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Entity do
+RSpec.describe Hanami::OldEntity do
   describe "manual schema (types)" do
     %i[strict struct].each do |type|
       it "allows to build schema with #{type.inspect}" do

--- a/spec/unit/hanami/entity/schemaless_spec.rb
+++ b/spec/unit/hanami/entity/schemaless_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Hanami::Entity do
       it "raises error for unknown methods" do
         entity = described_class.new
 
-        expect { entity.foo }.to raise_error(NoMethodError)
+        # TODO: Maybe wrap on a Hanami::Model::Error
+        expect { entity.foo }.to raise_error(ROM::Struct::MissingAttribute)
       end
 
       it "returns empty hash for #attributes" do

--- a/spec/unit/hanami/entity/schemaless_spec.rb
+++ b/spec/unit/hanami/entity/schemaless_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Hanami::Entity do
   describe "schemaless" do
     let(:described_class) do
-      Class.new(Hanami::Entity[:struct])
+      Class.new(Hanami::OldEntity[:struct])
     end
 
     let(:input) do

--- a/spec/unit/hanami/entity_spec.rb
+++ b/spec/unit/hanami/entity_spec.rb
@@ -2,9 +2,9 @@
 
 require "ostruct"
 
-RSpec.describe Hanami::Entity do
+RSpec.describe Hanami::OldEntity do
   let(:described_class) do
-    Class.new(Hanami::Entity[:struct])
+    Class.new(Hanami::OldEntity[:struct])
   end
 
   describe "equality" do
@@ -61,14 +61,14 @@ RSpec.describe Hanami::Entity do
 
     it "returns different object hash for different class but same id" do
       entity1 = described_class.new(id: 1)
-      entity2 = Class.new(Hanami::Entity).new(id: 1)
+      entity2 = Class.new(Hanami::OldEntity).new(id: 1)
 
       expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
     end
 
     it "returns different object hash for different class and different id" do
       entity1 = described_class.new(id: 1)
-      entity2 = Class.new(Hanami::Entity).new(id: 2)
+      entity2 = Class.new(Hanami::OldEntity).new(id: 2)
 
       expect(entity1.hash).to_not eq(entity2.hash), "Expected #{entity1.hash} to NOT equal #{entity2.hash}"
     end


### PR DESCRIPTION
:warning: Achtung: This is a true *draft* PR. The code is messy. The commit history is changing all the time and broken tests are a thing. :warning: 

This PR is the first step towards bringing `model` closer to `rom`.

In this we introduce the `Relation` abstraction in the same terms as `rom` does. This simplifies our code, boot process and exposes more of ROM to the users. 