### PR TITLE
Use environment variables when interacting with PostgreSQL CLI tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           ruby-version: ${{matrix.ruby}}
       - name: Run all tests
         env:
-          PGPASSWORD: root
           HANAMI_DATABASE_USERNAME: root
           HANAMI_DATABASE_PASSWORD: root
           HANAMI_DATABASE_HOST: 127.0.0.1

--- a/lib/hanami/model/migrator/postgres_adapter.rb
+++ b/lib/hanami/model/migrator/postgres_adapter.rb
@@ -98,24 +98,15 @@ module Hanami
         def call_db_command(command)
           require "open3"
 
+          set_environment_variables
+
           begin
-            Open3.popen3(*command_with_credentials(command)) do |_stdin, _stdout, stderr, wait_thr|
+            Open3.popen3(command, database) do |_stdin, _stdout, stderr, wait_thr|
               raise MigrationError.new(modified_message(stderr.read)) unless wait_thr.value.success? # wait_thr.value is the exit status
             end
           rescue SystemCallError => exception
             raise MigrationError.new(modified_message(exception.message))
           end
-        end
-
-        def command_with_credentials(command)
-          result = [escape(command)]
-          result << "--host=#{host}" unless Utils::Blank.blank?(host)
-          result << "--port=#{port}" unless Utils::Blank.blank?(port)
-          result << "--username=#{username}" unless Utils::Blank.blank?(username)
-          result << "--password=#{password}" unless Utils::Blank.blank?(password)
-          result << database
-
-          result.compact
         end
 
         # @since 1.1.0

--- a/spec/support/database/strategies/postgresql.rb
+++ b/spec/support/database/strategies/postgresql.rb
@@ -88,12 +88,18 @@ module Database
       end
 
       def create_database
+        env = {
+          "PGHOST" => ENV["HANAMI_DATABASE_HOST"],
+          "PGUSER" => ENV["HANAMI_DATABASE_USERNAME"],
+          "PGPASSWORD" => ENV["HANAMI_DATABASE_PASSWORD"]
+        }
+
         try("Failed to drop Postgres database: #{database_name}") do
-          system "dropdb --if-exists #{database_name}"
+          system env, "dropdb --if-exists #{database_name}"
         end
 
         try("Failed to create Postgres database: #{database_name}") do
-          system "createdb #{database_name}"
+          system env, "createdb #{database_name}"
         end
       end
 

--- a/spec/unit/hanami/model/migrator/postgresql.rb
+++ b/spec/unit/hanami/model/migrator/postgresql.rb
@@ -30,10 +30,15 @@ RSpec.shared_examples "migrator_postgresql" do
     let(:database) { random }
     let(:url) do
       db = database
+      uri = format("%<host>s/%<db>s?user=%<user>s&password=%<password>s",
+                   host: ENV.fetch("HANAMI_DATABASE_HOST", "127.0.0.1"),
+                   db: db,
+                   user: ENV["HANAMI_DATABASE_USERNAME"],
+                   password: ENV["HANAMI_DATABASE_PASSWORD"])
 
       Platform.match do
-        engine(:ruby)  { "postgresql://#{ENV.fetch('HANAMI_DATABASE_HOST', '127.0.0.1')}/#{db}?user=#{ENV['HANAMI_DATABASE_USERNAME']}" }
-        engine(:jruby) { "jdbc:postgresql://#{ENV.fetch('HANAMI_DATABASE_HOST', '127.0.0.1')}/#{db}?user=#{ENV['HANAMI_DATABASE_USERNAME']}" }
+        engine(:ruby) { "postgresql://#{uri}" }
+        engine(:jruby) { "jdbc:postgresql://#{uri}" }
       end
     end
 


### PR DESCRIPTION
Instead of using command line flags, environment variables are set for the execution of any PostgreSQL command.

The migrator spec builds a URL that excludes the password, but that URL is then used to build a connection, which is then used to run a PostgreSQL command. That command will not receive a password because the password in the connection string was absent.

Remove the `ci.yml` hack that forces `PGPASSWORD` to be present.

Closes #595