### PR TITLE
Fix postgresql in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ name: ci
       - "Rakefile"
       - "Gemfile"
       - ".rubocop.yml"
+      - "script/ci"
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           ruby-version: ${{matrix.ruby}}
       - name: Run all tests
         env:
+          PGPASSWORD: root
           HANAMI_DATABASE_USERNAME: root
           HANAMI_DATABASE_PASSWORD: root
           HANAMI_DATABASE_HOST: 127.0.0.1

--- a/spec/unit/hanami/model/sql/console/postgresql.rb
+++ b/spec/unit/hanami/model/sql/console/postgresql.rb
@@ -5,6 +5,12 @@ require "hanami/model/sql/consoles/postgresql"
 RSpec.shared_examples "sql_console_postgresql" do
   let(:sql_console) { Hanami::Model::Sql::Consoles::Postgresql.new(uri) }
 
+  around(:each) do |example|
+    original_pgpassword = ENV["PGPASSWORD"]
+    example.run
+    ENV["PGPASSWORD"] = original_pgpassword
+  end
+
   describe "#connection_string" do
     let(:uri) { URI.parse("postgres://username:password@localhost:1234/foo_development") }
 


### PR DESCRIPTION
The CI failing silently for postgresql came down to two issues:

1. The password isn't being set for `createdb` and `dropdb` correctly, causing the first `createdb` to sit forever. I've forced `PGPASSWORD` manually in `ci.yml` but this might be something we need to fix elsewhere (the postgres adapter maybe - see [this comment](https://github.com/hanami/model/issues/595#issuecomment-780735067)).
2. Depending on the rspec seed, the value of `PGPASSWORD` is being destroyed and never being reset during a spec run, causing further issues later. I've added an around hook as a temporary fix but we probably want to improve either the specs (ie. not call `ENV.delete`) or perhaps not modify `ENV` but have a `Hash` for `ENV` when calling `open3`.