### PR TITLE
Bump rubocop TargetRubyVersion to 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,5 @@ Style/RescueStandardError:
   Enabled: false
 Style/DateTime:
   Enabled: false
+AllCops:
+  TargetRubyVersion: 2.6

--- a/lib/hanami/entity/schema.rb
+++ b/lib/hanami/entity/schema.rb
@@ -169,7 +169,7 @@ module Hanami
           raise LocalJumpError unless block_given?
 
           @attributes, @schema = Dsl.build(type, &blk)
-          @attributes = Hash[@attributes.map { |k, _| [k, true] }]
+          @attributes = @attributes.transform_values { |_| true }
           freeze
         end
 

--- a/lib/hanami/model/migrator/sqlite_adapter.rb
+++ b/lib/hanami/model/migrator/sqlite_adapter.rb
@@ -108,16 +108,14 @@ module Hanami
         #
         def dump_migrations_data
           execute "sqlite3 #{escape(path)} .dump" do |stdout|
-            begin
-              contents = stdout.read.split($INPUT_RECORD_SEPARATOR)
-              contents = contents.grep(/^INSERT INTO "?#{migrations_table}"?/)
+            contents = stdout.read.split($INPUT_RECORD_SEPARATOR)
+            contents = contents.grep(/^INSERT INTO "?#{migrations_table}"?/)
 
-              ::File.open(schema, ::File::CREAT | ::File::BINARY | ::File::WRONLY | ::File::APPEND) do |file|
-                file.write(contents.join($INPUT_RECORD_SEPARATOR))
-              end
-            rescue => exception
-              raise MigrationError.new(exception.message)
+            ::File.open(schema, ::File::CREAT | ::File::BINARY | ::File::WRONLY | ::File::APPEND) do |file|
+              file.write(contents.join($INPUT_RECORD_SEPARATOR))
             end
+          rescue => exception
+            raise MigrationError.new(exception.message)
           end
         end
       end

--- a/lib/hanami/model/sql/entity/schema.rb
+++ b/lib/hanami/model/sql/entity/schema.rb
@@ -36,7 +36,7 @@ module Hanami
           def initialize(registry, relation, mapping)
             attributes  = build(registry, relation, mapping)
             @schema     = Types::Coercible::Hash.schema(attributes)
-            @attributes = Hash[attributes.map { |k, _| [k, true] }]
+            @attributes = attributes.transform_values { |_| true }
             freeze
           end
 


### PR DESCRIPTION
According information in `hanami-model` README

```
Hanami::Model supports Ruby (MRI) 2.6+
```

But rubocop still relied on TargetRubyVersion 2.3.
Moreover seems it caused CI broken. 

So this patch should fix this issue.