### PR TITLE
Ignore `schema_migrations` and `schema_info` errors

### DIFF
--- a/lib/hanami/model/migrator/logger.rb
+++ b/lib/hanami/model/migrator/logger.rb
@@ -40,7 +40,7 @@ module Hanami
           super(nil, stream: stream, formatter: Formatter.new)
         end
 
-        # @since <version>
+        # @since x.x.x
         # @api public
         def error(progname = nil, &block)
           return true if _ignorable(progname)
@@ -50,7 +50,7 @@ module Hanami
 
         private
 
-        # @since <version>
+        # @since x.x.x
         # @api private
         def _ignorable(progname)
           IGNORABLE_PATTERNS.any? { |r| progname =~ r }

--- a/lib/hanami/model/migrator/logger.rb
+++ b/lib/hanami/model/migrator/logger.rb
@@ -53,7 +53,7 @@ module Hanami
         # @since x.x.x
         # @api private
         def _ignorable(progname)
-          IGNORABLE_PATTERNS.any? { |r| progname =~ r }
+          IGNORABLE_PATTERNS.any? { |r| progname.match?(r) }
         end
       end
     end

--- a/spec/unit/hanami/model/migrator/logger_spec.rb
+++ b/spec/unit/hanami/model/migrator/logger_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Model::Migrator::Logger do
+  subject(:logger) { described_class.new(stream) }
+
+  let(:stream) { File.open(File::NULL, "w") }
+
+  shared_examples "supress `no such table` error for `schema_migrations` table" do |message|
+    context "and text matches `schema_migrations` table error" do
+      it "does not invoke Logger#add" do
+        expect(logger).to_not receive(:add)
+
+        logger.error(message)
+      end
+
+      it "returns true" do
+        result = logger.error(message)
+
+        expect(result).to eq(true)
+      end
+    end
+  end
+
+  shared_examples "supress `no such table` error for `schema_info` table" do |message|
+    context "and text matches `schema_info` table error" do
+      it "does not invoke Logger#add" do
+        expect(logger).to_not receive(:add)
+
+        logger.error(message)
+      end
+
+      it "returns true" do
+        result = logger.error(message)
+
+        expect(result).to eq(true)
+      end
+    end
+  end
+
+  shared_examples "does not supress common messages" do |message|
+    context "and text refers to another table" do
+      it "invokes Logger#add" do
+        expect(logger)
+          .to receive(:add)
+          .once
+          .with(Logger::ERROR, nil, message)
+
+        logger.error(message)
+      end
+
+      it "returns true" do
+        result = logger.error(message)
+
+        expect(result).to eq(true)
+      end
+    end
+  end
+
+  describe "#error" do
+    context "when sqlite" do
+      include_examples "supress `no such table` error for `schema_migrations` table", "SQLite::SQLException: no such table: schema_migrations: SELECT NULL AS 'nil' FROM `schema_migrations` LIMIT 1"
+      include_examples "supress `no such table` error for `schema_info` table", "SQLite::SQLException: no such table: schema_info: SELECT NULL AS 'nil' FROM `schema_info` LIMIT 1"
+      include_examples "does not supress common messages", "SQLite::SQLException: no such table: my_table: SELECT NULL AS 'nil' FROM `my_table` LIMIT 1"
+    end
+
+    context "when postgres" do
+      include_examples "supress `no such table` error for `schema_migrations` table", "PG::UndefinedTable: ERROR:  relation \"schema_migrations\" does not exist"
+      include_examples "supress `no such table` error for `schema_info` table", "PG::UndefinedTable: ERROR:  relation \"schema_info\" does not exist"
+      include_examples "does not supress common messages", "PG::UndefinedTable: ERROR:  relation \"my_table\" does not exist"
+    end
+
+    context "when mysql" do
+      include_examples "supress `no such table` error for `schema_migrations` table", "Mysql2::Error: Table 'bookshelf_development.schema_migrations' doesn't exist: SELECT NULL AS `nil` FROM `schema_migrations` LIMIT 1"
+      include_examples "supress `no such table` error for `schema_info` table", "Mysql2::Error: Table 'bookshelf_development.schema_info' doesn't exist: SELECT NULL AS `nil` FROM `schema_info` LIMIT 1"
+      include_examples "does not supress common messages", "Mysql2::Error: Table 'bookshelf_development.my_table' doesn't exist: SELECT NULL AS `nil` FROM `my_table` LIMIT 1"
+    end
+  end
+end


### PR DESCRIPTION
Related to: https://github.com/hanami/hanami/issues/1087

### Changes

- Implement method `error` from STD Lib [Logger](https://github.com/ruby/logger/blob/master/lib/logger.rb#L546) in order to suppress the lines we don't want to show in the output
- Create a simple expectation to cover the new behavior

### Rational

The `Sequel` gem yields an error log for the absence of `schema_migrations` and/or `schema_info` table right before creating it and, for that reason, we can see those errors the first time we try to prepare/migrate the database even though it doesn't produce blockers.

### Inputs

The errors we are getting for each adapter are:

#### SQLite
```
SQLite3::SQLException: no such table: schema_migrations: SELECT NULL AS 'nil' FROM `schema_migrations` LIMIT 1
SQLite3::SQLException: no such table: schema_info: SELECT NULL AS 'nil' FROM `schema_info` LIMIT 1
```

#### Postgres
```
PG::UndefinedTable: ERROR:  relation "schema_migrations" does not exist
PG::UndefinedTable: ERROR:  relation "schema_info" does not exist
```

#### MySQL
```
Mysql2::Error: Table 'bookshelf_development.schema_migrations' doesn't exist: SELECT NULL AS `nil` FROM `schema_migrations` LIMIT 1
Mysql2::Error: Table 'bookshelf_development.schema_info' doesn't exist: SELECT NULL AS `nil` FROM `schema_migrations` LIMIT 1
```

